### PR TITLE
Add NodePort and LoadBalancer Service definitions to manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,56 @@ You can deploy NGINX Kubernetes Gateway on an existing Kubernetes 1.16+ cluster.
    nginx-gateway-5d4f4c7db7-xk2kq   2/2     Running   0          112s
    ```
 
+## Expose NGINX Kubernetes Gateway
+
+You can gain access to NGINX Kubernetes Gateway by creating a `NodePort` Service or a `LoadBalancer` Service.
+
+### Create a NodePort Service
+
+Create a service with type `NodePort`:
+
+```
+kubectl apply -f deploy/manifests/service/nodeport.yaml
+```
+
+A `NodePort` service will randomly allocate one port on every node of the cluster. To access NGINX Kubernetes Gateway, use an IP address of any node in the cluster along with the allocated port.
+
+### Create a LoadBalancer Service
+
+Create a service with type `LoadBalancer` using the appropriate manifest for your cloud provider. 
+
+- For GCP or Azure:
+
+   ```
+   kubectl apply -f deploy/manifests/service/loadbalancer.yaml
+   ```
+
+   Lookup the public IP of the load balancer:
+   
+   ```
+   kubectl get svc nginx-gateway -n nginx-gateway
+   ``` 
+   
+   Use the public IP of the load balancer to access NGINX Kubernetes Gateway.
+   
+- For AWS:
+
+   ```
+   kubectl apply -f deploy/manifests/service/loadbalancer-aws-nlb.yaml
+   ```
+
+   In AWS, the NLB DNS name will be reported by Kubernetes in lieu of a public IP. To get the DNS name run:
+
+   ```
+   kubectl get svc nginx-gateway -n nginx-gateway
+   ``` 
+  
+   In general, you should rely on the NLB DNS name, however for testing purposes you can resolve the DNS name to get the IP address of the load balancer:
+
+   ```
+   nslookup <dns-name>
+   ```
+
 # Test NGINX Kubernetes Gateway
 
 To test the NGINX Kubernetes Gateway run:

--- a/deploy/manifests/service/loadbalancer-aws-nlb.yaml
+++ b/deploy/manifests/service/loadbalancer-aws-nlb.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-gateway
+  namespace: nginx-gateway
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: nginx-gateway

--- a/deploy/manifests/service/loadbalancer.yaml
+++ b/deploy/manifests/service/loadbalancer.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-gateway
+  namespace: nginx-gateway
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: nginx-gateway

--- a/deploy/manifests/service/nodeport.yaml
+++ b/deploy/manifests/service/nodeport.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-gateway
+  namespace: nginx-gateway
+spec:
+  type: NodePort 
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: nginx-gateway


### PR DESCRIPTION
Adds NodePort and LoadBalancer Service definitions to manifests directory. Also, updates the README with instructions on how to expose the gateway. 
