### PR TITLE
Fix NGF fails to recover if conf files are unexpectedly removed

### DIFF
--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -172,7 +172,6 @@ func StartManager(cfg config.Config) error {
 		nginxFileMgr: file.NewManagerImpl(
 			cfg.Logger.WithName("nginxFileManager"),
 			file.NewStdLibOSFileManager(),
-			nil,
 		),
 		nginxRuntimeMgr:     ngxruntime.NewManagerImpl(ngxruntimeCollector),
 		statusUpdater:       statusUpdater,

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -172,6 +172,7 @@ func StartManager(cfg config.Config) error {
 		nginxFileMgr: file.NewManagerImpl(
 			cfg.Logger.WithName("nginxFileManager"),
 			file.NewStdLibOSFileManager(),
+			nil,
 		),
 		nginxRuntimeMgr:     ngxruntime.NewManagerImpl(ngxruntimeCollector),
 		statusUpdater:       statusUpdater,

--- a/internal/mode/static/nginx/file/manager.go
+++ b/internal/mode/static/nginx/file/manager.go
@@ -91,7 +91,7 @@ func (m *ManagerImpl) ReplaceFiles(files []File) error {
 		if err := m.osFileManager.Remove(path); err != nil {
 			if os.IsNotExist(err) {
 				m.logger.V(1).Info(
-					"File not found when attempting to replace",
+					"File not found when attempting to delete",
 					"path", path,
 					"error", err,
 				)

--- a/internal/mode/static/nginx/file/manager.go
+++ b/internal/mode/static/nginx/file/manager.go
@@ -90,14 +90,14 @@ func (m *ManagerImpl) ReplaceFiles(files []File) error {
 	for _, path := range m.lastWrittenPaths {
 		if err := m.osFileManager.Remove(path); err != nil {
 			if os.IsNotExist(err) {
-				m.logger.V(1).Info(
+				m.logger.Info(
 					"File not found when attempting to delete",
 					"path", path,
 					"error", err,
 				)
-			} else {
-				return fmt.Errorf("failed to delete file %q: %w", path, err)
+				continue
 			}
+			return fmt.Errorf("failed to delete file %q: %w", path, err)
 		}
 
 		m.logger.Info("Deleted file", "path", path)

--- a/internal/mode/static/nginx/file/manager.go
+++ b/internal/mode/static/nginx/file/manager.go
@@ -76,11 +76,10 @@ type ManagerImpl struct {
 }
 
 // NewManagerImpl creates a new NewManagerImpl.
-func NewManagerImpl(logger logr.Logger, osFileManager OSFileManager, lastWrittenPaths []string) *ManagerImpl {
+func NewManagerImpl(logger logr.Logger, osFileManager OSFileManager) *ManagerImpl {
 	return &ManagerImpl{
-		logger:           logger,
-		osFileManager:    osFileManager,
-		lastWrittenPaths: lastWrittenPaths,
+		logger:        logger,
+		osFileManager: osFileManager,
 	}
 }
 

--- a/internal/mode/static/nginx/file/manager.go
+++ b/internal/mode/static/nginx/file/manager.go
@@ -88,7 +88,11 @@ func NewManagerImpl(logger logr.Logger, osFileManager OSFileManager) *ManagerImp
 func (m *ManagerImpl) ReplaceFiles(files []File) error {
 	for _, path := range m.lastWrittenPaths {
 		if err := m.osFileManager.Remove(path); err != nil {
-			return fmt.Errorf("failed to delete file %q: %w", path, err)
+			if os.IsNotExist(err) {
+				m.logger.V(1).Info("file not found, failed to delete file %q: %w", path, err)
+			} else {
+				return fmt.Errorf("failed to delete file %q: %w", path, err)
+			}
 		}
 
 		m.logger.Info("deleted file", "path", path)

--- a/internal/mode/static/nginx/file/manager_test.go
+++ b/internal/mode/static/nginx/file/manager_test.go
@@ -60,7 +60,7 @@ var _ = Describe("EventHandler", func() {
 		}
 
 		BeforeAll(func() {
-			mgr = file.NewManagerImpl(zap.New(), file.NewStdLibOSFileManager())
+			mgr = file.NewManagerImpl(zap.New(), file.NewStdLibOSFileManager(), nil)
 			tmpDir = GinkgoT().TempDir()
 
 			regular1 = file.File{
@@ -116,9 +116,28 @@ var _ = Describe("EventHandler", func() {
 		})
 	})
 
+	When("file does not exist", func() {
+		It("should not error", func() {
+			tmpDir := GinkgoT().TempDir()
+			mgr := file.NewManagerImpl(
+				zap.New(),
+				file.NewStdLibOSFileManager(),
+				[]string{filepath.Join(tmpDir, "file-does-not-exist.md")})
+			files := []file.File{
+				{
+					Type:    file.TypeRegular,
+					Path:    filepath.Join(tmpDir, "regular-1.conf"),
+					Content: []byte("regular-1"),
+				},
+			}
+
+			Expect(mgr.ReplaceFiles(files)).ShouldNot(HaveOccurred())
+		})
+	})
+
 	When("file type is not supported", func() {
 		It("should panic", func() {
-			mgr := file.NewManagerImpl(zap.New(), nil)
+			mgr := file.NewManagerImpl(zap.New(), nil, nil)
 
 			files := []file.File{
 				{
@@ -155,7 +174,7 @@ var _ = Describe("EventHandler", func() {
 		DescribeTable(
 			"should return error on file IO error",
 			func(fakeOSMgr *filefakes.FakeOSFileManager) {
-				mgr := file.NewManagerImpl(zap.New(), fakeOSMgr)
+				mgr := file.NewManagerImpl(zap.New(), fakeOSMgr, nil)
 
 				// special case for Remove
 				// to kick off removing, we need to successfully write files beforehand

--- a/internal/mode/static/nginx/file/manager_test.go
+++ b/internal/mode/static/nginx/file/manager_test.go
@@ -119,20 +119,19 @@ var _ = Describe("EventHandler", func() {
 	When("file does not exist", func() {
 		It("should not error", func() {
 			fakeOSMgr := &filefakes.FakeOSFileManager{}
-			tmpDir := GinkgoT().TempDir()
 			mgr := file.NewManagerImpl(zap.New(), fakeOSMgr)
 
 			files := []file.File{
 				{
 					Type:    file.TypeRegular,
-					Path:    filepath.Join(tmpDir, "regular-1.conf"),
+					Path:    "regular-1.conf",
 					Content: []byte("regular-1"),
 				},
 			}
 
 			Expect(mgr.ReplaceFiles(files)).ToNot(HaveOccurred())
-			fakeOSMgr.RemoveReturns(os.ErrNotExist)
 
+			fakeOSMgr.RemoveReturns(os.ErrNotExist)
 			Expect(mgr.ReplaceFiles(files)).ToNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
### Proposed changes

Problem: When the `http.conf` file did not exist, any updates to NGF would cause NGF to error as it could not "replace" that file as it didn't exist.

Solution: Added a check to see if the error returned from trying to remove a conf file was a `IsNotExist`, if so, continue and act as if the file has been deleted.

Testing: Manually tested that NGF was able to recover after manually deleting the `http.conf` file and deploying an example. Also checked for `config-version.conf` and saw the same fixed results.

Note: Part of AC was determining how the `http.conf` file could be removed as a part of our normal workflow and I worked with @kate-osborn to run through some of the most realistic scenarios and they all felt very unlikely to happen and we decided to log an error message at the debug level for when this occurs and not to pursue looking into it anymore. Perhaps when looking through log messages if one sees the log message, they can revisit this situation with more information.

Closes #1110

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
