### PR TITLE
Read Go build info from the binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ builds:
       - all=-trimpath={{.Env.GOPATH}}
     asmflags:
       - all=-trimpath={{.Env.GOPATH}}
+    ldflags:
+      - -s -w -X main.version={{.Version}}
     main: ./cmd/gateway/
     binary: gateway
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARGET ?= local ## The target of the build. Possible values: local and container
 KIND_KUBE_CONFIG_FOLDER = $${HOME}/.kube/kind ## The folder where the kind kubeconfig is stored
 OUT_DIR ?= $(shell pwd)/build/out ## The folder where the binary will be stored
 ARCH ?= amd64 ## The architecture of the image and/or binary. For example: amd64 or arm64
-override DOCKER_BUILD_OPTIONS += --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg DATE=$(DATE) ## The options for the docker build command. For example, --pull
+override DOCKER_BUILD_OPTIONS += --build-arg VERSION=$(VERSION) ## The options for the docker build command. For example, --pull
 
 .DEFAULT_GOAL := help
 
@@ -28,7 +28,7 @@ container: build ## Build the container
 build: ## Build the binary
 ifeq (${TARGET},local)
 	@go version || (code=$$?; printf "\033[0;31mError\033[0m: unable to build locally\n"; exit $$code)
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o $(OUT_DIR)/gateway github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION}" -o $(OUT_DIR)/gateway github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway
 endif
 
 .PHONY: build-goreleaser

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1.4
 FROM golang:1.20 as builder
 ARG VERSION
-ARG GIT_COMMIT
-ARG DATE
 
 WORKDIR /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway
 
@@ -12,7 +10,7 @@ RUN go mod download
 COPY cmd /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd
 COPY internal /go/src/github.com/nginxinc/nginx-kubernetes-gateway/internal
 COPY pkg /go/src/github.com/nginxinc/nginx-kubernetes-gateway/pkg
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o gateway .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION}" -o gateway .
 
 FROM alpine:3.18 as capabilizer
 RUN apk add --no-cache libcap

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -5,12 +5,8 @@ import (
 	"os"
 )
 
-var (
-	// Set during go build
-	version string
-	commit  string
-	date    string
-)
+// Set during go build
+var version string
 
 func main() {
 	rootCmd := createRootCommand()


### PR DESCRIPTION
Uses build info from `runtime/debug`, so it doesn't need to be injected at build time.

This is possible since [go 1.18](https://go.dev/doc/go1.18#debug/buildinfo)