### PR TITLE
Add tests section to labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,3 +20,6 @@ documentation:
 dependencies:
   - head-branch: ['^deps/', '^dep/', '^dependabot/', 'pre-commit-ci-update-config']
   - changed-files: ['go.mod', 'go.sum']
+
+tests:
+  - head-branch: ['^test/', '^tests/']


### PR DESCRIPTION
Problem:
PRs adding tests are not labelled with `tests`

Solution:
Add section in the `.github/labeler.yml` config to label PRs from branches prefixed with `test` or `tests` with the `tests` label

Closes #1145 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
