### PR TITLE
Add PartiallyInvalid HTTPRoute Condition

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -174,6 +174,7 @@ Fields:
       - `ResolvedRefs/False/BackendNotFound`
       - `ResolvedRefs/False/UnsupportedValue` - custom reason for when one of the HTTPRoute rules has a backendRef
               with an unsupported value.
+      - `PartiallyInvalid/True/UnsupportedValue`
 
 ### ReferenceGrant
 

--- a/internal/mode/static/state/conditions/conditions.go
+++ b/internal/mode/static/state/conditions/conditions.go
@@ -59,6 +59,9 @@ const (
 		"is programmed again"
 	// RouteConditionPartiallyInvalid is a condition which indicates that the Route contains
 	// a combination of both valid and invalid rules.
+	//
+	// FIXME(Jee): Update to Gateway sig v1 version when released.
+	// https://github.com/nginxinc/nginx-gateway-fabric/issues/1168
 	RouteConditionPartiallyInvalid v1beta1.RouteConditionType = "PartiallyInvalid"
 )
 

--- a/internal/mode/static/state/conditions/conditions.go
+++ b/internal/mode/static/state/conditions/conditions.go
@@ -57,6 +57,9 @@ const (
 	RouteMessageFailedNginxReload = GatewayMessageFailedNginxReload + ". NGINX may still be configured " +
 		"for this HTTPRoute. However, future updates to this resource will not be configured until the Gateway " +
 		"is programmed again"
+	// RouteConditionPartiallyInvalid is a condition which indicates that the Route contains
+	// a combination of both valid and invalid rules.
+	RouteConditionPartiallyInvalid v1beta1.RouteConditionType = "PartiallyInvalid"
 )
 
 // DeduplicateConditions removes duplicate conditions based on the condition type.
