### PR TITLE
Add deployment manifests as release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,3 +55,12 @@ milestones:
 
 snapshot:
   name_template: 'edge'
+
+before:
+  hooks:
+    - make crds-release-file
+
+release:
+  extra_files:
+    - glob: ./build/out/crds.yaml
+    - glob: ./deploy/manifests/nginx-gateway.yaml

--- a/scripts/combine-crds.sh
+++ b/scripts/combine-crds.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+mkdir -p build/out
+
+CRD_FILE=build/out/crds.yaml
+echo "# NGINX Gateway API CustomResourceDefinitions" > ${CRD_FILE}
+
+for file in `ls deploy/manifests/crds/*.yaml`; do
+    echo "#" >> ${CRD_FILE}
+    echo "# $file" >> ${CRD_FILE}
+    echo "#" >> ${CRD_FILE}
+    cat $file >> ${CRD_FILE}
+done


### PR DESCRIPTION
Problem: As a user, I want an easy way to install the NGF manifests. Currently, I have to clone the repository.

Solution: By including the manifests as part of a release, the repo no longer has to be cloned to install NGF. Note: the service definitions are not uploaded and therefore still require a clone if they are to be installed.

Testing: Created a release in my fork and verified that the artifacts existed. Successfully installed NGF using those artifacts.

Example release:
![Screenshot 2023-09-20 at 2 03 45 PM](https://github.com/nginxinc/nginx-gateway-fabric/assets/8921145/7a194250-e9aa-4254-b56f-0f1ea831a58a)


Closes #913

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
