### PR TITLE
Fix docs links in notes

### DIFF
--- a/conformance/provisioner/README.md
+++ b/conformance/provisioner/README.md
@@ -19,9 +19,10 @@ Global Flags:
 https://github.com/nginxinc/nginx-gateway-fabric/issues/634). However, it can be used in the Gateway API conformance
 tests, which expect a Gateway API implementation to provision an independent data plane per Gateway.
 >
-> Note: Provisioner uses [this manifest](/deploy/manifests/deployment.yaml) to create an NGF static mode Deployment.
-This manifest gets included into the NGF binary during the NGF build. To customize the Deployment, modify the manifest
-and **re-build** NGF.
+> Note: Provisioner uses [this manifest](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/conformance/provisioner/static-deployment.yaml)
+to create an NGF static mode Deployment.
+> This manifest gets included into the NGF binary during the NGF build. To customize the Deployment, modify the
+manifest and **re-build** NGF.
 
 How to deploy:
 

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -14,7 +14,7 @@ This chart deploys the NGINX Gateway Fabric in your Kubernetes cluster.
 > Note: The Gateway API resources from the standard channel (the CRDs and the validating webhook) must be installed
 > before deploying NGINX Gateway Fabric. If they are already installed in your cluster, please ensure they are
 > the correct version as supported by the NGINX Gateway Fabric -
-> [see the Technical Specifications](../../README.md#technical-specifications).
+> [see the Technical Specifications](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/README.md#technical-specifications).
 
 To install the Gateway resources from [the Gateway API repo](https://github.com/kubernetes-sigs/gateway-api), run:
 

--- a/docs/guides/upgrade-apps-without-downtime.md
+++ b/docs/guides/upgrade-apps-without-downtime.md
@@ -5,7 +5,7 @@ This guide explains how to use NGINX Gateway Fabric to upgrade applications with
 Multiple upgrade methods are mentioned, assuming existing familiarity: this guide focuses primarily on how to use NGINX
 Gateway Fabric to accomplish them.
 
-> See the [Architecture document](/docs/architecture.md) to learn more about NGINX Gateway Fabric architecture.
+> See the [Architecture document](../architecture.md) to learn more about NGINX Gateway Fabric architecture.
 
 ## NGINX Gateway Fabric Functionality
 
@@ -83,7 +83,7 @@ For example, an application can be exposed using a routing rule like below:
     port: 80
 ```
 
-> See the [Cafe example](/examples/cafe-example) for a basic example.
+> See the [Cafe example](../../examples/cafe-example) for a basic example.
 
 The upgrade methods in the next sections cover:
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -80,7 +80,8 @@ with the changes and update the status field of the corresponding Enhancement Pr
 
 > Note:
 >
-> Make sure to read the [Development Guide](/CONTRIBUTING.md#development-guide) before making any code changes.
+> Make sure to read the [Development Guide](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md#development-guide)
+> before making any code changes.
 
 ## Status
 


### PR DESCRIPTION
Problem: Internal docs links within notes aren't working properly.

Solution: Adjusted these links so they redirect properly.

Closes #1150

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
