### PR TITLE
Support local compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # GoLand IDE
 .idea
+
+# Binary
+gateway

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,12 @@ RUN go mod download
 COPY cmd /go/src/github.com/nginxinc/nginx-gateway-kubernetes/cmd
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o gateway .
 
-FROM scratch as container
-COPY --from=builder /go/src/github.com/nginxinc/nginx-gateway-kubernetes/cmd/gateway/gateway /usr/bin/
+FROM scratch as common
 USER 1001:1001
 ENTRYPOINT [ "/usr/bin/gateway" ]
+
+FROM common as container
+COPY --from=builder /go/src/github.com/nginxinc/nginx-gateway-kubernetes/cmd/gateway/gateway /usr/bin/
+
+FROM common as local
+COPY ./gateway /usr/bin/


### PR DESCRIPTION
Use local go env to compile binary by default.
To build in container, use:
```
make container TARGET=container
```