@@ -146,6 +149,17 @@ func NewRouteUnsupportedValue(msg string) conditions.Condition {
 	return conditions.Condition{
 		Type:    string(v1beta1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
+		Reason:  string(v1beta1.RouteReasonUnsupportedValue),
+		Message: msg,
+	}
+}
+
+// NewRoutePartiallyInvalid returns a Condition that indicates that the HTTPRoute contains a combination
+// of both valid and invalid rules.
+func NewRoutePartiallyInvalid(msg string) conditions.Condition {
+	return conditions.Condition{
+		Type:    string(RouteConditionPartiallyInvalid),
+		Status:  metav1.ConditionTrue,
 		Reason:  string(v1beta1.RouteReasonUnsupportedValue),
 		Message: msg,
 	}

--- a/internal/mode/static/state/conditions/conditions.go
+++ b/internal/mode/static/state/conditions/conditions.go
@@ -156,12 +156,16 @@ func NewRouteUnsupportedValue(msg string) conditions.Condition {
 
 // NewRoutePartiallyInvalid returns a Condition that indicates that the HTTPRoute contains a combination
 // of both valid and invalid rules.
+//
+// // nolint:lll
+// The message must start with "Dropped Rules(s)" according to the Gateway API spec
+// See https://github.com/kubernetes-sigs/gateway-api/blob/37d81593e5a965ed76582dbc1a2f56bbd57c0622/apis/v1/shared_types.go#L408-L413
 func NewRoutePartiallyInvalid(msg string) conditions.Condition {
 	return conditions.Condition{
 		Type:    string(RouteConditionPartiallyInvalid),
 		Status:  metav1.ConditionTrue,
 		Reason:  string(v1beta1.RouteReasonUnsupportedValue),
-		Message: msg,
+		Message: "Dropped Rule(s): " + msg,
 	}
 }
 

--- a/internal/mode/static/state/conditions/conditions.go
+++ b/internal/mode/static/state/conditions/conditions.go
@@ -60,7 +60,7 @@ const (
 	// RouteConditionPartiallyInvalid is a condition which indicates that the Route contains
 	// a combination of both valid and invalid rules.
 	//
-	// FIXME(Jee): Update to Gateway sig v1 version when released.
+	// FIXME(bjee19): Update to Gateway sig v1 version when released.
 	// https://github.com/nginxinc/nginx-gateway-fabric/issues/1168
 	RouteConditionPartiallyInvalid v1beta1.RouteConditionType = "PartiallyInvalid"
 )

--- a/internal/mode/static/state/graph/httproute.go
+++ b/internal/mode/static/state/graph/httproute.go
@@ -233,7 +233,6 @@ func buildRoute(
 		msg := allRulesErrs.ToAggregate().Error()
 
 		if atLeastOneValid {
-			msg = "Dropped Rule(s): " + msg
 			r.Conditions = append(r.Conditions, staticConds.NewRoutePartiallyInvalid(msg))
 		} else {
 			msg = "All rules are invalid: " + msg

--- a/internal/mode/static/state/graph/httproute.go
+++ b/internal/mode/static/state/graph/httproute.go
@@ -233,10 +233,8 @@ func buildRoute(
 		msg := allRulesErrs.ToAggregate().Error()
 
 		if atLeastOneValid {
-			// FIXME(pleshakov): Partial validity for HTTPRoute rules is not defined in the Gateway API spec yet.
-			// See https://github.com/nginxinc/nginx-gateway-fabric/issues/485
-			msg = "Some rules are invalid: " + msg
-			r.Conditions = append(r.Conditions, staticConds.NewTODO(msg))
+			msg = "Dropped Rule(s): " + msg
+			r.Conditions = append(r.Conditions, staticConds.NewRoutePartiallyInvalid(msg))
 		} else {
 			msg = "All rules are invalid: " + msg
 			r.Conditions = append(r.Conditions, staticConds.NewRouteUnsupportedValue(msg))

--- a/internal/mode/static/state/graph/httproute_test.go
+++ b/internal/mode/static/state/graph/httproute_test.go
@@ -354,22 +354,18 @@ func TestBuildRoute(t *testing.T) {
 	hrInvalidFilters := createHTTPRoute("hr", gatewayNsName.Name, "example.com", "/filter")
 	addFilterToPath(hrInvalidFilters, "/filter", invalidFilter)
 
-	hrInvalidValidRules := createHTTPRoute("hr", gatewayNsName.Name, "example.com", invalidPath, "/filter", "/")
+	hrDroppedInvalidMatches := createHTTPRoute("hr", gatewayNsName.Name, "example.com", invalidPath, "/")
 
-	hrInvalidValidRulesWithInvalidFilter := createHTTPRoute(
+	hrDroppedInvalidMatchesAndInvalidFilter := createHTTPRoute(
 		"hr",
 		gatewayNsName.Name,
 		"example.com",
 		invalidPath, "/filter", "/")
-	addFilterToPath(hrInvalidValidRulesWithInvalidFilter, "/filter", invalidFilter)
+	addFilterToPath(hrDroppedInvalidMatchesAndInvalidFilter, "/filter", invalidFilter)
 
-	hrInvalidValidFilter := createHTTPRoute("hr", gatewayNsName.Name, "example.com", "/filter", "/")
-	addFilterToPath(hrInvalidValidFilter, "/filter", validFilter)
-	addFilterToPath(hrInvalidValidFilter, "/", invalidFilter)
-
-	hrInvalidValidRuleAndFilter := createHTTPRoute("hr", gatewayNsName.Name, "example.com", invalidPath, "/filter", "/")
-	addFilterToPath(hrInvalidValidRuleAndFilter, "/filter", validFilter)
-	addFilterToPath(hrInvalidValidRuleAndFilter, "/", invalidFilter)
+	hrDroppedInvalidFilters := createHTTPRoute("hr", gatewayNsName.Name, "example.com", "/filter", "/")
+	addFilterToPath(hrDroppedInvalidFilters, "/filter", validFilter)
+	addFilterToPath(hrDroppedInvalidFilters, "/", invalidFilter)
 
 	validatorInvalidFieldsInRule := &validationfakes.FakeHTTPFieldsValidator{
 		ValidatePathInMatchStub: func(path string) error {
@@ -498,9 +494,9 @@ func TestBuildRoute(t *testing.T) {
 		},
 		{
 			validator: validatorInvalidFieldsInRule,
-			hr:        hrInvalidValidRules,
+			hr:        hrDroppedInvalidMatches,
 			expected: &Route{
-				Source: hrInvalidValidRules,
+				Source: hrDroppedInvalidMatches,
 				Valid:  true,
 				ParentRefs: []ParentRef{
 					{
@@ -522,20 +518,16 @@ func TestBuildRoute(t *testing.T) {
 						ValidMatches: true,
 						ValidFilters: true,
 					},
-					{
-						ValidMatches: true,
-						ValidFilters: true,
-					},
 				},
 			},
-			name: "invalid and valid rules",
+			name: "dropped invalid rule with invalid matches",
 		},
 
 		{
 			validator: validatorInvalidFieldsInRule,
-			hr:        hrInvalidValidRulesWithInvalidFilter,
+			hr:        hrDroppedInvalidMatchesAndInvalidFilter,
 			expected: &Route{
-				Source: hrInvalidValidRulesWithInvalidFilter,
+				Source: hrDroppedInvalidMatchesAndInvalidFilter,
 				Valid:  true,
 				ParentRefs: []ParentRef{
 					{
@@ -565,13 +557,13 @@ func TestBuildRoute(t *testing.T) {
 					},
 				},
 			},
-			name: "invalid filter with invalid and valid rules",
+			name: "dropped invalid rule with invalid filters and invalid rule with invalid matches",
 		},
 		{
 			validator: validatorInvalidFieldsInRule,
-			hr:        hrInvalidValidFilter,
+			hr:        hrDroppedInvalidFilters,
 			expected: &Route{
-				Source: hrInvalidValidFilter,
+				Source: hrDroppedInvalidFilters,
 				Valid:  true,
 				ParentRefs: []ParentRef{
 					{
@@ -596,43 +588,7 @@ func TestBuildRoute(t *testing.T) {
 					},
 				},
 			},
-			name: "invalid and valid filter with valid rules",
-		},
-		{
-			validator: validatorInvalidFieldsInRule,
-			hr:        hrInvalidValidRuleAndFilter,
-			expected: &Route{
-				Source: hrInvalidValidRuleAndFilter,
-				Valid:  true,
-				ParentRefs: []ParentRef{
-					{
-						Idx:     0,
-						Gateway: gatewayNsName,
-					},
-				},
-				Conditions: []conditions.Condition{
-					staticConds.NewRoutePartiallyInvalid(
-						`[spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path, ` +
-							`spec.rules[2].filters[0].requestRedirect.hostname: Invalid value: ` +
-							`"invalid.example.com": invalid hostname]`,
-					),
-				},
-				Rules: []Rule{
-					{
-						ValidMatches: false,
-						ValidFilters: true,
-					},
-					{
-						ValidMatches: true,
-						ValidFilters: true,
-					},
-					{
-						ValidMatches: true,
-						ValidFilters: false,
-					},
-				},
-			},
-			name: "invalid filter and rules with valid filter and rules",
+			name: "dropped invalid rule with invalid filters",
 		},
 	}
 

--- a/internal/mode/static/state/graph/httproute_test.go
+++ b/internal/mode/static/state/graph/httproute_test.go
@@ -356,12 +356,12 @@ func TestBuildRoute(t *testing.T) {
 
 	hrDroppedInvalidMatches := createHTTPRoute("hr", gatewayNsName.Name, "example.com", invalidPath, "/")
 
-	hrDroppedInvalidMatchesAndInvalidFilter := createHTTPRoute(
+	hrDroppedInvalidMatchesAndInvalidFilters := createHTTPRoute(
 		"hr",
 		gatewayNsName.Name,
 		"example.com",
 		invalidPath, "/filter", "/")
-	addFilterToPath(hrDroppedInvalidMatchesAndInvalidFilter, "/filter", invalidFilter)
+	addFilterToPath(hrDroppedInvalidMatchesAndInvalidFilters, "/filter", invalidFilter)
 
 	hrDroppedInvalidFilters := createHTTPRoute("hr", gatewayNsName.Name, "example.com", "/filter", "/")
 	addFilterToPath(hrDroppedInvalidFilters, "/filter", validFilter)
@@ -525,9 +525,9 @@ func TestBuildRoute(t *testing.T) {
 
 		{
 			validator: validatorInvalidFieldsInRule,
-			hr:        hrDroppedInvalidMatchesAndInvalidFilter,
+			hr:        hrDroppedInvalidMatchesAndInvalidFilters,
 			expected: &Route{
-				Source: hrDroppedInvalidMatchesAndInvalidFilter,
+				Source: hrDroppedInvalidMatchesAndInvalidFilters,
 				Valid:  true,
 				ParentRefs: []ParentRef{
 					{

--- a/internal/mode/static/state/graph/httproute_test.go
+++ b/internal/mode/static/state/graph/httproute_test.go
@@ -510,8 +510,7 @@ func TestBuildRoute(t *testing.T) {
 				},
 				Conditions: []conditions.Condition{
 					staticConds.NewRoutePartiallyInvalid(
-						`Dropped Rule(s): ` +
-							`spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path`,
+						`spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path`,
 					),
 				},
 				Rules: []Rule{
@@ -546,8 +545,7 @@ func TestBuildRoute(t *testing.T) {
 				},
 				Conditions: []conditions.Condition{
 					staticConds.NewRoutePartiallyInvalid(
-						`Dropped Rule(s): ` +
-							`[spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path, ` +
+						`[spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path, ` +
 							`spec.rules[1].filters[0].requestRedirect.hostname: Invalid value: ` +
 							`"invalid.example.com": invalid hostname]`,
 					),
@@ -583,8 +581,7 @@ func TestBuildRoute(t *testing.T) {
 				},
 				Conditions: []conditions.Condition{
 					staticConds.NewRoutePartiallyInvalid(
-						`Dropped Rule(s): ` +
-							`spec.rules[1].filters[0].requestRedirect.hostname: Invalid value: ` +
+						`spec.rules[1].filters[0].requestRedirect.hostname: Invalid value: ` +
 							`"invalid.example.com": invalid hostname`,
 					),
 				},
@@ -615,8 +612,7 @@ func TestBuildRoute(t *testing.T) {
 				},
 				Conditions: []conditions.Condition{
 					staticConds.NewRoutePartiallyInvalid(
-						`Dropped Rule(s): ` +
-							`[spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path, ` +
+						`[spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path, ` +
 							`spec.rules[2].filters[0].requestRedirect.hostname: Invalid value: ` +
 							`"invalid.example.com": invalid hostname]`,
 					),


### PR DESCRIPTION
### Proposed changes

Replace previously used TODO Conditions with PartiallyInvalid HTTPRoute Condition.

Problem: There was no HTTPRoute Condition that conveyed when a Route was PartiallyInvalid.

Solution: Added the PartiallyInvalid HTTPRoute Condition.

Testing: Manually deployed HTTPRoute with invalid and valid rules and checked to see if the HTTPRoute correctly displayed the new condition. Also checked to see if the matches are valid, with an invalid filter, that the HTTPRoute correctly displayed the new condition. Added additional Unit Tests.

Please focus on (optional): Did I update all the documentation? Are the tests that I added all necessary and done correctly? 

Closes #485

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
