### PR TITLE
[DO NOT MERGE] Test upgrade gateway API to v1.0.0-rc2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,8 +222,7 @@ jobs:
           make create-kind-cluster KIND_KUBE_CONFIG=${kube_config}
           echo "KUBECONFIG=${kube_config}" >> "$GITHUB_ENV"
           kind load docker-image ${{ steps.ngf-meta.outputs.tags }} ${{ steps.nginx-meta.outputs.tags }}
-          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.1/standard-install.yaml
-          kubectl wait --for=condition=complete job/gateway-api-admission-patch job/gateway-api-admission -n gateway-system
+          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0-rc1/standard-install.yaml
 
       - name: Install Chart
         run: >

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -153,7 +153,7 @@ jobs:
           make run-conformance-tests TAG=${{ github.sha }} VERSION=${{ github.ref_name }}
           core_result=$(cat conformance-profile.yaml | yq '.profiles[0].core.result')
           extended_result=$(cat conformance-profile.yaml | yq '.profiles[0].extended.result')
-          [ ${core_result} != "failure" ] && [ ${extended_result} != "failure" ] || echo "Conformance test failed, See above for details."; exit 2
+          if [ "${core_result}" == "failure" ] || [ "${extended_result}" == "failure" ]; then echo "Conformance test failed, see previous job for details." && exit 2; fi
         working-directory: ./conformance
 
       - name: Upload profile to release

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -149,7 +149,11 @@ jobs:
         working-directory: ./conformance
 
       - name: Run conformance tests
-        run: make run-conformance-tests TAG=${{ github.sha }} VERSION=${{ github.ref_name }}
+        run: |
+          make run-conformance-tests TAG=${{ github.sha }} VERSION=${{ github.ref_name }}
+          core_result=$(cat conformance-profile.yaml | yq '.profiles[0].core.result')
+          extended_result=$(cat conformance-profile.yaml | yq '.profiles[0].extended.result')
+          [ ${core_result} != "failure" ] && [ ${extended_result} != "failure" ] || echo "Conformance test failed, See above for details."; exit 2
         working-directory: ./conformance
 
       - name: Upload profile to release

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -1,7 +1,7 @@
 NGF_TAG = edge
 NGF_PREFIX = nginx-gateway-fabric
 NGINX_IMAGE_NAME = $(NGF_PREFIX)/nginx
-GW_API_VERSION ?= 0.8.1
+GW_API_VERSION ?= 1.0.0-rc1
 GATEWAY_CLASS = nginx
 SUPPORTED_FEATURES = HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,GatewayClassObservedGenerationBump
 KIND_IMAGE ?= $(shell grep -m1 'FROM kindest/node' <tests/Dockerfile | awk -F'[ ]' '{print $$2}')
@@ -48,7 +48,6 @@ load-images: ## Load NGF and NGINX images on configured kind cluster
 .PHONY: prepare-ngf-dependencies
 prepare-ngf-dependencies: update-ngf-manifest ## Install NGF dependencies on configured kind cluster
 	./scripts/install-gateway.sh $(GW_API_VERSION)
-	kubectl wait --for=condition=available --timeout=60s deployment gateway-api-admission-server -n gateway-system
 	kubectl apply -f $(CRDS)
 	kubectl apply -f $(NGF_MANIFEST)
 

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -1,7 +1,7 @@
 NGF_TAG = edge
 NGF_PREFIX = nginx-gateway-fabric
 NGINX_IMAGE_NAME = $(NGF_PREFIX)/nginx
-GW_API_VERSION ?= 1.0.0-rc1
+GW_API_VERSION ?= 1.0.0-rc2
 GATEWAY_CLASS = nginx
 SUPPORTED_FEATURES = HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,GatewayClassObservedGenerationBump
 KIND_IMAGE ?= $(shell grep -m1 'FROM kindest/node' <tests/Dockerfile | awk -F'[ ]' '{print $$2}')
@@ -78,9 +78,8 @@ run-conformance-tests: ## Run conformance tests
 								--report-output=output.txt; cat output.txt" | tee output.txt
 	sed -e '1,/CONFORMANCE PROFILE/d' output.txt > conformance-profile.yaml
 	rm output.txt
-	$(eval result_core=$(shell cat conformance-profile.yaml | yq '.profiles[0].core.result'))
-	$(eval result_extended=$(shell cat conformance-profile.yaml | yq '.profiles[0].extended.result'))
-	[ "$(result_core)" != "failure" ] && [ "$(result_extended)" != "failure" ] || exit 2
+	[ $(shell cat conformance-profile.yaml | yq '.profiles[0].core.result') != "failure" ] \
+		&& [ $(shell cat conformance-profile.yaml | yq '.profiles[0].extended.result') != "failure" ] || exit 2
 
 .PHONY: cleanup-conformance-tests
 cleanup-conformance-tests: ## Clean up conformance tests fixtures

--- a/conformance/scripts/install-gateway.sh
+++ b/conformance/scripts/install-gateway.sh
@@ -9,7 +9,6 @@ if [ $1 == "main" ]; then
     temp_dir=$(mktemp -d)
     cd ${temp_dir}
     curl -s https://codeload.github.com/kubernetes-sigs/gateway-api/tar.gz/main | tar -xz --strip=2 gateway-api-main/config
-    kubectl apply -f webhook
     kubectl apply -f crd/standard
     rm -rf ${temp_dir}
 else

--- a/conformance/scripts/uninstall-gateway.sh
+++ b/conformance/scripts/uninstall-gateway.sh
@@ -9,7 +9,6 @@ if [ $1 == "main" ]; then
     temp_dir=$(mktemp -d)
     cd ${temp_dir}
     curl -s https://codeload.github.com/kubernetes-sigs/gateway-api/tar.gz/main | tar -xz --strip=2 gateway-api-main/config
-    kubectl delete -f webhook
     kubectl delete -f crd/standard
     rm -rf ${temp_dir}
 else

--- a/conformance/tests/conformance_test.go
+++ b/conformance/tests/conformance_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/apis/v1alpha1"
@@ -43,6 +44,7 @@ func TestConformance(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	g.Expect(v1alpha2.AddToScheme(client.Scheme())).To(Succeed())
+	g.Expect(v1.AddToScheme(client.Scheme())).To(Succeed())
 	g.Expect(v1beta1.AddToScheme(client.Scheme())).To(Succeed())
 
 	supportedFeatures := suite.ParseSupportedFeatures(*flags.SupportedFeatures)

--- a/deploy/helm-chart/templates/gatewayclass.yaml
+++ b/deploy/helm-chart/templates/gatewayclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: {{ .Values.nginxGateway.gatewayClassName }}

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -234,7 +234,7 @@ spec:
         emptyDir: {}
 ---
 # Source: nginx-gateway-fabric/templates/gatewayclass.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: nginx

--- a/design/resource-validation.md
+++ b/design/resource-validation.md
@@ -88,7 +88,7 @@ We will introduce two validation methods to be run by NGF control plane:
 ### Re-run of Webhook Validation
 
 Before processing a resource, NGF will validate it using the functions from
-the [validation package](https://github.com/kubernetes-sigs/gateway-api/tree/b241afc88e68c952cc0a59a5c72a51358dc2bada/apis/v1beta1/validation)
+the [validation package](https://github.com/kubernetes-sigs/gateway-api/tree/b241afc88e68c952cc0a59a5c72a51358dc2bada/apis/v1/validation)
 from the Gateway API. This will ensure that the webhook validation cannot be bypassed (it can be bypassed if the webhook
 is not installed, misconfigured, or running a different version), and it will allow us to avoid repeating the same
 validation in our code.

--- a/design/resource-validation.md
+++ b/design/resource-validation.md
@@ -88,7 +88,7 @@ We will introduce two validation methods to be run by NGF control plane:
 ### Re-run of Webhook Validation
 
 Before processing a resource, NGF will validate it using the functions from
-the [validation package](https://github.com/kubernetes-sigs/gateway-api/tree/b241afc88e68c952cc0a59a5c72a51358dc2bada/apis/v1/validation)
+the [validation package](https://github.com/kubernetes-sigs/gateway-api/tree/fa4b0a519b30a33b205ac0256876afc1456f2dd3/apis/v1/validation)
 from the Gateway API. This will ensure that the webhook validation cannot be bypassed (it can be bypassed if the webhook
 is not installed, misconfigured, or running a different version), and it will allow us to avoid repeating the same
 validation in our code.

--- a/docs/developer/logging-guidelines.md
+++ b/docs/developer/logging-guidelines.md
@@ -188,7 +188,7 @@ The next section shows how to add context.
 
    ```go
    // hr implements client.Object (controller-runtime)
-   // hr is *v1beta1.HTTPRoute
+   // hr is *v1.HTTPRoute
     logger.Info(
         "Processed resource",
         "resource", hr,
@@ -196,7 +196,7 @@ The next section shows how to add context.
    ```
 
    ```json
-   {"level":"info","ts":"2023-07-20T15:10:03-04:00","msg":"Processed resource","resource":{"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"HTTPRoute","namespace":"test","name":"hr-1"}}
+   {"level":"info","ts":"2023-07-20T15:10:03-04:00","msg":"Processed resource","resource":{"apiVersion":"gateway.networking.k8s.io/v1","kind":"HTTPRoute","namespace":"test","name":"hr-1"}}
    ```
 
    > The resource must include `TypeMeta`, otherwise its `apiVersion` and `kind` will not be printed.
@@ -276,7 +276,7 @@ For the developer, log messages are formatted as text strings (except key/values
 example:
 
 ```text
-2023-07-21T12:41:37.640-0400    INFO    Processed resource      {"resource": {"apiVersion": "gateway.networking.k8s.io/v1beta1", "kind": "HTTPRoute", "namespace": "test", "name": "hr-1"}}
+2023-07-21T12:41:37.640-0400    INFO    Processed resource      {"resource": {"apiVersion": "gateway.networking.k8s.io/v1", "kind": "HTTPRoute", "namespace": "test", "name": "hr-1"}}
 ```
 
 The formatting is controlled during the logger initialization.

--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -6,9 +6,9 @@ This document describes which Gateway API resources NGINX Gateway Fabric support
 
 | Resource                            | Core Support Level | Extended Support Level | Implementation-Specific Support Level | API Version |
 |-------------------------------------|--------------------|------------------------|---------------------------------------|-------------|
-| [GatewayClass](#gatewayclass)       | Supported          | Not supported          | Not Supported                         | v1beta1     |
-| [Gateway](#gateway)                 | Supported          | Not supported          | Not Supported                         | v1beta1     |
-| [HTTPRoute](#httproute)             | Supported          | Partially supported    | Not Supported                         | v1beta1     |
+| [GatewayClass](#gatewayclass)       | Supported          | Not supported          | Not Supported                         | v1          |
+| [Gateway](#gateway)                 | Supported          | Not supported          | Not Supported                         | v1          |
+| [HTTPRoute](#httproute)             | Supported          | Partially supported    | Not Supported                         | v1          |
 | [ReferenceGrant](#referencegrant)   | Supported          | N/A                    | Not Supported                         | v1beta1     |
 | [Custom policies](#custom-policies) | Not supported      | N/A                    | Not Supported                         | N/A         |
 | [TLSRoute](#tlsroute)               | Not supported      | Not supported          | Not Supported                         | N/A         |

--- a/docs/guides/advanced-routing.md
+++ b/docs/guides/advanced-routing.md
@@ -46,7 +46,7 @@ The [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway/) resource is ty
 
 ```yaml
 kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: cafe
@@ -66,7 +66,7 @@ The [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/) is typical
 
 ```yaml
 kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -175,7 +175,7 @@ We are reusing the previous Gateway for these applications, so all we need to cr
 
 ```yaml
 kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/docs/guides/integrating-cert-manager.md
+++ b/docs/guides/integrating-cert-manager.md
@@ -121,7 +121,7 @@ Next we need to deploy our Gateway. Use can use the below YAML manifest, updatin
 field to the required value for your environment.
 
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -216,7 +216,7 @@ Deploy our HTTPRoute to configure our routing rules for the coffee application. 
 spec refers to the Listener configured in the previous step.
 
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee

--- a/docs/guides/routing-traffic-to-your-app.md
+++ b/docs/guides/routing-traffic-to-your-app.md
@@ -25,8 +25,8 @@ With this architecture, the coffee application is not accessible outside the clu
 on the hostname `cafe.example.com` so that clients outside the cluster can access it.
 
 To do this, we will install NGINX Gateway Fabric and create two Gateway API resources:
-a [Gateway](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.Gateway) and
-an [HTTPRoute](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.HTTPRoute).
+a [Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.Gateway) and
+an [HTTPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.HTTPRoute).
 With these resources, we will configure a simple routing rule to match all HTTP traffic with the
 hostname `cafe.example.com` and route it to the coffee Service.
 
@@ -143,7 +143,7 @@ only configure Gateways with a `gatewayClassName` of `nginx` unless you change t
 [command-line flag](/docs/cli-help.md#static-mode).
 
 We specify
-a [listener](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.Listener) on
+a [Listener](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.Listener) on
 the Gateway to open an entry point on the cluster. In this case, since the coffee application accepts HTTP requests, we
 create an HTTP listener, named `http`, that listens on port 80.
 
@@ -177,16 +177,16 @@ EOF
 ```
 
 To attach the `coffee` HTTPRoute to the `cafe` Gateway, we specify the Gateway name in
-the [`parentRefs`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.CommonRouteSpec)
+the [`parentRefs`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.CommonRouteSpec)
 field. The attachment will succeed if the hostnames and protocol in the HTTPRoute are allowed by at least one of the
 Gateway's listeners.
 
-The [`hostnames`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec)
+The [`hostnames`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec)
 field allows you to list the hostnames that the HTTPRoute matches. In this case, incoming requests handled by the `http`
 listener with the HTTP host header `cafe.example.com` will match this HTTPRoute and will be routed according to the
 rules in the spec.
 
-The [`rules`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule)
+The [`rules`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule)
 field defines routing rules for the HTTPRoute. A rule is selected if the request satisfies one of the rule's `matches`.
 To forward traffic for all paths to the coffee Service we specify a match with the PathPrefix `/` and target the coffee
 Service using the `backendRef` field.

--- a/docs/guides/routing-traffic-to-your-app.md
+++ b/docs/guides/routing-traffic-to-your-app.md
@@ -25,8 +25,8 @@ With this architecture, the coffee application is not accessible outside the clu
 on the hostname `cafe.example.com` so that clients outside the cluster can access it.
 
 To do this, we will install NGINX Gateway Fabric and create two Gateway API resources:
-a [Gateway](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.Gateway) and
-an [HTTPRoute](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute).
+a [Gateway](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.Gateway) and
+an [HTTPRoute](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.HTTPRoute).
 With these resources, we will configure a simple routing rule to match all HTTP traffic with the
 hostname `cafe.example.com` and route it to the coffee Service.
 
@@ -124,7 +124,7 @@ To create the `cafe` Gateway, copy and paste the following into your terminal:
 
 ```yaml
 kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: cafe
@@ -143,20 +143,20 @@ only configure Gateways with a `gatewayClassName` of `nginx` unless you change t
 [command-line flag](/docs/cli-help.md#static-mode).
 
 We specify
-a [listener](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.Listener) on
+a [listener](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.Listener) on
 the Gateway to open an entry point on the cluster. In this case, since the coffee application accepts HTTP requests, we
 create an HTTP listener, named `http`, that listens on port 80.
 
 By default, Gateways only allow routes (such as HTTPRoutes) to attach if they are in the same namespace as the Gateway.
 If you want to change this behavior, you can set
-the [`allowedRoutes`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.AllowedRoutes)
+the [`allowedRoutes`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.AllowedRoutes)
 field.
 
 Now, let's create the HTTPRoute by copying and pasting the following into your terminal:
 
 ```yaml
 kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -177,16 +177,16 @@ EOF
 ```
 
 To attach the `coffee` HTTPRoute to the `cafe` Gateway, we specify the Gateway name in
-the [`parentRefs`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.CommonRouteSpec)
+the [`parentRefs`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.CommonRouteSpec)
 field. The attachment will succeed if the hostnames and protocol in the HTTPRoute are allowed by at least one of the
 Gateway's listeners.
 
-The [`hostnames`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteSpec)
+The [`hostnames`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec)
 field allows you to list the hostnames that the HTTPRoute matches. In this case, incoming requests handled by the `http`
 listener with the HTTP host header `cafe.example.com` will match this HTTPRoute and will be routed according to the
 rules in the spec.
 
-The [`rules`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteRule)
+The [`rules`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule)
 field defines routing rules for the HTTPRoute. A rule is selected if the request satisfies one of the rule's `matches`.
 To forward traffic for all paths to the coffee Service we specify a match with the PathPrefix `/` and target the coffee
 Service using the `backendRef` field.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ the `--service` argument to the controller.
 
 > **Important**
 > The Service manifests expose NGINX Gateway Fabric on ports 80 and 443, which exposes any
-> Gateway [Listener](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.Listener)
+> Gateway [Listener](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.Listener)
 > configured for those ports. If you'd like to use different ports in your listeners,
 > update the manifests accordingly.
 >

--- a/examples/advanced-routing/cafe-routes.yaml
+++ b/examples/advanced-routing/cafe-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -32,7 +32,7 @@ spec:
     - name: coffee-v2-svc
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/examples/advanced-routing/gateway.yaml
+++ b/examples/advanced-routing/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: cafe

--- a/examples/cafe-example/cafe-routes.yaml
+++ b/examples/cafe-example/cafe-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -17,7 +17,7 @@ spec:
     - name: coffee
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/examples/cafe-example/gateway.yaml
+++ b/examples/cafe-example/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/examples/cross-namespace-routing/cafe-routes.yaml
+++ b/examples/cross-namespace-routing/cafe-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -18,7 +18,7 @@ spec:
       namespace: cafe
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/examples/cross-namespace-routing/gateway.yaml
+++ b/examples/cross-namespace-routing/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/examples/http-header-filter/echo-route.yaml
+++ b/examples/http-header-filter/echo-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: headers

--- a/examples/http-header-filter/gateway.yaml
+++ b/examples/http-header-filter/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/examples/https-termination/README.md
+++ b/examples/https-termination/README.md
@@ -81,7 +81,7 @@ reference a Secret in a different Namespace.
 
    To configure HTTPS termination for our cafe application, we will bind our `coffee` and `tea` HTTPRoutes to
    the `https` listener in [cafe-routes.yaml](./cafe-routes.yaml) using
-   the [`parentReference`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.ParentReference)
+   the [`parentReference`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.ParentReference)
    field:
 
    ```yaml
@@ -91,7 +91,7 @@ reference a Secret in a different Namespace.
    ```
 
    To configure an HTTPS redirect from port 80 to 443, we will bind the special `cafe-tls-redirect` HTTPRoute with
-   a [`HTTPRequestRedirectFilter`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRequestRedirectFilter)
+   a [`HTTPRequestRedirectFilter`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.HTTPRequestRedirectFilter)
    to the `http` listener:
 
    ```yaml

--- a/examples/https-termination/cafe-routes.yaml
+++ b/examples/https-termination/cafe-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: cafe-tls-redirect
@@ -15,7 +15,7 @@ spec:
         scheme: https
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -34,7 +34,7 @@ spec:
     - name: coffee
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/examples/https-termination/gateway.yaml
+++ b/examples/https-termination/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/examples/traffic-splitting/cafe-route-equal-weight.yaml
+++ b/examples/traffic-splitting/cafe-route-equal-weight.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: cafe-route

--- a/examples/traffic-splitting/cafe-route.yaml
+++ b/examples/traffic-splitting/cafe-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: cafe-route

--- a/examples/traffic-splitting/gateway.yaml
+++ b/examples/traffic-splitting/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,11 @@ module github.com/nginxinc/nginx-gateway-fabric
 
 go 1.21.3
 
-// Pinned to a version that is properly licensed.
-replace github.com/chzyer/logex v1.1.10 => github.com/chzyer/logex v1.2.0
+replace (
+	// Pinned to a version that is properly licensed.
+	github.com/chzyer/logex v1.1.10 => github.com/chzyer/logex v1.2.0
+	sigs.k8s.io/gateway-api => sigs.k8s.io/gateway-api v1.0.0-rc1
+)
 
 require (
 	github.com/go-logr/logr v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.3
 replace (
 	// Pinned to a version that is properly licensed.
 	github.com/chzyer/logex v1.1.10 => github.com/chzyer/logex v1.2.0
-	sigs.k8s.io/gateway-api => sigs.k8s.io/gateway-api v1.0.0-rc1
+	sigs.k8s.io/gateway-api => sigs.k8s.io/gateway-api v1.0.0-rc2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigw
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
 sigs.k8s.io/controller-tools v0.13.0 h1:NfrvuZ4bxyolhDBt/rCZhDnx3M2hzlhgo5n3Iv2RykI=
 sigs.k8s.io/controller-tools v0.13.0/go.mod h1:5vw3En2NazbejQGCeWKRrE7q4P+CW8/klfVqP8QZkgA=
-sigs.k8s.io/gateway-api v1.0.0-rc1 h1:v7N9fWTcQxox5aP2IrViDw6imeUHMAt2WFjI4BYo0sw=
-sigs.k8s.io/gateway-api v1.0.0-rc1/go.mod h1:+QpYENjk9s31/abu2Pv5BpK2v88UQDK2aeQCwCvy6ck=
+sigs.k8s.io/gateway-api v1.0.0-rc2 h1:+7rq7j5fehUkMkgnJyL90mtXrVnz8aj5SXsRqIEW3Mk=
+sigs.k8s.io/gateway-api v1.0.0-rc2/go.mod h1:+QpYENjk9s31/abu2Pv5BpK2v88UQDK2aeQCwCvy6ck=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigw
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
 sigs.k8s.io/controller-tools v0.13.0 h1:NfrvuZ4bxyolhDBt/rCZhDnx3M2hzlhgo5n3Iv2RykI=
 sigs.k8s.io/controller-tools v0.13.0/go.mod h1:5vw3En2NazbejQGCeWKRrE7q4P+CW8/klfVqP8QZkgA=
-sigs.k8s.io/gateway-api v0.8.1 h1:Bo4NMAQFYkQZnHXOfufbYwbPW7b3Ic5NjpbeW6EJxuU=
-sigs.k8s.io/gateway-api v0.8.1/go.mod h1:0PteDrsrgkRmr13nDqFWnev8tOysAVrwnvfFM55tSVg=
+sigs.k8s.io/gateway-api v1.0.0-rc1 h1:v7N9fWTcQxox5aP2IrViDw6imeUHMAt2WFjI4BYo0sw=
+sigs.k8s.io/gateway-api v1.0.0-rc1/go.mod h1:+QpYENjk9s31/abu2Pv5BpK2v88UQDK2aeQCwCvy6ck=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/internal/framework/conditions/conditions.go
+++ b/internal/framework/conditions/conditions.go
@@ -2,7 +2,7 @@ package conditions
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (
@@ -10,7 +10,7 @@ const (
 	// that reference this controller, and we ignored the resource in question and picked the
 	// GatewayClass that is referenced in the command-line argument.
 	// This reason is used with GatewayClassConditionAccepted (false).
-	GatewayClassReasonGatewayClassConflict v1beta1.GatewayClassConditionReason = "GatewayClassConflict"
+	GatewayClassReasonGatewayClassConflict v1.GatewayClassConditionReason = "GatewayClassConflict"
 
 	// GatewayClassMessageGatewayClassConflict is a message that describes GatewayClassReasonGatewayClassConflict.
 	GatewayClassMessageGatewayClassConflict = "The resource is ignored due to a conflicting GatewayClass resource"
@@ -28,9 +28,9 @@ type Condition struct {
 func NewDefaultGatewayClassConditions() []Condition {
 	return []Condition{
 		{
-			Type:    string(v1beta1.GatewayClassConditionStatusAccepted),
+			Type:    string(v1.GatewayClassConditionStatusAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  string(v1beta1.GatewayClassReasonAccepted),
+			Reason:  string(v1.GatewayClassReasonAccepted),
 			Message: "GatewayClass is accepted",
 		},
 	}
@@ -40,7 +40,7 @@ func NewDefaultGatewayClassConditions() []Condition {
 // due to a conflict with another GatewayClass.
 func NewGatewayClassConflict() Condition {
 	return Condition{
-		Type:    string(v1beta1.GatewayClassConditionStatusAccepted),
+		Type:    string(v1.GatewayClassConditionStatusAccepted),
 		Status:  metav1.ConditionFalse,
 		Reason:  string(GatewayClassReasonGatewayClassConflict),
 		Message: GatewayClassMessageGatewayClassConflict,

--- a/internal/framework/controller/predicate/gatewayclass.go
+++ b/internal/framework/controller/predicate/gatewayclass.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // GatewayClassPredicate implements a predicate function based on the controllerName of a GatewayClass.
@@ -19,7 +19,7 @@ func (gcp GatewayClassPredicate) Create(e event.CreateEvent) bool {
 		return false
 	}
 
-	gc, ok := e.Object.(*v1beta1.GatewayClass)
+	gc, ok := e.Object.(*v1.GatewayClass)
 	if !ok {
 		return false
 	}
@@ -30,14 +30,14 @@ func (gcp GatewayClassPredicate) Create(e event.CreateEvent) bool {
 // Update implements default UpdateEvent filter for validating a GatewayClass controllerName.
 func (gcp GatewayClassPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld != nil {
-		gcOld, ok := e.ObjectOld.(*v1beta1.GatewayClass)
+		gcOld, ok := e.ObjectOld.(*v1.GatewayClass)
 		if ok && string(gcOld.Spec.ControllerName) == gcp.ControllerName {
 			return true
 		}
 	}
 
 	if e.ObjectNew != nil {
-		gcNew, ok := e.ObjectNew.(*v1beta1.GatewayClass)
+		gcNew, ok := e.ObjectNew.(*v1.GatewayClass)
 		if ok && string(gcNew.Spec.ControllerName) == gcp.ControllerName {
 			return true
 		}

--- a/internal/framework/controller/predicate/gatewayclass_test.go
+++ b/internal/framework/controller/predicate/gatewayclass_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func TestGatewayClassPredicate(t *testing.T) {
@@ -13,8 +13,8 @@ func TestGatewayClassPredicate(t *testing.T) {
 
 	p := GatewayClassPredicate{ControllerName: "nginx-ctlr"}
 
-	gc := &v1beta1.GatewayClass{
-		Spec: v1beta1.GatewayClassSpec{
+	gc := &v1.GatewayClass{
+		Spec: v1.GatewayClassSpec{
 			ControllerName: "nginx-ctlr",
 		},
 	}
@@ -22,8 +22,8 @@ func TestGatewayClassPredicate(t *testing.T) {
 	g.Expect(p.Create(event.CreateEvent{Object: gc})).To(BeTrue())
 	g.Expect(p.Update(event.UpdateEvent{ObjectNew: gc})).To(BeTrue())
 
-	gc2 := &v1beta1.GatewayClass{
-		Spec: v1beta1.GatewayClassSpec{
+	gc2 := &v1.GatewayClass{
+		Spec: v1.GatewayClassSpec{
 			ControllerName: "unknown",
 		},
 	}

--- a/internal/framework/controller/reconciler.go
+++ b/internal/framework/controller/reconciler.go
@@ -50,7 +50,7 @@ func NewReconciler(cfg ReconcilerConfig) *Reconciler {
 }
 
 func newObject(objectType client.Object) client.Object {
-	// without Elem(), t will be a pointer to the type. For example, *v1beta1.Gateway, not v1beta1.Gateway
+	// without Elem(), t will be a pointer to the type. For example, *v1.Gateway, not v1.Gateway
 	t := reflect.TypeOf(objectType).Elem()
 
 	// We could've used objectType.DeepCopyObject() here, but it's a bit slower confirmed by benchmarks.

--- a/internal/framework/controller/reconciler_test.go
+++ b/internal/framework/controller/reconciler_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller/controllerfakes"
@@ -37,7 +37,7 @@ var _ = Describe("Reconciler", func() {
 			Name:      "hr-1",
 		}
 
-		hr1 = &v1beta1.HTTPRoute{
+		hr1 = &v1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: hr1NsName.Namespace,
 				Name:      hr1NsName.Name,
@@ -49,7 +49,7 @@ var _ = Describe("Reconciler", func() {
 			Name:      "hr-2",
 		}
 
-		hr2 = &v1beta1.HTTPRoute{
+		hr2 = &v1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: hr2NsName.Namespace,
 				Name:      hr2NsName.Name,
@@ -57,30 +57,30 @@ var _ = Describe("Reconciler", func() {
 		}
 	)
 
-	getReturnsHRForHR := func(hr *v1beta1.HTTPRoute) getFunc {
+	getReturnsHRForHR := func(hr *v1.HTTPRoute) getFunc {
 		return func(
 			ctx context.Context,
 			nsname types.NamespacedName,
 			object client.Object,
 			option ...client.GetOption,
 		) error {
-			Expect(object).To(BeAssignableToTypeOf(&v1beta1.HTTPRoute{}))
+			Expect(object).To(BeAssignableToTypeOf(&v1.HTTPRoute{}))
 			Expect(nsname).To(Equal(client.ObjectKeyFromObject(hr)))
 
-			hr.DeepCopyInto(object.(*v1beta1.HTTPRoute))
+			hr.DeepCopyInto(object.(*v1.HTTPRoute))
 
 			return nil
 		}
 	}
 
-	getReturnsNotFoundErrorForHR := func(hr *v1beta1.HTTPRoute) getFunc {
+	getReturnsNotFoundErrorForHR := func(hr *v1.HTTPRoute) getFunc {
 		return func(
 			ctx context.Context,
 			nsname types.NamespacedName,
 			object client.Object,
 			option ...client.GetOption,
 		) error {
-			Expect(object).To(BeAssignableToTypeOf(&v1beta1.HTTPRoute{}))
+			Expect(object).To(BeAssignableToTypeOf(&v1.HTTPRoute{}))
 			Expect(nsname).To(Equal(client.ObjectKeyFromObject(hr)))
 
 			return apierrors.NewNotFound(schema.GroupResource{}, "not found")
@@ -112,7 +112,7 @@ var _ = Describe("Reconciler", func() {
 	})
 
 	Describe("Normal cases", func() {
-		testUpsert := func(hr *v1beta1.HTTPRoute) {
+		testUpsert := func(hr *v1.HTTPRoute) {
 			fakeGetter.GetCalls(getReturnsHRForHR(hr))
 
 			resultCh := startReconciling(client.ObjectKeyFromObject(hr))
@@ -121,14 +121,14 @@ var _ = Describe("Reconciler", func() {
 			Eventually(resultCh).Should(Receive(Equal(result{err: nil, reconcileResult: reconcile.Result{}})))
 		}
 
-		testDelete := func(hr *v1beta1.HTTPRoute) {
+		testDelete := func(hr *v1.HTTPRoute) {
 			fakeGetter.GetCalls(getReturnsNotFoundErrorForHR(hr))
 
 			resultCh := startReconciling(client.ObjectKeyFromObject(hr))
 
 			Eventually(eventCh).Should(Receive(Equal(&events.DeleteEvent{
 				NamespacedName: client.ObjectKeyFromObject(hr),
-				Type:           &v1beta1.HTTPRoute{},
+				Type:           &v1.HTTPRoute{},
 			})))
 			Eventually(resultCh).Should(Receive(Equal(result{err: nil, reconcileResult: reconcile.Result{}})))
 		}
@@ -137,7 +137,7 @@ var _ = Describe("Reconciler", func() {
 			BeforeEach(func() {
 				rec = controller.NewReconciler(controller.ReconcilerConfig{
 					Getter:     fakeGetter,
-					ObjectType: &v1beta1.HTTPRoute{},
+					ObjectType: &v1.HTTPRoute{},
 					EventCh:    eventCh,
 				})
 			})
@@ -162,7 +162,7 @@ var _ = Describe("Reconciler", func() {
 
 				rec = controller.NewReconciler(controller.ReconcilerConfig{
 					Getter:               fakeGetter,
-					ObjectType:           &v1beta1.HTTPRoute{},
+					ObjectType:           &v1.HTTPRoute{},
 					EventCh:              eventCh,
 					NamespacedNameFilter: filter,
 				})
@@ -204,7 +204,7 @@ var _ = Describe("Reconciler", func() {
 		BeforeEach(func() {
 			rec = controller.NewReconciler(controller.ReconcilerConfig{
 				Getter:     fakeGetter,
-				ObjectType: &v1beta1.HTTPRoute{},
+				ObjectType: &v1.HTTPRoute{},
 				EventCh:    eventCh,
 			})
 		})

--- a/internal/framework/controller/register_test.go
+++ b/internal/framework/controller/register_test.go
@@ -14,7 +14,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller/controllerfakes"
@@ -30,6 +31,7 @@ func TestRegister(t *testing.T) {
 
 	getDefaultFakes := func() fakes {
 		scheme := runtime.NewScheme()
+		utilruntime.Must(v1.AddToScheme(scheme))
 		utilruntime.Must(v1beta1.AddToScheme(scheme))
 
 		indexer := &controllerfakes.FakeFieldIndexer{}
@@ -80,7 +82,7 @@ func TestRegister(t *testing.T) {
 		},
 	}
 
-	objectType := &v1beta1.HTTPRoute{}
+	objectType := &v1.HTTPRoute{}
 	nsNameFilter := func(nsname types.NamespacedName) (bool, string) {
 		return true, ""
 	}

--- a/internal/framework/events/event.go
+++ b/internal/framework/events/event.go
@@ -16,7 +16,7 @@ type UpsertEvent struct {
 
 // DeleteEvent representing deleting a resource.
 type DeleteEvent struct {
-	// Type is the resource type. For example, if the event is for *v1beta1.HTTPRoute, pass &v1beta1.HTTPRoute{} as Type.
+	// Type is the resource type. For example, if the event is for *v1.HTTPRoute, pass &v1.HTTPRoute{} as Type.
 	Type client.Object
 	// NamespacedName is the namespace & name of the deleted resource.
 	NamespacedName types.NamespacedName

--- a/internal/framework/events/first_eventbatch_preparer_test.go
+++ b/internal/framework/events/first_eventbatch_preparer_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/events"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/events/eventsfakes"
@@ -32,9 +32,9 @@ var _ = Describe("FirstEventBatchPreparer", func() {
 		fakeReader = &eventsfakes.FakeReader{}
 		preparer = events.NewFirstEventBatchPreparerImpl(
 			fakeReader,
-			[]client.Object{&v1beta1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: gcName}}},
+			[]client.Object{&v1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: gcName}}},
 			[]client.ObjectList{
-				&v1beta1.HTTPRouteList{},
+				&v1.HTTPRouteList{},
 			})
 	})
 
@@ -48,7 +48,7 @@ var _ = Describe("FirstEventBatchPreparer", func() {
 			fakeReader.GetCalls(
 				func(ctx context.Context, name types.NamespacedName, object client.Object, opts ...client.GetOption) error {
 					Expect(name).Should(Equal(types.NamespacedName{Name: gcName}))
-					Expect(object).Should(BeAssignableToTypeOf(&v1beta1.GatewayClass{}))
+					Expect(object).Should(BeAssignableToTypeOf(&v1.GatewayClass{}))
 
 					return apierrors.NewNotFound(schema.GroupResource{}, "test")
 				},
@@ -62,25 +62,25 @@ var _ = Describe("FirstEventBatchPreparer", func() {
 		})
 
 		It("should prepare one event for each resource type", func() {
-			gatewayClass := v1beta1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: gcName}}
+			gatewayClass := v1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: gcName}}
 
 			fakeReader.GetCalls(
 				func(ctx context.Context, name types.NamespacedName, object client.Object, opts ...client.GetOption) error {
 					Expect(name).Should(Equal(types.NamespacedName{Name: gcName}))
-					Expect(object).Should(BeAssignableToTypeOf(&v1beta1.GatewayClass{}))
+					Expect(object).Should(BeAssignableToTypeOf(&v1.GatewayClass{}))
 
 					reflect.Indirect(reflect.ValueOf(object)).Set(reflect.Indirect(reflect.ValueOf(&gatewayClass)))
 					return nil
 				},
 			)
 
-			httpRoute := v1beta1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+			httpRoute := v1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
 
 			fakeReader.ListCalls(func(ctx context.Context, list client.ObjectList, option ...client.ListOption) error {
 				Expect(option).To(BeEmpty())
 
 				switch typedList := list.(type) {
-				case *v1beta1.HTTPRouteList:
+				case *v1.HTTPRouteList:
 					typedList.Items = append(typedList.Items, httpRoute)
 				default:
 					Fail(fmt.Sprintf("unknown type: %T", typedList))
@@ -107,8 +107,8 @@ var _ = Describe("FirstEventBatchPreparer", func() {
 				fakeReader.GetReturns(apierrors.NewNotFound(schema.GroupResource{}, "test"))
 				fakeReader.ListCalls(
 					func(ctx context.Context, list client.ObjectList, option ...client.ListOption) error {
-						httpRoute := v1beta1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
-						typedList := list.(*v1beta1.HTTPRouteList)
+						httpRoute := v1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+						typedList := list.(*v1.HTTPRouteList)
 						typedList.Items = append(typedList.Items, httpRoute)
 
 						return nil
@@ -147,9 +147,9 @@ var _ = Describe("FirstEventBatchPreparer", func() {
 				fakeReader.ListReturns(nil)
 
 				switch obj.(type) {
-				case *v1beta1.GatewayClass:
+				case *v1.GatewayClass:
 					fakeReader.GetReturns(readerError)
-				case *v1beta1.HTTPRoute:
+				case *v1.HTTPRoute:
 					fakeReader.ListReturnsOnCall(0, readerError)
 				default:
 					Fail(fmt.Sprintf("Unknown type: %T", obj))
@@ -159,8 +159,8 @@ var _ = Describe("FirstEventBatchPreparer", func() {
 				Expect(batch).To(BeNil())
 				Expect(err).To(MatchError(readerError))
 			},
-			Entry("GatewayClass", &v1beta1.GatewayClass{}),
-			Entry("HTTPRoute", &v1beta1.HTTPRoute{}),
+			Entry("GatewayClass", &v1.GatewayClass{}),
+			Entry("HTTPRoute", &v1.HTTPRoute{}),
 		)
 	})
 })

--- a/internal/framework/status/gateway.go
+++ b/internal/framework/status/gateway.go
@@ -4,15 +4,15 @@ import (
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // prepareGatewayStatus prepares the status for a Gateway resource.
 func prepareGatewayStatus(
 	gatewayStatus GatewayStatus,
 	transitionTime metav1.Time,
-) v1beta1.GatewayStatus {
-	listenerStatuses := make([]v1beta1.ListenerStatus, 0, len(gatewayStatus.ListenerStatuses))
+) v1.GatewayStatus {
+	listenerStatuses := make([]v1.ListenerStatus, 0, len(gatewayStatus.ListenerStatuses))
 
 	// FIXME(pleshakov) Maintain the order from the Gateway resource
 	// https://github.com/nginxinc/nginx-gateway-fabric/issues/689
@@ -25,15 +25,15 @@ func prepareGatewayStatus(
 	for _, name := range names {
 		s := gatewayStatus.ListenerStatuses[name]
 
-		listenerStatuses = append(listenerStatuses, v1beta1.ListenerStatus{
-			Name:           v1beta1.SectionName(name),
+		listenerStatuses = append(listenerStatuses, v1.ListenerStatus{
+			Name:           v1.SectionName(name),
 			SupportedKinds: s.SupportedKinds,
 			AttachedRoutes: s.AttachedRoutes,
 			Conditions:     convertConditions(s.Conditions, gatewayStatus.ObservedGeneration, transitionTime),
 		})
 	}
 
-	return v1beta1.GatewayStatus{
+	return v1.GatewayStatus{
 		Listeners:  listenerStatuses,
 		Addresses:  gatewayStatus.Addresses,
 		Conditions: convertConditions(gatewayStatus.Conditions, gatewayStatus.ObservedGeneration, transitionTime),

--- a/internal/framework/status/gateway_test.go
+++ b/internal/framework/status/gateway_test.go
@@ -6,14 +6,14 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 )
 
 func TestPrepareGatewayStatus(t *testing.T) {
-	podIP := v1beta1.GatewayStatusAddress{
-		Type:  helpers.GetPointer(v1beta1.IPAddressType),
+	podIP := v1.GatewayStatusAddress{
+		Type:  helpers.GetPointer(v1.IPAddressType),
 		Value: "1.2.3.4",
 	}
 	status := GatewayStatus{
@@ -22,25 +22,25 @@ func TestPrepareGatewayStatus(t *testing.T) {
 			"listener": {
 				AttachedRoutes: 3,
 				Conditions:     CreateTestConditions("ListenerTest"),
-				SupportedKinds: []v1beta1.RouteGroupKind{
+				SupportedKinds: []v1.RouteGroupKind{
 					{
-						Kind: v1beta1.Kind("HTTPRoute"),
+						Kind: v1.Kind("HTTPRoute"),
 					},
 				},
 			},
 		},
-		Addresses:          []v1beta1.GatewayStatusAddress{podIP},
+		Addresses:          []v1.GatewayStatusAddress{podIP},
 		ObservedGeneration: 1,
 	}
 
 	transitionTime := metav1.NewTime(time.Now())
 
-	expected := v1beta1.GatewayStatus{
+	expected := v1.GatewayStatus{
 		Conditions: CreateExpectedAPIConditions("GatewayTest", 1, transitionTime),
-		Listeners: []v1beta1.ListenerStatus{
+		Listeners: []v1.ListenerStatus{
 			{
 				Name: "listener",
-				SupportedKinds: []v1beta1.RouteGroupKind{
+				SupportedKinds: []v1.RouteGroupKind{
 					{
 						Kind: "HTTPRoute",
 					},
@@ -49,7 +49,7 @@ func TestPrepareGatewayStatus(t *testing.T) {
 				Conditions:     CreateExpectedAPIConditions("ListenerTest", 1, transitionTime),
 			},
 		},
-		Addresses: []v1beta1.GatewayStatusAddress{podIP},
+		Addresses: []v1.GatewayStatusAddress{podIP},
 	}
 
 	g := NewWithT(t)

--- a/internal/framework/status/gatewayclass.go
+++ b/internal/framework/status/gatewayclass.go
@@ -2,12 +2,12 @@ package status
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // prepareGatewayClassStatus prepares the status for the GatewayClass resource.
-func prepareGatewayClassStatus(status GatewayClassStatus, transitionTime metav1.Time) v1beta1.GatewayClassStatus {
-	return v1beta1.GatewayClassStatus{
+func prepareGatewayClassStatus(status GatewayClassStatus, transitionTime metav1.Time) v1.GatewayClassStatus {
+	return v1.GatewayClassStatus{
 		Conditions: convertConditions(status.Conditions, status.ObservedGeneration, transitionTime),
 	}
 }

--- a/internal/framework/status/gatewayclass_test.go
+++ b/internal/framework/status/gatewayclass_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 )
@@ -18,7 +18,7 @@ func TestPrepareGatewayClassStatus(t *testing.T) {
 		ObservedGeneration: 1,
 		Conditions:         CreateTestConditions("Test"),
 	}
-	expected := v1beta1.GatewayClassStatus{
+	expected := v1.GatewayClassStatus{
 		Conditions: CreateExpectedAPIConditions("Test", 1, transitionTime),
 	}
 

--- a/internal/framework/status/httproute.go
+++ b/internal/framework/status/httproute.go
@@ -2,20 +2,20 @@ package status
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // prepareHTTPRouteStatus prepares the status for an HTTPRoute resource.
 func prepareHTTPRouteStatus(
-	oldStatus v1beta1.HTTPRouteStatus,
+	oldStatus v1.HTTPRouteStatus,
 	status HTTPRouteStatus,
 	gatewayCtlrName string,
 	transitionTime metav1.Time,
-) v1beta1.HTTPRouteStatus {
+) v1.HTTPRouteStatus {
 	// maxParents is the max number of parent statuses which is the sum of all new parent statuses and all old parent
 	// statuses.
 	maxParents := len(status.ParentStatuses) + len(oldStatus.Parents)
-	parents := make([]v1beta1.RouteParentStatus, 0, maxParents)
+	parents := make([]v1.RouteParentStatus, 0, maxParents)
 
 	// keep all the parent statuses that belong to other controllers
 	for _, os := range oldStatus.Parents {
@@ -27,20 +27,20 @@ func prepareHTTPRouteStatus(
 	for _, ps := range status.ParentStatuses {
 		// reassign the iteration variable inside the loop to fix implicit memory aliasing
 		ps := ps
-		p := v1beta1.RouteParentStatus{
-			ParentRef: v1beta1.ParentReference{
-				Namespace:   (*v1beta1.Namespace)(&ps.GatewayNsName.Namespace),
-				Name:        v1beta1.ObjectName(ps.GatewayNsName.Name),
+		p := v1.RouteParentStatus{
+			ParentRef: v1.ParentReference{
+				Namespace:   (*v1.Namespace)(&ps.GatewayNsName.Namespace),
+				Name:        v1.ObjectName(ps.GatewayNsName.Name),
 				SectionName: ps.SectionName,
 			},
-			ControllerName: v1beta1.GatewayController(gatewayCtlrName),
+			ControllerName: v1.GatewayController(gatewayCtlrName),
 			Conditions:     convertConditions(ps.Conditions, status.ObservedGeneration, transitionTime),
 		}
 		parents = append(parents, p)
 	}
 
-	return v1beta1.HTTPRouteStatus{
-		RouteStatus: v1beta1.RouteStatus{
+	return v1.HTTPRouteStatus{
+		RouteStatus: v1.RouteStatus{
 			Parents: parents,
 		},
 	}

--- a/internal/framework/status/httproute_test.go
+++ b/internal/framework/status/httproute_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 )
@@ -21,7 +21,7 @@ func TestPrepareHTTPRouteStatus(t *testing.T) {
 		ParentStatuses: []ParentStatus{
 			{
 				GatewayNsName: gwNsName1,
-				SectionName:   helpers.GetPointer[v1beta1.SectionName]("http"),
+				SectionName:   helpers.GetPointer[v1.SectionName]("http"),
 				Conditions:    CreateTestConditions("Test"),
 			},
 			{
@@ -35,86 +35,86 @@ func TestPrepareHTTPRouteStatus(t *testing.T) {
 	gatewayCtlrName := "test.example.com"
 	transitionTime := metav1.NewTime(time.Now())
 
-	oldStatus := v1beta1.HTTPRouteStatus{
-		RouteStatus: v1beta1.RouteStatus{
-			Parents: []v1beta1.RouteParentStatus{
+	oldStatus := v1.HTTPRouteStatus{
+		RouteStatus: v1.RouteStatus{
+			Parents: []v1.RouteParentStatus{
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer(v1beta1.Namespace(gwNsName1.Namespace)),
-						Name:        v1beta1.ObjectName(gwNsName1.Name),
-						SectionName: helpers.GetPointer[v1beta1.SectionName]("http"),
+					ParentRef: v1.ParentReference{
+						Namespace:   helpers.GetPointer(v1.Namespace(gwNsName1.Namespace)),
+						Name:        v1.ObjectName(gwNsName1.Name),
+						SectionName: helpers.GetPointer[v1.SectionName]("http"),
 					},
-					ControllerName: v1beta1.GatewayController(gatewayCtlrName),
+					ControllerName: v1.GatewayController(gatewayCtlrName),
 					Conditions:     CreateExpectedAPIConditions("Old", 1, transitionTime),
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer(v1beta1.Namespace(gwNsName1.Namespace)),
-						Name:        v1beta1.ObjectName(gwNsName1.Name),
-						SectionName: helpers.GetPointer[v1beta1.SectionName]("http"),
+					ParentRef: v1.ParentReference{
+						Namespace:   helpers.GetPointer(v1.Namespace(gwNsName1.Namespace)),
+						Name:        v1.ObjectName(gwNsName1.Name),
+						SectionName: helpers.GetPointer[v1.SectionName]("http"),
 					},
-					ControllerName: v1beta1.GatewayController("not-our-controller"),
+					ControllerName: v1.GatewayController("not-our-controller"),
 					Conditions:     CreateExpectedAPIConditions("Test", 1, transitionTime),
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer(v1beta1.Namespace(gwNsName2.Namespace)),
-						Name:        v1beta1.ObjectName(gwNsName2.Name),
+					ParentRef: v1.ParentReference{
+						Namespace:   helpers.GetPointer(v1.Namespace(gwNsName2.Namespace)),
+						Name:        v1.ObjectName(gwNsName2.Name),
 						SectionName: nil,
 					},
-					ControllerName: v1beta1.GatewayController(gatewayCtlrName),
+					ControllerName: v1.GatewayController(gatewayCtlrName),
 					Conditions:     CreateExpectedAPIConditions("Old", 1, transitionTime),
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer(v1beta1.Namespace(gwNsName2.Namespace)),
-						Name:        v1beta1.ObjectName(gwNsName2.Name),
+					ParentRef: v1.ParentReference{
+						Namespace:   helpers.GetPointer(v1.Namespace(gwNsName2.Namespace)),
+						Name:        v1.ObjectName(gwNsName2.Name),
 						SectionName: nil,
 					},
-					ControllerName: v1beta1.GatewayController("not-our-controller"),
+					ControllerName: v1.GatewayController("not-our-controller"),
 					Conditions:     CreateExpectedAPIConditions("Test", 1, transitionTime),
 				},
 			},
 		},
 	}
 
-	expected := v1beta1.HTTPRouteStatus{
-		RouteStatus: v1beta1.RouteStatus{
-			Parents: []v1beta1.RouteParentStatus{
+	expected := v1.HTTPRouteStatus{
+		RouteStatus: v1.RouteStatus{
+			Parents: []v1.RouteParentStatus{
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer(v1beta1.Namespace(gwNsName1.Namespace)),
-						Name:        v1beta1.ObjectName(gwNsName1.Name),
-						SectionName: helpers.GetPointer[v1beta1.SectionName]("http"),
+					ParentRef: v1.ParentReference{
+						Namespace:   helpers.GetPointer(v1.Namespace(gwNsName1.Namespace)),
+						Name:        v1.ObjectName(gwNsName1.Name),
+						SectionName: helpers.GetPointer[v1.SectionName]("http"),
 					},
-					ControllerName: v1beta1.GatewayController("not-our-controller"),
+					ControllerName: v1.GatewayController("not-our-controller"),
 					Conditions:     CreateExpectedAPIConditions("Test", 1, transitionTime),
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer(v1beta1.Namespace(gwNsName2.Namespace)),
-						Name:        v1beta1.ObjectName(gwNsName2.Name),
+					ParentRef: v1.ParentReference{
+						Namespace:   helpers.GetPointer(v1.Namespace(gwNsName2.Namespace)),
+						Name:        v1.ObjectName(gwNsName2.Name),
 						SectionName: nil,
 					},
-					ControllerName: v1beta1.GatewayController("not-our-controller"),
+					ControllerName: v1.GatewayController("not-our-controller"),
 					Conditions:     CreateExpectedAPIConditions("Test", 1, transitionTime),
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer(v1beta1.Namespace(gwNsName1.Namespace)),
-						Name:        v1beta1.ObjectName(gwNsName1.Name),
-						SectionName: helpers.GetPointer[v1beta1.SectionName]("http"),
+					ParentRef: v1.ParentReference{
+						Namespace:   helpers.GetPointer(v1.Namespace(gwNsName1.Namespace)),
+						Name:        v1.ObjectName(gwNsName1.Name),
+						SectionName: helpers.GetPointer[v1.SectionName]("http"),
 					},
-					ControllerName: v1beta1.GatewayController(gatewayCtlrName),
+					ControllerName: v1.GatewayController(gatewayCtlrName),
 					Conditions:     CreateExpectedAPIConditions("Test", 1, transitionTime),
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer(v1beta1.Namespace(gwNsName2.Namespace)),
-						Name:        v1beta1.ObjectName(gwNsName2.Name),
+					ParentRef: v1.ParentReference{
+						Namespace:   helpers.GetPointer(v1.Namespace(gwNsName2.Namespace)),
+						Name:        v1.ObjectName(gwNsName2.Name),
 						SectionName: nil,
 					},
-					ControllerName: v1beta1.GatewayController(gatewayCtlrName),
+					ControllerName: v1.GatewayController(gatewayCtlrName),
 					Conditions:     CreateExpectedAPIConditions("Test", 1, transitionTime),
 				},
 			},

--- a/internal/framework/status/setters_test.go
+++ b/internal/framework/status/setters_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
@@ -66,7 +66,7 @@ func TestNewNginxGatewayStatusSetter(t *testing.T) {
 func TestNewGatewayClassStatusSetter(t *testing.T) {
 	tests := []struct {
 		name         string
-		status       v1beta1.GatewayClassStatus
+		status       gatewayv1.GatewayClassStatus
 		newStatus    GatewayClassStatus
 		expStatusSet bool
 	}{
@@ -82,7 +82,7 @@ func TestNewGatewayClassStatusSetter(t *testing.T) {
 			newStatus: GatewayClassStatus{
 				Conditions: []conditions.Condition{{Message: "new condition"}},
 			},
-			status: v1beta1.GatewayClassStatus{
+			status: gatewayv1.GatewayClassStatus{
 				Conditions: []v1.Condition{{Message: "old condition"}},
 			},
 			expStatusSet: true,
@@ -92,7 +92,7 @@ func TestNewGatewayClassStatusSetter(t *testing.T) {
 			newStatus: GatewayClassStatus{
 				Conditions: []conditions.Condition{{Message: "same condition"}},
 			},
-			status: v1beta1.GatewayClassStatus{
+			status: gatewayv1.GatewayClassStatus{
 				Conditions: []v1.Condition{{Message: "same condition"}},
 			},
 			expStatusSet: false,
@@ -106,21 +106,21 @@ func TestNewGatewayClassStatusSetter(t *testing.T) {
 			g := NewWithT(t)
 
 			setter := newGatewayClassStatusSetter(clock, test.newStatus)
-			statusSet := setter(&v1beta1.GatewayClass{Status: test.status})
+			statusSet := setter(&gatewayv1.GatewayClass{Status: test.status})
 			g.Expect(statusSet).To(Equal(test.expStatusSet))
 		})
 	}
 }
 
 func TestNewGatewayStatusSetter(t *testing.T) {
-	expAddress := v1beta1.GatewayStatusAddress{
-		Type:  helpers.GetPointer(v1beta1.IPAddressType),
+	expAddress := gatewayv1.GatewayStatusAddress{
+		Type:  helpers.GetPointer(gatewayv1.IPAddressType),
 		Value: "10.0.0.0",
 	}
 
 	tests := []struct {
 		name         string
-		status       v1beta1.GatewayStatus
+		status       gatewayv1.GatewayStatus
 		newStatus    GatewayStatus
 		expStatusSet bool
 	}{
@@ -128,7 +128,7 @@ func TestNewGatewayStatusSetter(t *testing.T) {
 			name: "Gateway has no status",
 			newStatus: GatewayStatus{
 				Conditions: []conditions.Condition{{Message: "new condition"}},
-				Addresses:  []v1beta1.GatewayStatusAddress{expAddress},
+				Addresses:  []gatewayv1.GatewayStatusAddress{expAddress},
 			},
 			expStatusSet: true,
 		},
@@ -136,11 +136,11 @@ func TestNewGatewayStatusSetter(t *testing.T) {
 			name: "Gateway has old status",
 			newStatus: GatewayStatus{
 				Conditions: []conditions.Condition{{Message: "new condition"}},
-				Addresses:  []v1beta1.GatewayStatusAddress{expAddress},
+				Addresses:  []gatewayv1.GatewayStatusAddress{expAddress},
 			},
-			status: v1beta1.GatewayStatus{
+			status: gatewayv1.GatewayStatus{
 				Conditions: []v1.Condition{{Message: "old condition"}},
-				Addresses:  []v1beta1.GatewayStatusAddress{expAddress},
+				Addresses:  []gatewayv1.GatewayStatusAddress{expAddress},
 			},
 			expStatusSet: true,
 		},
@@ -148,11 +148,11 @@ func TestNewGatewayStatusSetter(t *testing.T) {
 			name: "Gateway has same status",
 			newStatus: GatewayStatus{
 				Conditions: []conditions.Condition{{Message: "same condition"}},
-				Addresses:  []v1beta1.GatewayStatusAddress{expAddress},
+				Addresses:  []gatewayv1.GatewayStatusAddress{expAddress},
 			},
-			status: v1beta1.GatewayStatus{
+			status: gatewayv1.GatewayStatus{
 				Conditions: []v1.Condition{{Message: "same condition"}},
-				Addresses:  []v1beta1.GatewayStatusAddress{expAddress},
+				Addresses:  []gatewayv1.GatewayStatusAddress{expAddress},
 			},
 			expStatusSet: false,
 		},
@@ -166,7 +166,7 @@ func TestNewGatewayStatusSetter(t *testing.T) {
 
 			setter := newGatewayStatusSetter(clock, test.newStatus)
 
-			statusSet := setter(&v1beta1.Gateway{Status: test.status})
+			statusSet := setter(&gatewayv1.Gateway{Status: test.status})
 			g.Expect(statusSet).To(Equal(test.expStatusSet))
 		})
 	}
@@ -177,7 +177,7 @@ func TestNewHTTPRouteStatusSetter(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		status       v1beta1.HTTPRouteStatus
+		status       gatewayv1.HTTPRouteStatus
 		newStatus    HTTPRouteStatus
 		expStatusSet bool
 	}{
@@ -201,12 +201,12 @@ func TestNewHTTPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			status: v1beta1.HTTPRouteStatus{
-				RouteStatus: v1beta1.RouteStatus{
-					Parents: []v1beta1.RouteParentStatus{
+			status: gatewayv1.HTTPRouteStatus{
+				RouteStatus: gatewayv1.RouteStatus{
+					Parents: []gatewayv1.RouteParentStatus{
 						{
-							ParentRef:      v1beta1.ParentReference{},
-							ControllerName: v1beta1.GatewayController(controllerName),
+							ParentRef:      gatewayv1.ParentReference{},
+							ControllerName: gatewayv1.GatewayController(controllerName),
 							Conditions:     []v1.Condition{{Message: "old condition"}},
 						},
 					},
@@ -223,12 +223,12 @@ func TestNewHTTPRouteStatusSetter(t *testing.T) {
 					},
 				},
 			},
-			status: v1beta1.HTTPRouteStatus{
-				RouteStatus: v1beta1.RouteStatus{
-					Parents: []v1beta1.RouteParentStatus{
+			status: gatewayv1.HTTPRouteStatus{
+				RouteStatus: gatewayv1.RouteStatus{
+					Parents: []gatewayv1.RouteParentStatus{
 						{
-							ParentRef:      v1beta1.ParentReference{},
-							ControllerName: v1beta1.GatewayController(controllerName),
+							ParentRef:      gatewayv1.ParentReference{},
+							ControllerName: gatewayv1.GatewayController(controllerName),
 							Conditions:     []v1.Condition{{Message: "same condition"}},
 						},
 					},
@@ -246,22 +246,22 @@ func TestNewHTTPRouteStatusSetter(t *testing.T) {
 
 			setter := newHTTPRouteStatusSetter(controllerName, clock, test.newStatus)
 
-			statusSet := setter(&v1beta1.HTTPRoute{Status: test.status})
+			statusSet := setter(&gatewayv1.HTTPRoute{Status: test.status})
 			g.Expect(statusSet).To(Equal(test.expStatusSet))
 		})
 	}
 }
 
 func TestGWStatusEqual(t *testing.T) {
-	getDefaultStatus := func() v1beta1.GatewayStatus {
-		return v1beta1.GatewayStatus{
-			Addresses: []v1beta1.GatewayStatusAddress{
+	getDefaultStatus := func() gatewayv1.GatewayStatus {
+		return gatewayv1.GatewayStatus{
+			Addresses: []gatewayv1.GatewayStatusAddress{
 				{
-					Type:  helpers.GetPointer(v1beta1.IPAddressType),
+					Type:  helpers.GetPointer(gatewayv1.IPAddressType),
 					Value: "10.0.0.0",
 				},
 				{
-					Type:  helpers.GetPointer(v1beta1.IPAddressType),
+					Type:  helpers.GetPointer(gatewayv1.IPAddressType),
 					Value: "11.0.0.0",
 				},
 			},
@@ -270,16 +270,16 @@ func TestGWStatusEqual(t *testing.T) {
 					Type: "type", /* conditions are covered by another test*/
 				},
 			},
-			Listeners: []v1beta1.ListenerStatus{
+			Listeners: []gatewayv1.ListenerStatus{
 				{
 					Name: "listener1",
-					SupportedKinds: []v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayv1.RouteGroupKind{
 						{
-							Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
+							Group: helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
+							Group: helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName),
 							Kind:  "TCPRoute",
 						},
 					},
@@ -292,9 +292,9 @@ func TestGWStatusEqual(t *testing.T) {
 				},
 				{
 					Name: "listener2",
-					SupportedKinds: []v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayv1.RouteGroupKind{
 						{
-							Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
+							Group: helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName),
 							Kind:  "HTTPRoute",
 						},
 					},
@@ -307,9 +307,9 @@ func TestGWStatusEqual(t *testing.T) {
 				},
 				{
 					Name: "listener3",
-					SupportedKinds: []v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayv1.RouteGroupKind{
 						{
-							Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
+							Group: helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName),
 							Kind:  "HTTPRoute",
 						},
 					},
@@ -324,20 +324,20 @@ func TestGWStatusEqual(t *testing.T) {
 		}
 	}
 
-	getModifiedStatus := func(mod func(v1beta1.GatewayStatus) v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+	getModifiedStatus := func(mod func(gatewayv1.GatewayStatus) gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 		return mod(getDefaultStatus())
 	}
 
 	tests := []struct {
 		name       string
-		prevStatus v1beta1.GatewayStatus
-		curStatus  v1beta1.GatewayStatus
+		prevStatus gatewayv1.GatewayStatus
+		curStatus  gatewayv1.GatewayStatus
 		expEqual   bool
 	}{
 		{
 			name:       "different number of addresses",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Addresses = status.Addresses[:1]
 				return status
 			}),
@@ -346,8 +346,8 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different address type",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
-				status.Addresses[1].Type = helpers.GetPointer(v1beta1.HostnameAddressType)
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
+				status.Addresses[1].Type = helpers.GetPointer(gatewayv1.HostnameAddressType)
 				return status
 			}),
 			expEqual: false,
@@ -355,7 +355,7 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different address value",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Addresses[0].Value = "12.0.0.0"
 				return status
 			}),
@@ -364,7 +364,7 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different conditions",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Conditions[0].Type = "different"
 				return status
 			}),
@@ -373,7 +373,7 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different number of listener statuses",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Listeners = status.Listeners[:2]
 				return status
 			}),
@@ -382,7 +382,7 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different listener status name",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Listeners[2].Name = "different"
 				return status
 			}),
@@ -391,7 +391,7 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different listener status attached routes",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Listeners[1].AttachedRoutes++
 				return status
 			}),
@@ -400,7 +400,7 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different listener status conditions",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Listeners[0].Conditions[0].Type = "different"
 				return status
 			}),
@@ -409,7 +409,7 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different listener status supported kinds (different number)",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Listeners[0].SupportedKinds = status.Listeners[0].SupportedKinds[:1]
 				return status
 			}),
@@ -418,7 +418,7 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different listener status supported kinds (different kind)",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
 				status.Listeners[1].SupportedKinds[0].Kind = "TCPRoute"
 				return status
 			}),
@@ -427,8 +427,8 @@ func TestGWStatusEqual(t *testing.T) {
 		{
 			name:       "different listener status supported kinds (different group)",
 			prevStatus: getDefaultStatus(),
-			curStatus: getModifiedStatus(func(status v1beta1.GatewayStatus) v1beta1.GatewayStatus {
-				status.Listeners[1].SupportedKinds[0].Group = helpers.GetPointer[v1beta1.Group]("different")
+			curStatus: getModifiedStatus(func(status gatewayv1.GatewayStatus) gatewayv1.GatewayStatus {
+				status.Listeners[1].SupportedKinds[0].Group = helpers.GetPointer[gatewayv1.Group]("different")
 				return status
 			}),
 			expEqual: false,
@@ -458,41 +458,41 @@ func TestHRStatusEqual(t *testing.T) {
 		},
 	}
 
-	previousStatus := v1beta1.HTTPRouteStatus{
-		RouteStatus: v1beta1.RouteStatus{
-			Parents: []v1beta1.RouteParentStatus{
+	previousStatus := gatewayv1.HTTPRouteStatus{
+		RouteStatus: gatewayv1.RouteStatus{
+			Parents: []gatewayv1.RouteParentStatus{
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
+					ParentRef: gatewayv1.ParentReference{
+						Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
 						Name:        "our-parent",
-						SectionName: helpers.GetPointer[v1beta1.SectionName]("section1"),
+						SectionName: helpers.GetPointer[gatewayv1.SectionName]("section1"),
 					},
 					ControllerName: "ours",
 					Conditions:     testConds,
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
+					ParentRef: gatewayv1.ParentReference{
+						Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
 						Name:        "not-our-parent",
-						SectionName: helpers.GetPointer[v1beta1.SectionName]("section1"),
+						SectionName: helpers.GetPointer[gatewayv1.SectionName]("section1"),
 					},
 					ControllerName: "not-ours",
 					Conditions:     testConds,
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
+					ParentRef: gatewayv1.ParentReference{
+						Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
 						Name:        "our-parent",
-						SectionName: helpers.GetPointer[v1beta1.SectionName]("section2"),
+						SectionName: helpers.GetPointer[gatewayv1.SectionName]("section2"),
 					},
 					ControllerName: "ours",
 					Conditions:     testConds,
 				},
 				{
-					ParentRef: v1beta1.ParentReference{
-						Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
+					ParentRef: gatewayv1.ParentReference{
+						Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
 						Name:        "not-our-parent",
-						SectionName: helpers.GetPointer[v1beta1.SectionName]("section2"),
+						SectionName: helpers.GetPointer[gatewayv1.SectionName]("section2"),
 					},
 					ControllerName: "not-ours",
 					Conditions:     testConds,
@@ -501,24 +501,24 @@ func TestHRStatusEqual(t *testing.T) {
 		},
 	}
 
-	getDefaultStatus := func() v1beta1.HTTPRouteStatus {
-		return v1beta1.HTTPRouteStatus{
-			RouteStatus: v1beta1.RouteStatus{
-				Parents: []v1beta1.RouteParentStatus{
+	getDefaultStatus := func() gatewayv1.HTTPRouteStatus {
+		return gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{
 					{
-						ParentRef: v1beta1.ParentReference{
-							Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
+						ParentRef: gatewayv1.ParentReference{
+							Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
 							Name:        "our-parent",
-							SectionName: helpers.GetPointer[v1beta1.SectionName]("section1"),
+							SectionName: helpers.GetPointer[gatewayv1.SectionName]("section1"),
 						},
 						ControllerName: "ours",
 						Conditions:     testConds,
 					},
 					{
-						ParentRef: v1beta1.ParentReference{
-							Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
+						ParentRef: gatewayv1.ParentReference{
+							Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
 							Name:        "our-parent",
-							SectionName: helpers.GetPointer[v1beta1.SectionName]("section2"),
+							SectionName: helpers.GetPointer[gatewayv1.SectionName]("section2"),
 						},
 						ControllerName: "ours",
 						Conditions:     testConds,
@@ -528,30 +528,32 @@ func TestHRStatusEqual(t *testing.T) {
 		}
 	}
 
-	newParentStatus := v1beta1.RouteParentStatus{
-		ParentRef: v1beta1.ParentReference{
-			Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
+	newParentStatus := gatewayv1.RouteParentStatus{
+		ParentRef: gatewayv1.ParentReference{
+			Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
 			Name:        "our-parent",
-			SectionName: helpers.GetPointer[v1beta1.SectionName]("section3"),
+			SectionName: helpers.GetPointer[gatewayv1.SectionName]("section3"),
 		},
 		ControllerName: "ours",
 		Conditions:     testConds,
 	}
 
-	getModifiedStatus := func(mod func(status v1beta1.HTTPRouteStatus) v1beta1.HTTPRouteStatus) v1beta1.HTTPRouteStatus {
+	getModifiedStatus := func(
+		mod func(status gatewayv1.HTTPRouteStatus) gatewayv1.HTTPRouteStatus,
+	) gatewayv1.HTTPRouteStatus {
 		return mod(getDefaultStatus())
 	}
 
 	tests := []struct {
 		name       string
-		prevStatus v1beta1.HTTPRouteStatus
-		curStatus  v1beta1.HTTPRouteStatus
+		prevStatus gatewayv1.HTTPRouteStatus
+		curStatus  gatewayv1.HTTPRouteStatus
 		expEqual   bool
 	}{
 		{
 			name:       "stale status",
 			prevStatus: previousStatus,
-			curStatus: getModifiedStatus(func(status v1beta1.HTTPRouteStatus) v1beta1.HTTPRouteStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.HTTPRouteStatus) gatewayv1.HTTPRouteStatus {
 				// remove last parent status
 				status.Parents = status.Parents[:1]
 				return status
@@ -561,7 +563,7 @@ func TestHRStatusEqual(t *testing.T) {
 		{
 			name:       "new status",
 			prevStatus: previousStatus,
-			curStatus: getModifiedStatus(func(status v1beta1.HTTPRouteStatus) v1beta1.HTTPRouteStatus {
+			curStatus: getModifiedStatus(func(status gatewayv1.HTTPRouteStatus) gatewayv1.HTTPRouteStatus {
 				// add another parent status
 				status.Parents = append(status.Parents, newParentStatus)
 				return status
@@ -586,12 +588,12 @@ func TestHRStatusEqual(t *testing.T) {
 }
 
 func TestRouteParentStatusEqual(t *testing.T) {
-	getDefaultStatus := func() v1beta1.RouteParentStatus {
-		return v1beta1.RouteParentStatus{
-			ParentRef: v1beta1.ParentReference{
-				Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
+	getDefaultStatus := func() gatewayv1.RouteParentStatus {
+		return gatewayv1.RouteParentStatus{
+			ParentRef: gatewayv1.ParentReference{
+				Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
 				Name:        "parent",
-				SectionName: helpers.GetPointer[v1beta1.SectionName]("section"),
+				SectionName: helpers.GetPointer[gatewayv1.SectionName]("section"),
 			},
 			ControllerName: "controller",
 			Conditions: []v1.Condition{
@@ -602,20 +604,22 @@ func TestRouteParentStatusEqual(t *testing.T) {
 		}
 	}
 
-	getModifiedStatus := func(mod func(v1beta1.RouteParentStatus) v1beta1.RouteParentStatus) v1beta1.RouteParentStatus {
+	getModifiedStatus := func(
+		mod func(gatewayv1.RouteParentStatus) gatewayv1.RouteParentStatus,
+	) gatewayv1.RouteParentStatus {
 		return mod(getDefaultStatus())
 	}
 
 	tests := []struct {
 		name     string
-		p1       v1beta1.RouteParentStatus
-		p2       v1beta1.RouteParentStatus
+		p1       gatewayv1.RouteParentStatus
+		p2       gatewayv1.RouteParentStatus
 		expEqual bool
 	}{
 		{
 			name: "different controller name",
 			p1:   getDefaultStatus(),
-			p2: getModifiedStatus(func(status v1beta1.RouteParentStatus) v1beta1.RouteParentStatus {
+			p2: getModifiedStatus(func(status gatewayv1.RouteParentStatus) gatewayv1.RouteParentStatus {
 				status.ControllerName = "different"
 				return status
 			}),
@@ -624,7 +628,7 @@ func TestRouteParentStatusEqual(t *testing.T) {
 		{
 			name: "different parentRef name",
 			p1:   getDefaultStatus(),
-			p2: getModifiedStatus(func(status v1beta1.RouteParentStatus) v1beta1.RouteParentStatus {
+			p2: getModifiedStatus(func(status gatewayv1.RouteParentStatus) gatewayv1.RouteParentStatus {
 				status.ParentRef.Name = "different"
 				return status
 			}),
@@ -633,8 +637,8 @@ func TestRouteParentStatusEqual(t *testing.T) {
 		{
 			name: "different parentRef namespace",
 			p1:   getDefaultStatus(),
-			p2: getModifiedStatus(func(status v1beta1.RouteParentStatus) v1beta1.RouteParentStatus {
-				status.ParentRef.Namespace = helpers.GetPointer[v1beta1.Namespace]("different")
+			p2: getModifiedStatus(func(status gatewayv1.RouteParentStatus) gatewayv1.RouteParentStatus {
+				status.ParentRef.Namespace = helpers.GetPointer[gatewayv1.Namespace]("different")
 				return status
 			}),
 			expEqual: false,
@@ -642,8 +646,8 @@ func TestRouteParentStatusEqual(t *testing.T) {
 		{
 			name: "different parentRef section name",
 			p1:   getDefaultStatus(),
-			p2: getModifiedStatus(func(status v1beta1.RouteParentStatus) v1beta1.RouteParentStatus {
-				status.ParentRef.SectionName = helpers.GetPointer[v1beta1.SectionName]("different")
+			p2: getModifiedStatus(func(status gatewayv1.RouteParentStatus) gatewayv1.RouteParentStatus {
+				status.ParentRef.SectionName = helpers.GetPointer[gatewayv1.SectionName]("different")
 				return status
 			}),
 			expEqual: false,
@@ -651,7 +655,7 @@ func TestRouteParentStatusEqual(t *testing.T) {
 		{
 			name: "different conditions",
 			p1:   getDefaultStatus(),
-			p2: getModifiedStatus(func(status v1beta1.RouteParentStatus) v1beta1.RouteParentStatus {
+			p2: getModifiedStatus(func(status gatewayv1.RouteParentStatus) gatewayv1.RouteParentStatus {
 				status.Conditions[0].Type = "different"
 				return status
 			}),

--- a/internal/framework/status/statuses.go
+++ b/internal/framework/status/statuses.go
@@ -2,7 +2,7 @@ package status
 
 import (
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
@@ -22,7 +22,7 @@ type GatewayAPIStatuses struct {
 }
 
 func (g GatewayAPIStatuses) APIGroup() string {
-	return v1beta1.GroupName
+	return v1.GroupName
 }
 
 // NginxGatewayStatus holds status-related information about the NginxGateway resource.
@@ -58,7 +58,7 @@ type GatewayStatus struct {
 	// Conditions is the list of conditions for this Gateway.
 	Conditions []conditions.Condition
 	// Addresses holds the list of GatewayStatusAddresses.
-	Addresses []v1beta1.GatewayStatusAddress
+	Addresses []v1.GatewayStatusAddress
 	// ObservedGeneration is the generation of the resource that was processed.
 	ObservedGeneration int64
 	// Ignored tells whether or not this Gateway is ignored.
@@ -70,7 +70,7 @@ type ListenerStatus struct {
 	// Conditions is the list of conditions for this listener.
 	Conditions []conditions.Condition
 	// SupportedKinds is the list of SupportedKinds for this listener.
-	SupportedKinds []v1beta1.RouteGroupKind
+	SupportedKinds []v1.RouteGroupKind
 	// AttachedRoutes is the number of routes attached to the listener.
 	AttachedRoutes int32
 }
@@ -88,7 +88,7 @@ type ParentStatus struct {
 	// GatewayNsName is the Namespaced name of the Gateway, which the parentRef references.
 	GatewayNsName types.NamespacedName
 	// SectionName is the SectionName of the parentRef.
-	SectionName *v1beta1.SectionName
+	SectionName *v1.SectionName
 	// Conditions is the list of conditions that are relevant to the parentRef.
 	Conditions []conditions.Condition
 }

--- a/internal/framework/status/statusfakes/fake_updater.go
+++ b/internal/framework/status/statusfakes/fake_updater.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/status"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type FakeUpdater struct {
@@ -25,11 +25,11 @@ type FakeUpdater struct {
 		arg1 context.Context
 		arg2 status.Status
 	}
-	UpdateAddressesStub        func(context.Context, []v1beta1.GatewayStatusAddress)
+	UpdateAddressesStub        func(context.Context, []v1.GatewayStatusAddress)
 	updateAddressesMutex       sync.RWMutex
 	updateAddressesArgsForCall []struct {
 		arg1 context.Context
-		arg2 []v1beta1.GatewayStatusAddress
+		arg2 []v1.GatewayStatusAddress
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -124,16 +124,16 @@ func (fake *FakeUpdater) UpdateArgsForCall(i int) (context.Context, status.Statu
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeUpdater) UpdateAddresses(arg1 context.Context, arg2 []v1beta1.GatewayStatusAddress) {
-	var arg2Copy []v1beta1.GatewayStatusAddress
+func (fake *FakeUpdater) UpdateAddresses(arg1 context.Context, arg2 []v1.GatewayStatusAddress) {
+	var arg2Copy []v1.GatewayStatusAddress
 	if arg2 != nil {
-		arg2Copy = make([]v1beta1.GatewayStatusAddress, len(arg2))
+		arg2Copy = make([]v1.GatewayStatusAddress, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.updateAddressesMutex.Lock()
 	fake.updateAddressesArgsForCall = append(fake.updateAddressesArgsForCall, struct {
 		arg1 context.Context
-		arg2 []v1beta1.GatewayStatusAddress
+		arg2 []v1.GatewayStatusAddress
 	}{arg1, arg2Copy})
 	stub := fake.UpdateAddressesStub
 	fake.recordInvocation("UpdateAddresses", []interface{}{arg1, arg2Copy})
@@ -149,13 +149,13 @@ func (fake *FakeUpdater) UpdateAddressesCallCount() int {
 	return len(fake.updateAddressesArgsForCall)
 }
 
-func (fake *FakeUpdater) UpdateAddressesCalls(stub func(context.Context, []v1beta1.GatewayStatusAddress)) {
+func (fake *FakeUpdater) UpdateAddressesCalls(stub func(context.Context, []v1.GatewayStatusAddress)) {
 	fake.updateAddressesMutex.Lock()
 	defer fake.updateAddressesMutex.Unlock()
 	fake.UpdateAddressesStub = stub
 }
 
-func (fake *FakeUpdater) UpdateAddressesArgsForCall(i int) (context.Context, []v1beta1.GatewayStatusAddress) {
+func (fake *FakeUpdater) UpdateAddressesArgsForCall(i int) (context.Context, []v1.GatewayStatusAddress) {
 	fake.updateAddressesMutex.RLock()
 	defer fake.updateAddressesMutex.RUnlock()
 	argsForCall := fake.updateAddressesArgsForCall[i]

--- a/internal/framework/status/updater.go
+++ b/internal/framework/status/updater.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller"
@@ -28,7 +28,7 @@ type Updater interface {
 	// Update updates the statuses of the resources.
 	Update(context.Context, Status)
 	// UpdateAddresses updates the Gateway Addresses when the Gateway Service changes.
-	UpdateAddresses(context.Context, []v1beta1.GatewayStatusAddress)
+	UpdateAddresses(context.Context, []v1.GatewayStatusAddress)
 	// Enable enables status updates. The updater will update the statuses in Kubernetes API to ensure they match the
 	// statuses of the last Update invocation.
 	Enable(ctx context.Context)
@@ -176,7 +176,7 @@ func (upd *UpdaterImpl) updateGatewayAPI(ctx context.Context, statuses GatewayAP
 			default:
 			}
 
-			upd.writeStatuses(ctx, nsname, &v1beta1.GatewayClass{}, newGatewayClassStatusSetter(upd.cfg.Clock, gcs))
+			upd.writeStatuses(ctx, nsname, &v1.GatewayClass{}, newGatewayClassStatusSetter(upd.cfg.Clock, gcs))
 		}
 	}
 
@@ -187,7 +187,7 @@ func (upd *UpdaterImpl) updateGatewayAPI(ctx context.Context, statuses GatewayAP
 		default:
 		}
 
-		upd.writeStatuses(ctx, nsname, &v1beta1.Gateway{}, newGatewayStatusSetter(upd.cfg.Clock, gs))
+		upd.writeStatuses(ctx, nsname, &v1.Gateway{}, newGatewayStatusSetter(upd.cfg.Clock, gs))
 	}
 
 	for nsname, rs := range statuses.HTTPRouteStatuses {
@@ -200,7 +200,7 @@ func (upd *UpdaterImpl) updateGatewayAPI(ctx context.Context, statuses GatewayAP
 		upd.writeStatuses(
 			ctx,
 			nsname,
-			&v1beta1.HTTPRoute{},
+			&v1.HTTPRoute{},
 			newHTTPRouteStatusSetter(upd.cfg.GatewayCtlrName, upd.cfg.Clock, rs),
 		)
 	}
@@ -235,7 +235,7 @@ func (upd *UpdaterImpl) writeStatuses(
 }
 
 // UpdateAddresses is called when the Gateway Status needs its addresses updated.
-func (upd *UpdaterImpl) UpdateAddresses(ctx context.Context, addresses []v1beta1.GatewayStatusAddress) {
+func (upd *UpdaterImpl) UpdateAddresses(ctx context.Context, addresses []v1.GatewayStatusAddress) {
 	defer upd.lock.Unlock()
 	upd.lock.Lock()
 

--- a/internal/framework/status/updater_retry_test.go
+++ b/internal/framework/status/updater_retry_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller/controllerfakes"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/status"
@@ -83,7 +83,7 @@ func TestNewRetryUpdateFunc(t *testing.T) {
 				fakeGetter,
 				fakeStatusUpdater,
 				types.NamespacedName{},
-				&v1beta1.GatewayClass{},
+				&v1.GatewayClass{},
 				zap.New(),
 				func(client.Object) bool { return test.statusSetterReturns },
 			)

--- a/internal/framework/status/updater_test.go
+++ b/internal/framework/status/updater_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
@@ -41,15 +41,15 @@ var _ = Describe("Updater", func() {
 	BeforeEach(OncePerOrdered, func() {
 		scheme := runtime.NewScheme()
 
-		Expect(v1beta1.AddToScheme(scheme)).Should(Succeed())
+		Expect(v1.AddToScheme(scheme)).Should(Succeed())
 		Expect(ngfAPI.AddToScheme(scheme)).Should(Succeed())
 
 		client = fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(
-				&v1beta1.GatewayClass{},
-				&v1beta1.Gateway{},
-				&v1beta1.HTTPRoute{},
+				&v1.GatewayClass{},
+				&v1.Gateway{},
+				&v1.HTTPRoute{},
 				&ngfAPI.NginxGateway{},
 			).
 			Build()
@@ -69,12 +69,12 @@ var _ = Describe("Updater", func() {
 
 		var (
 			updater       *status.UpdaterImpl
-			gc            *v1beta1.GatewayClass
-			gw, ignoredGw *v1beta1.Gateway
-			hr            *v1beta1.HTTPRoute
+			gc            *v1.GatewayClass
+			gw, ignoredGw *v1.Gateway
+			hr            *v1.HTTPRoute
 			ng            *ngfAPI.NginxGateway
-			addr          = v1beta1.GatewayStatusAddress{
-				Type:  helpers.GetPointer(v1beta1.IPAddressType),
+			addr          = v1.GatewayStatusAddress{
+				Type:  helpers.GetPointer(v1.IPAddressType),
 				Value: "1.2.3.4",
 			}
 
@@ -93,10 +93,10 @@ var _ = Describe("Updater", func() {
 								"http": {
 									AttachedRoutes: 1,
 									Conditions:     status.CreateTestConditions("Test"),
-									SupportedKinds: []v1beta1.RouteGroupKind{{Kind: "HTTPRoute"}},
+									SupportedKinds: []v1.RouteGroupKind{{Kind: "HTTPRoute"}},
 								},
 							},
-							Addresses:          []v1beta1.GatewayStatusAddress{addr},
+							Addresses:          []v1.GatewayStatusAddress{addr},
 							ObservedGeneration: gens.gateways,
 						},
 						{Namespace: "test", Name: "ignored-gateway"}: {
@@ -111,7 +111,7 @@ var _ = Describe("Updater", func() {
 							ParentStatuses: []status.ParentStatus{
 								{
 									GatewayNsName: types.NamespacedName{Namespace: "test", Name: "gateway"},
-									SectionName:   helpers.GetPointer[v1beta1.SectionName]("http"),
+									SectionName:   helpers.GetPointer[v1.SectionName]("http"),
 									Conditions:    status.CreateTestConditions("Test"),
 								},
 							},
@@ -131,60 +131,60 @@ var _ = Describe("Updater", func() {
 				}
 			}
 
-			createExpectedGCWithGeneration = func(generation int64) *v1beta1.GatewayClass {
-				return &v1beta1.GatewayClass{
+			createExpectedGCWithGeneration = func(generation int64) *v1.GatewayClass {
+				return &v1.GatewayClass{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: gcName,
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "GatewayClass",
-						APIVersion: "gateway.networking.k8s.io/v1beta1",
+						APIVersion: "gateway.networking.k8s.io/v1",
 					},
-					Status: v1beta1.GatewayClassStatus{
+					Status: v1.GatewayClassStatus{
 						Conditions: status.CreateExpectedAPIConditions("Test", generation, fakeClockTime),
 					},
 				}
 			}
 
-			createExpectedGwWithGeneration = func(generation int64) *v1beta1.Gateway {
-				return &v1beta1.Gateway{
+			createExpectedGwWithGeneration = func(generation int64) *v1.Gateway {
+				return &v1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
 						Name:      "gateway",
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Gateway",
-						APIVersion: "gateway.networking.k8s.io/v1beta1",
+						APIVersion: "gateway.networking.k8s.io/v1",
 					},
-					Status: v1beta1.GatewayStatus{
+					Status: v1.GatewayStatus{
 						Conditions: status.CreateExpectedAPIConditions("Test", generation, fakeClockTime),
-						Listeners: []v1beta1.ListenerStatus{
+						Listeners: []v1.ListenerStatus{
 							{
 								Name:           "http",
 								AttachedRoutes: 1,
 								Conditions:     status.CreateExpectedAPIConditions("Test", generation, fakeClockTime),
-								SupportedKinds: []v1beta1.RouteGroupKind{{Kind: "HTTPRoute"}},
+								SupportedKinds: []v1.RouteGroupKind{{Kind: "HTTPRoute"}},
 							},
 						},
-						Addresses: []v1beta1.GatewayStatusAddress{addr},
+						Addresses: []v1.GatewayStatusAddress{addr},
 					},
 				}
 			}
 
-			createExpectedIgnoredGw = func() *v1beta1.Gateway {
-				return &v1beta1.Gateway{
+			createExpectedIgnoredGw = func() *v1.Gateway {
+				return &v1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
 						Name:      "ignored-gateway",
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Gateway",
-						APIVersion: "gateway.networking.k8s.io/v1beta1",
+						APIVersion: "gateway.networking.k8s.io/v1",
 					},
-					Status: v1beta1.GatewayStatus{
+					Status: v1.GatewayStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               string(v1beta1.GatewayConditionAccepted),
+								Type:               string(v1.GatewayConditionAccepted),
 								Status:             metav1.ConditionFalse,
 								ObservedGeneration: 1,
 								LastTransitionTime: fakeClockTime,
@@ -192,7 +192,7 @@ var _ = Describe("Updater", func() {
 								Message:            staticConds.GatewayMessageGatewayConflict,
 							},
 							{
-								Type:               string(v1beta1.GatewayConditionProgrammed),
+								Type:               string(v1.GatewayConditionProgrammed),
 								Status:             metav1.ConditionFalse,
 								ObservedGeneration: 1,
 								LastTransitionTime: fakeClockTime,
@@ -204,25 +204,25 @@ var _ = Describe("Updater", func() {
 				}
 			}
 
-			createExpectedHR = func() *v1beta1.HTTPRoute {
-				return &v1beta1.HTTPRoute{
+			createExpectedHR = func() *v1.HTTPRoute {
+				return &v1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
 						Name:      "route1",
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "HTTPRoute",
-						APIVersion: "gateway.networking.k8s.io/v1beta1",
+						APIVersion: "gateway.networking.k8s.io/v1",
 					},
-					Status: v1beta1.HTTPRouteStatus{
-						RouteStatus: v1beta1.RouteStatus{
-							Parents: []v1beta1.RouteParentStatus{
+					Status: v1.HTTPRouteStatus{
+						RouteStatus: v1.RouteStatus{
+							Parents: []v1.RouteParentStatus{
 								{
-									ControllerName: v1beta1.GatewayController(gatewayCtrlName),
-									ParentRef: v1beta1.ParentReference{
-										Namespace:   (*v1beta1.Namespace)(helpers.GetPointer("test")),
+									ControllerName: v1.GatewayController(gatewayCtrlName),
+									ParentRef: v1.ParentReference{
+										Namespace:   (*v1.Namespace)(helpers.GetPointer("test")),
 										Name:        "gateway",
-										SectionName: (*v1beta1.SectionName)(helpers.GetPointer("http")),
+										SectionName: (*v1.SectionName)(helpers.GetPointer("http")),
 									},
 									Conditions: status.CreateExpectedAPIConditions("Test", 5, fakeClockTime),
 								},
@@ -259,43 +259,43 @@ var _ = Describe("Updater", func() {
 				UpdateGatewayClassStatus: true,
 			})
 
-			gc = &v1beta1.GatewayClass{
+			gc = &v1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: gcName,
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "GatewayClass",
-					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 			}
-			gw = &v1beta1.Gateway{
+			gw = &v1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "gateway",
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Gateway",
-					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 			}
-			ignoredGw = &v1beta1.Gateway{
+			ignoredGw = &v1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "ignored-gateway",
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Gateway",
-					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 			}
-			hr = &v1beta1.HTTPRoute{
+			hr = &v1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "route1",
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "HTTPRoute",
-					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 			}
 			ng = &ngfAPI.NginxGateway{
@@ -326,7 +326,7 @@ var _ = Describe("Updater", func() {
 		})
 
 		It("should have the updated status of GatewayClass in the API server", func() {
-			latestGc := &v1beta1.GatewayClass{}
+			latestGc := &v1.GatewayClass{}
 			expectedGc := createExpectedGCWithGeneration(1)
 
 			err := client.Get(context.Background(), types.NamespacedName{Name: gcName}, latestGc)
@@ -338,7 +338,7 @@ var _ = Describe("Updater", func() {
 		})
 
 		It("should have the updated status of Gateway in the API server", func() {
-			latestGw := &v1beta1.Gateway{}
+			latestGw := &v1.Gateway{}
 			expectedGw := createExpectedGwWithGeneration(1)
 
 			err := client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "gateway"}, latestGw)
@@ -350,7 +350,7 @@ var _ = Describe("Updater", func() {
 		})
 
 		It("should have the updated status of ignored Gateway in the API server", func() {
-			latestGw := &v1beta1.Gateway{}
+			latestGw := &v1.Gateway{}
 			expectedGw := createExpectedIgnoredGw()
 
 			err := client.Get(
@@ -366,7 +366,7 @@ var _ = Describe("Updater", func() {
 		})
 
 		It("should have the updated status of HTTPRoute in the API server", func() {
-			latestHR := &v1beta1.HTTPRoute{}
+			latestHR := &v1.HTTPRoute{}
 			expectedHR := createExpectedHR()
 
 			err := client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "route1"}, latestHR)
@@ -400,22 +400,22 @@ var _ = Describe("Updater", func() {
 		When("the Gateway Service is updated with a new address", func() {
 			AfterEach(func() {
 				// reset the IP for the remaining tests
-				updater.UpdateAddresses(context.Background(), []v1beta1.GatewayStatusAddress{
+				updater.UpdateAddresses(context.Background(), []v1.GatewayStatusAddress{
 					{
-						Type:  helpers.GetPointer(v1beta1.IPAddressType),
+						Type:  helpers.GetPointer(v1.IPAddressType),
 						Value: "1.2.3.4",
 					},
 				})
 			})
 
 			It("should update the previous Gateway statuses with new address", func() {
-				latestGw := &v1beta1.Gateway{}
+				latestGw := &v1.Gateway{}
 				expectedGw := createExpectedGwWithGeneration(1)
 				expectedGw.Status.Addresses[0].Value = "5.6.7.8"
 
-				updater.UpdateAddresses(context.Background(), []v1beta1.GatewayStatusAddress{
+				updater.UpdateAddresses(context.Background(), []v1.GatewayStatusAddress{
 					{
-						Type:  helpers.GetPointer(v1beta1.IPAddressType),
+						Type:  helpers.GetPointer(v1.IPAddressType),
 						Value: "5.6.7.8",
 					},
 				})
@@ -444,7 +444,7 @@ var _ = Describe("Updater", func() {
 
 		When("updating with canceled context", func() {
 			It("should not have the updated status of GatewayClass in the API server", func() {
-				latestGc := &v1beta1.GatewayClass{}
+				latestGc := &v1.GatewayClass{}
 				expectedGc := createExpectedGCWithGeneration(1)
 
 				err := client.Get(context.Background(), types.NamespacedName{Name: gcName}, latestGc)
@@ -456,7 +456,7 @@ var _ = Describe("Updater", func() {
 			})
 
 			It("should not have the updated status of Gateway in the API server", func() {
-				latestGw := &v1beta1.Gateway{}
+				latestGw := &v1.Gateway{}
 				expectedGw := createExpectedGwWithGeneration(1)
 
 				err := client.Get(
@@ -472,7 +472,7 @@ var _ = Describe("Updater", func() {
 			})
 
 			It("should not have the updated status of ignored Gateway in the API server", func() {
-				latestGw := &v1beta1.Gateway{}
+				latestGw := &v1.Gateway{}
 				expectedGw := createExpectedIgnoredGw()
 
 				err := client.Get(
@@ -489,7 +489,7 @@ var _ = Describe("Updater", func() {
 			})
 
 			It("should not have the updated status of HTTPRoute in the API server", func() {
-				latestHR := &v1beta1.HTTPRoute{}
+				latestHR := &v1.HTTPRoute{}
 				expectedHR := createExpectedHR()
 
 				err := client.Get(
@@ -540,7 +540,7 @@ var _ = Describe("Updater", func() {
 			})
 
 			It("should not have the updated status of Gateway in the API server", func() {
-				latestGw := &v1beta1.Gateway{}
+				latestGw := &v1.Gateway{}
 				// testing that the generation has not changed from 1 to 3
 				expectedGw := createExpectedGwWithGeneration(1)
 
@@ -578,7 +578,7 @@ var _ = Describe("Updater", func() {
 			})
 
 			It("should have the updated status of Gateway in the API server", func() {
-				latestGw := &v1beta1.Gateway{}
+				latestGw := &v1.Gateway{}
 				expectedGw := createExpectedGwWithGeneration(3)
 
 				err := client.Get(
@@ -618,7 +618,7 @@ var _ = Describe("Updater", func() {
 			})
 
 			It("should have the updated status of Gateway in the API server", func() {
-				latestGw := &v1beta1.Gateway{}
+				latestGw := &v1.Gateway{}
 				expectedGw := createExpectedGwWithGeneration(4)
 
 				err := client.Get(
@@ -676,7 +676,7 @@ var _ = Describe("Updater", func() {
 
 				wg.Wait()
 
-				latestGw := &v1beta1.Gateway{}
+				latestGw := &v1.Gateway{}
 
 				err := client.Get(
 					context.Background(),
@@ -695,7 +695,7 @@ var _ = Describe("Updater", func() {
 	Describe("Skip GatewayClass updates", Ordered, func() {
 		var (
 			updater status.Updater
-			gc      *v1beta1.GatewayClass
+			gc      *v1.GatewayClass
 		)
 
 		BeforeAll(func() {
@@ -708,13 +708,13 @@ var _ = Describe("Updater", func() {
 				UpdateGatewayClassStatus: false,
 			})
 
-			gc = &v1beta1.GatewayClass{
+			gc = &v1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: gcName,
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "GatewayClass",
-					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					APIVersion: "gateway.networking.k8s.io/v1",
 				},
 			}
 		})
@@ -736,7 +736,7 @@ var _ = Describe("Updater", func() {
 				},
 			)
 
-			latestGc := &v1beta1.GatewayClass{}
+			latestGc := &v1.GatewayClass{}
 
 			err := client.Get(context.Background(), types.NamespacedName{Name: gcName}, latestGc)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/mode/provisioner/manager.go
+++ b/internal/mode/provisioner/manager.go
@@ -11,7 +11,7 @@ import (
 	ctlr "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	embeddedfiles "github.com/nginxinc/nginx-gateway-fabric"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller"
@@ -37,7 +37,7 @@ type Config struct {
 // many important features. See https://github.com/nginxinc/nginx-gateway-fabric/issues/634 for more details.
 func StartManager(cfg Config) error {
 	scheme := runtime.NewScheme()
-	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
+	utilruntime.Must(gatewayv1.AddToScheme(scheme))
 	utilruntime.Must(v1.AddToScheme(scheme))
 
 	options := manager.Options{
@@ -58,13 +58,13 @@ func StartManager(cfg Config) error {
 		options    []controller.Option
 	}{
 		{
-			objectType: &gatewayv1beta1.GatewayClass{},
+			objectType: &gatewayv1.GatewayClass{},
 			options: []controller.Option{
 				controller.WithK8sPredicate(predicate.GatewayClassPredicate{ControllerName: cfg.GatewayCtlrName}),
 			},
 		},
 		{
-			objectType: &gatewayv1beta1.Gateway{},
+			objectType: &gatewayv1.Gateway{},
 		},
 	}
 
@@ -86,10 +86,10 @@ func StartManager(cfg Config) error {
 	firstBatchPreparer := events.NewFirstEventBatchPreparerImpl(
 		mgr.GetCache(),
 		[]client.Object{
-			&gatewayv1beta1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: cfg.GatewayClassName}},
+			&gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: cfg.GatewayClassName}},
 		},
 		[]client.ObjectList{
-			&gatewayv1beta1.GatewayList{},
+			&gatewayv1.GatewayList{},
 		},
 	)
 

--- a/internal/mode/provisioner/store.go
+++ b/internal/mode/provisioner/store.go
@@ -5,21 +5,21 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/events"
 )
 
 // store stores the cluster state needed by the provisioner and allows to update it from the events.
 type store struct {
-	gatewayClasses map[types.NamespacedName]*v1beta1.GatewayClass
-	gateways       map[types.NamespacedName]*v1beta1.Gateway
+	gatewayClasses map[types.NamespacedName]*v1.GatewayClass
+	gateways       map[types.NamespacedName]*v1.Gateway
 }
 
 func newStore() *store {
 	return &store{
-		gatewayClasses: make(map[types.NamespacedName]*v1beta1.GatewayClass),
-		gateways:       make(map[types.NamespacedName]*v1beta1.Gateway),
+		gatewayClasses: make(map[types.NamespacedName]*v1.GatewayClass),
+		gateways:       make(map[types.NamespacedName]*v1.Gateway),
 	}
 }
 
@@ -28,18 +28,18 @@ func (s *store) update(batch events.EventBatch) {
 		switch e := event.(type) {
 		case *events.UpsertEvent:
 			switch obj := e.Resource.(type) {
-			case *v1beta1.GatewayClass:
+			case *v1.GatewayClass:
 				s.gatewayClasses[client.ObjectKeyFromObject(obj)] = obj
-			case *v1beta1.Gateway:
+			case *v1.Gateway:
 				s.gateways[client.ObjectKeyFromObject(obj)] = obj
 			default:
 				panic(fmt.Errorf("unknown resource type %T", e.Resource))
 			}
 		case *events.DeleteEvent:
 			switch e.Type.(type) {
-			case *v1beta1.GatewayClass:
+			case *v1.GatewayClass:
 				delete(s.gatewayClasses, e.NamespacedName)
-			case *v1beta1.Gateway:
+			case *v1.Gateway:
 				delete(s.gateways, e.NamespacedName)
 			default:
 				panic(fmt.Errorf("unknown resource type %T", e.Type))

--- a/internal/mode/static/build_statuses.go
+++ b/internal/mode/static/build_statuses.go
@@ -3,7 +3,7 @@ package static
 import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/status"
@@ -18,7 +18,7 @@ type nginxReloadResult struct {
 // buildGatewayAPIStatuses builds status.Statuses from a Graph.
 func buildGatewayAPIStatuses(
 	graph *graph.Graph,
-	gwAddresses []v1beta1.GatewayStatusAddress,
+	gwAddresses []v1.GatewayStatusAddress,
 	nginxReloadRes nginxReloadResult,
 ) status.GatewayAPIStatuses {
 	statuses := status.GatewayAPIStatuses{
@@ -76,7 +76,7 @@ func buildGatewayAPIStatuses(
 
 func buildGatewayClassStatuses(
 	gc *graph.GatewayClass,
-	ignoredGwClasses map[types.NamespacedName]*v1beta1.GatewayClass,
+	ignoredGwClasses map[types.NamespacedName]*v1.GatewayClass,
 ) status.GatewayClassStatuses {
 	statuses := make(status.GatewayClassStatuses)
 
@@ -108,8 +108,8 @@ func buildGatewayClassStatuses(
 
 func buildGatewayStatuses(
 	gateway *graph.Gateway,
-	ignoredGateways map[types.NamespacedName]*v1beta1.Gateway,
-	gwAddresses []v1beta1.GatewayStatusAddress,
+	ignoredGateways map[types.NamespacedName]*v1.Gateway,
+	gwAddresses []v1.GatewayStatusAddress,
 	nginxReloadRes nginxReloadResult,
 ) status.GatewayStatuses {
 	statuses := make(status.GatewayStatuses)
@@ -131,7 +131,7 @@ func buildGatewayStatuses(
 
 func buildGatewayStatus(
 	gateway *graph.Gateway,
-	gwAddresses []v1beta1.GatewayStatusAddress,
+	gwAddresses []v1.GatewayStatusAddress,
 	nginxReloadRes nginxReloadResult,
 ) status.GatewayStatus {
 	if !gateway.Valid {

--- a/internal/mode/static/build_statuses_test.go
+++ b/internal/mode/static/build_statuses_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	gw = &v1beta1.Gateway{
+	gw = &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "test",
 			Name:       "gateway",
@@ -26,7 +26,7 @@ var (
 		},
 	}
 
-	ignoredGw = &v1beta1.Gateway{
+	ignoredGw = &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "test",
 			Name:       "ignored-gateway",
@@ -36,9 +36,9 @@ var (
 )
 
 func TestBuildStatuses(t *testing.T) {
-	addr := []v1beta1.GatewayStatusAddress{
+	addr := []v1.GatewayStatusAddress{
 		{
-			Type:  helpers.GetPointer(v1beta1.IPAddressType),
+			Type:  helpers.GetPointer(v1.IPAddressType),
 			Value: "1.2.3.4",
 		},
 	}
@@ -55,18 +55,18 @@ func TestBuildStatuses(t *testing.T) {
 	routes := map[types.NamespacedName]*graph.Route{
 		{Namespace: "test", Name: "hr-valid"}: {
 			Valid: true,
-			Source: &v1beta1.HTTPRoute{
+			Source: &v1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: 3,
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
 							{
-								SectionName: helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+								SectionName: helpers.GetPointer[v1.SectionName]("listener-80-1"),
 							},
 							{
-								SectionName: helpers.GetPointer[v1beta1.SectionName]("listener-80-2"),
+								SectionName: helpers.GetPointer[v1.SectionName]("listener-80-2"),
 							},
 						},
 					},
@@ -93,15 +93,15 @@ func TestBuildStatuses(t *testing.T) {
 		{Namespace: "test", Name: "hr-invalid"}: {
 			Valid:      false,
 			Conditions: []conditions.Condition{invalidRouteCondition},
-			Source: &v1beta1.HTTPRoute{
+			Source: &v1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: 3,
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
 							{
-								SectionName: helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+								SectionName: helpers.GetPointer[v1.SectionName]("listener-80-1"),
 							},
 						},
 					},
@@ -119,7 +119,7 @@ func TestBuildStatuses(t *testing.T) {
 
 	graph := &graph.Graph{
 		GatewayClass: &graph.GatewayClass{
-			Source: &v1beta1.GatewayClass{
+			Source: &v1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 			},
 			Valid: true,
@@ -136,7 +136,7 @@ func TestBuildStatuses(t *testing.T) {
 			},
 			Valid: true,
 		},
-		IgnoredGateways: map[types.NamespacedName]*v1beta1.Gateway{
+		IgnoredGateways: map[types.NamespacedName]*v1.Gateway{
 			client.ObjectKeyFromObject(ignoredGw): ignoredGw,
 		},
 		Routes: routes,
@@ -173,12 +173,12 @@ func TestBuildStatuses(t *testing.T) {
 				ParentStatuses: []status.ParentStatus{
 					{
 						GatewayNsName: client.ObjectKeyFromObject(gw),
-						SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+						SectionName:   helpers.GetPointer[v1.SectionName]("listener-80-1"),
 						Conditions:    staticConds.NewDefaultRouteConditions(),
 					},
 					{
 						GatewayNsName: client.ObjectKeyFromObject(gw),
-						SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-2"),
+						SectionName:   helpers.GetPointer[v1.SectionName]("listener-80-2"),
 						Conditions: append(
 							staticConds.NewDefaultRouteConditions(),
 							invalidAttachmentCondition,
@@ -191,7 +191,7 @@ func TestBuildStatuses(t *testing.T) {
 				ParentStatuses: []status.ParentStatus{
 					{
 						GatewayNsName: client.ObjectKeyFromObject(gw),
-						SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+						SectionName:   helpers.GetPointer[v1.SectionName]("listener-80-1"),
 						Conditions: append(
 							staticConds.NewDefaultRouteConditions(),
 							invalidRouteCondition,
@@ -210,9 +210,9 @@ func TestBuildStatuses(t *testing.T) {
 }
 
 func TestBuildStatusesNginxErr(t *testing.T) {
-	addr := []v1beta1.GatewayStatusAddress{
+	addr := []v1.GatewayStatusAddress{
 		{
-			Type:  helpers.GetPointer(v1beta1.IPAddressType),
+			Type:  helpers.GetPointer(v1.IPAddressType),
 			Value: "1.2.3.4",
 		},
 	}
@@ -220,15 +220,15 @@ func TestBuildStatusesNginxErr(t *testing.T) {
 	routes := map[types.NamespacedName]*graph.Route{
 		{Namespace: "test", Name: "hr-valid"}: {
 			Valid: true,
-			Source: &v1beta1.HTTPRoute{
+			Source: &v1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: 3,
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
 							{
-								SectionName: helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+								SectionName: helpers.GetPointer[v1.SectionName]("listener-80-1"),
 							},
 						},
 					},
@@ -291,7 +291,7 @@ func TestBuildStatusesNginxErr(t *testing.T) {
 				ParentStatuses: []status.ParentStatus{
 					{
 						GatewayNsName: client.ObjectKeyFromObject(gw),
-						SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+						SectionName:   helpers.GetPointer[v1.SectionName]("listener-80-1"),
 						Conditions: []conditions.Condition{
 							staticConds.NewRouteResolvedRefs(),
 							staticConds.NewRouteGatewayNotProgrammed(staticConds.RouteMessageFailedNginxReload),
@@ -312,7 +312,7 @@ func TestBuildStatusesNginxErr(t *testing.T) {
 func TestBuildGatewayClassStatuses(t *testing.T) {
 	tests := []struct {
 		gc             *graph.GatewayClass
-		ignoredClasses map[types.NamespacedName]*v1beta1.GatewayClass
+		ignoredClasses map[types.NamespacedName]*v1.GatewayClass
 		expected       status.GatewayClassStatuses
 		name           string
 	}{
@@ -322,7 +322,7 @@ func TestBuildGatewayClassStatuses(t *testing.T) {
 		},
 		{
 			name: "nil gatewayclass and ignored gatewayclasses",
-			ignoredClasses: map[types.NamespacedName]*v1beta1.GatewayClass{
+			ignoredClasses: map[types.NamespacedName]*v1.GatewayClass{
 				{Name: "ignored-1"}: {
 					ObjectMeta: metav1.ObjectMeta{
 						Generation: 1,
@@ -348,7 +348,7 @@ func TestBuildGatewayClassStatuses(t *testing.T) {
 		{
 			name: "valid gatewayclass",
 			gc: &graph.GatewayClass{
-				Source: &v1beta1.GatewayClass{
+				Source: &v1.GatewayClass{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "valid-gc",
 						Generation: 1,
@@ -375,9 +375,9 @@ func TestBuildGatewayClassStatuses(t *testing.T) {
 }
 
 func TestBuildGatewayStatuses(t *testing.T) {
-	addr := []v1beta1.GatewayStatusAddress{
+	addr := []v1.GatewayStatusAddress{
 		{
-			Type:  helpers.GetPointer(v1beta1.IPAddressType),
+			Type:  helpers.GetPointer(v1.IPAddressType),
 			Value: "1.2.3.4",
 		},
 	}
@@ -385,7 +385,7 @@ func TestBuildGatewayStatuses(t *testing.T) {
 	tests := []struct {
 		nginxReloadRes  nginxReloadResult
 		gateway         *graph.Gateway
-		ignoredGateways map[types.NamespacedName]*v1beta1.Gateway
+		ignoredGateways map[types.NamespacedName]*v1.Gateway
 		expected        status.GatewayStatuses
 		name            string
 	}{
@@ -395,7 +395,7 @@ func TestBuildGatewayStatuses(t *testing.T) {
 		},
 		{
 			name: "nil gateway and ignored gateways",
-			ignoredGateways: map[types.NamespacedName]*v1beta1.Gateway{
+			ignoredGateways: map[types.NamespacedName]*v1.Gateway{
 				{Namespace: "test", Name: "ignored-1"}: {
 					ObjectMeta: metav1.ObjectMeta{
 						Generation: 1,

--- a/internal/mode/static/handler.go
+++ b/internal/mode/static/handler.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
@@ -235,10 +235,10 @@ func getGatewayAddresses(
 	k8sClient client.Client,
 	svc *v1.Service,
 	podConfig config.GatewayPodConfig,
-) ([]v1beta1.GatewayStatusAddress, error) {
-	podAddress := []v1beta1.GatewayStatusAddress{
+) ([]gatewayv1.GatewayStatusAddress, error) {
+	podAddress := []gatewayv1.GatewayStatusAddress{
 		{
-			Type:  helpers.GetPointer(v1beta1.IPAddressType),
+			Type:  helpers.GetPointer(gatewayv1.IPAddressType),
 			Value: podConfig.PodIP,
 		},
 	}
@@ -265,18 +265,18 @@ func getGatewayAddresses(
 		}
 	}
 
-	gwAddresses := make([]v1beta1.GatewayStatusAddress, 0, len(addresses)+len(hostnames))
+	gwAddresses := make([]gatewayv1.GatewayStatusAddress, 0, len(addresses)+len(hostnames))
 	for _, addr := range addresses {
-		statusAddr := v1beta1.GatewayStatusAddress{
-			Type:  helpers.GetPointer(v1beta1.IPAddressType),
+		statusAddr := gatewayv1.GatewayStatusAddress{
+			Type:  helpers.GetPointer(gatewayv1.IPAddressType),
 			Value: addr,
 		}
 		gwAddresses = append(gwAddresses, statusAddr)
 	}
 
 	for _, hostname := range hostnames {
-		statusAddr := v1beta1.GatewayStatusAddress{
-			Type:  helpers.GetPointer(v1beta1.HostnameAddressType),
+		statusAddr := gatewayv1.GatewayStatusAddress{
+			Type:  helpers.GetPointer(gatewayv1.HostnameAddressType),
 			Value: hostname,
 		}
 		gwAddresses = append(gwAddresses, statusAddr)

--- a/internal/mode/static/handler_test.go
+++ b/internal/mode/static/handler_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctlrZap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
@@ -121,7 +121,7 @@ var _ = Describe("eventHandler", func() {
 
 		When("a batch has one event", func() {
 			It("should process Upsert", func() {
-				e := &events.UpsertEvent{Resource: &v1beta1.HTTPRoute{}}
+				e := &events.UpsertEvent{Resource: &gatewayv1.HTTPRoute{}}
 				batch := []interface{}{e}
 
 				handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
@@ -132,7 +132,7 @@ var _ = Describe("eventHandler", func() {
 
 			It("should process Delete", func() {
 				e := &events.DeleteEvent{
-					Type:           &v1beta1.HTTPRoute{},
+					Type:           &gatewayv1.HTTPRoute{},
 					NamespacedName: types.NamespacedName{Namespace: "test", Name: "route"},
 				}
 				batch := []interface{}{e}
@@ -146,9 +146,9 @@ var _ = Describe("eventHandler", func() {
 
 		When("a batch has multiple events", func() {
 			It("should process events", func() {
-				upsertEvent := &events.UpsertEvent{Resource: &v1beta1.HTTPRoute{}}
+				upsertEvent := &events.UpsertEvent{Resource: &gatewayv1.HTTPRoute{}}
 				deleteEvent := &events.DeleteEvent{
-					Type:           &v1beta1.HTTPRoute{},
+					Type:           &gatewayv1.HTTPRoute{},
 					NamespacedName: types.NamespacedName{Namespace: "test", Name: "route"},
 				}
 				batch := []interface{}{upsertEvent, deleteEvent}
@@ -279,7 +279,7 @@ var _ = Describe("eventHandler", func() {
 	})
 
 	It("should set the health checker status properly when there are changes", func() {
-		e := &events.UpsertEvent{Resource: &v1beta1.HTTPRoute{}}
+		e := &events.UpsertEvent{Resource: &gatewayv1.HTTPRoute{}}
 		batch := []interface{}{e}
 
 		fakeProcessor.ProcessReturns(true, &graph.Graph{})
@@ -290,7 +290,7 @@ var _ = Describe("eventHandler", func() {
 	})
 
 	It("should set the health checker status properly when there are no changes or errors", func() {
-		e := &events.UpsertEvent{Resource: &v1beta1.HTTPRoute{}}
+		e := &events.UpsertEvent{Resource: &gatewayv1.HTTPRoute{}}
 		batch := []interface{}{e}
 
 		Expect(handler.cfg.healthChecker.readyCheck(nil)).ToNot(Succeed())
@@ -299,7 +299,7 @@ var _ = Describe("eventHandler", func() {
 	})
 
 	It("should set the health checker status properly when there is an error", func() {
-		e := &events.UpsertEvent{Resource: &v1beta1.HTTPRoute{}}
+		e := &events.UpsertEvent{Resource: &gatewayv1.HTTPRoute{}}
 		batch := []interface{}{e}
 
 		fakeProcessor.ProcessReturns(true, &graph.Graph{})

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	k8spredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
@@ -50,6 +51,7 @@ var scheme = runtime.NewScheme()
 
 func init() {
 	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
+	utilruntime.Must(gatewayv1.AddToScheme(scheme))
 	utilruntime.Must(apiv1.AddToScheme(scheme))
 	utilruntime.Must(discoveryV1.AddToScheme(scheme))
 	utilruntime.Must(ngfAPI.AddToScheme(scheme))
@@ -244,13 +246,13 @@ func registerControllers(
 	// make sure to also update prepareFirstEventBatchPreparerArgs()
 	controllerRegCfgs := []ctlrCfg{
 		{
-			objectType: &gatewayv1beta1.GatewayClass{},
+			objectType: &gatewayv1.GatewayClass{},
 			options: []controller.Option{
 				controller.WithK8sPredicate(predicate.GatewayClassPredicate{ControllerName: cfg.GatewayCtlrName}),
 			},
 		},
 		{
-			objectType: &gatewayv1beta1.Gateway{},
+			objectType: &gatewayv1.Gateway{},
 			options: func() []controller.Option {
 				if cfg.GatewayNsName != nil {
 					return []controller.Option{
@@ -261,7 +263,7 @@ func registerControllers(
 			}(),
 		},
 		{
-			objectType: &gatewayv1beta1.HTTPRoute{},
+			objectType: &gatewayv1.HTTPRoute{},
 		},
 		{
 			objectType: &apiv1.Service{},
@@ -340,23 +342,23 @@ func prepareFirstEventBatchPreparerArgs(
 	gwNsName *types.NamespacedName,
 ) ([]client.Object, []client.ObjectList) {
 	objects := []client.Object{
-		&gatewayv1beta1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: gcName}},
+		&gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: gcName}},
 	}
 	objectLists := []client.ObjectList{
 		&apiv1.ServiceList{},
 		&apiv1.SecretList{},
 		&apiv1.NamespaceList{},
 		&discoveryV1.EndpointSliceList{},
-		&gatewayv1beta1.HTTPRouteList{},
+		&gatewayv1.HTTPRouteList{},
 		&gatewayv1beta1.ReferenceGrantList{},
 	}
 
 	if gwNsName == nil {
-		objectLists = append(objectLists, &gatewayv1beta1.GatewayList{})
+		objectLists = append(objectLists, &gatewayv1.GatewayList{})
 	} else {
 		objects = append(
 			objects,
-			&gatewayv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwNsName.Name, Namespace: gwNsName.Namespace}},
+			&gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwNsName.Name, Namespace: gwNsName.Namespace}},
 		)
 	}
 

--- a/internal/mode/static/manager_test.go
+++ b/internal/mode/static/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/config"
@@ -28,15 +29,15 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 			name:     "gwNsName is nil",
 			gwNsName: nil,
 			expectedObjects: []client.Object{
-				&gatewayv1beta1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "nginx"}},
+				&gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "nginx"}},
 			},
 			expectedObjectLists: []client.ObjectList{
 				&apiv1.ServiceList{},
 				&apiv1.SecretList{},
 				&apiv1.NamespaceList{},
 				&discoveryV1.EndpointSliceList{},
-				&gatewayv1beta1.HTTPRouteList{},
-				&gatewayv1beta1.GatewayList{},
+				&gatewayv1.HTTPRouteList{},
+				&gatewayv1.GatewayList{},
 				&gatewayv1beta1.ReferenceGrantList{},
 			},
 		},
@@ -47,15 +48,15 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				Name:      "my-gateway",
 			},
 			expectedObjects: []client.Object{
-				&gatewayv1beta1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "nginx"}},
-				&gatewayv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "my-gateway", Namespace: "test"}},
+				&gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "nginx"}},
+				&gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "my-gateway", Namespace: "test"}},
 			},
 			expectedObjectLists: []client.ObjectList{
 				&apiv1.ServiceList{},
 				&apiv1.SecretList{},
 				&apiv1.NamespaceList{},
 				&discoveryV1.EndpointSliceList{},
-				&gatewayv1beta1.HTTPRouteList{},
+				&gatewayv1.HTTPRouteList{},
 				&gatewayv1beta1.ReferenceGrantList{},
 			},
 		},

--- a/internal/mode/static/nginx/config/servers.go
+++ b/internal/mode/static/nginx/config/servers.go
@@ -103,10 +103,10 @@ func createLocations(pathRules []dataplane.PathRule, listenerPort int32) []http.
 			}
 
 			// There could be a case when the filter has the type set but not the corresponding field.
-			// For example, type is v1beta1.HTTPRouteFilterRequestRedirect, but RequestRedirect field is nil.
+			// For example, type is v1.HTTPRouteFilterRequestRedirect, but RequestRedirect field is nil.
 			// The imported Webhook validation webhook catches that.
 
-			// FIXME(pleshakov): Ensure dataplane.Configuration -related types don't include v1beta1 types, so that
+			// FIXME(pleshakov): Ensure dataplane.Configuration -related types don't include v1 types, so that
 			// we don't need to make any assumptions like above here. After fixing this, ensure that there is a test
 			// for checking the imported Webhook validation catches the case above.
 			// https://github.com/nginxinc/nginx-gateway-fabric/issues/660

--- a/internal/mode/static/state/change_processor.go
+++ b/internal/mode/static/state/change_processor.go
@@ -13,9 +13,10 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	gwapivalidation "sigs.k8s.io/gateway-api/apis/v1beta1/validation"
+	gwapivalidation "sigs.k8s.io/gateway-api/apis/v1/validation"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/graph"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/relationship"
@@ -87,9 +88,9 @@ type ChangeProcessorImpl struct {
 // NewChangeProcessorImpl creates a new ChangeProcessorImpl for the Gateway resource with the configured namespace name.
 func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 	clusterStore := graph.ClusterState{
-		GatewayClasses:  make(map[types.NamespacedName]*v1beta1.GatewayClass),
-		Gateways:        make(map[types.NamespacedName]*v1beta1.Gateway),
-		HTTPRoutes:      make(map[types.NamespacedName]*v1beta1.HTTPRoute),
+		GatewayClasses:  make(map[types.NamespacedName]*v1.GatewayClass),
+		Gateways:        make(map[types.NamespacedName]*v1.Gateway),
+		HTTPRoutes:      make(map[types.NamespacedName]*v1.HTTPRoute),
 		Services:        make(map[types.NamespacedName]*apiv1.Service),
 		Namespaces:      make(map[types.NamespacedName]*apiv1.Namespace),
 		ReferenceGrants: make(map[types.NamespacedName]*v1beta1.ReferenceGrant),
@@ -119,17 +120,17 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 		extractGVK,
 		[]changeTrackingUpdaterObjectTypeCfg{
 			{
-				gvk:               extractGVK(&v1beta1.GatewayClass{}),
+				gvk:               extractGVK(&v1.GatewayClass{}),
 				store:             newObjectStoreMapAdapter(clusterStore.GatewayClasses),
 				trackUpsertDelete: true,
 			},
 			{
-				gvk:               extractGVK(&v1beta1.Gateway{}),
+				gvk:               extractGVK(&v1.Gateway{}),
 				store:             newObjectStoreMapAdapter(clusterStore.Gateways),
 				trackUpsertDelete: true,
 			},
 			{
-				gvk:               extractGVK(&v1beta1.HTTPRoute{}),
+				gvk:               extractGVK(&v1.HTTPRoute{}),
 				store:             newObjectStoreMapAdapter(clusterStore.HTTPRoutes),
 				trackUpsertDelete: true,
 			},
@@ -173,10 +174,10 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 			// the webhook doesn't validate them.
 			// It only validates a GatewayClass update that requires the previous version of the resource,
 			// which NGF cannot reliably provide - for example, after NGF restarts).
-			// https://github.com/kubernetes-sigs/gateway-api/blob/v0.8.1/apis/v1beta1/validation/gatewayclass.go#L28
-			case *v1beta1.Gateway:
+			// https://github.com/kubernetes-sigs/gateway-api/blob/v0.8.1/apis/v1/validation/gatewayclass.go#L28
+			case *v1.Gateway:
 				err = gwapivalidation.ValidateGateway(o).ToAggregate()
-			case *v1beta1.HTTPRoute:
+			case *v1.HTTPRoute:
 				err = gwapivalidation.ValidateHTTPRoute(o).ToAggregate()
 			}
 

--- a/internal/mode/static/state/change_processor.go
+++ b/internal/mode/static/state/change_processor.go
@@ -174,7 +174,7 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 			// the webhook doesn't validate them.
 			// It only validates a GatewayClass update that requires the previous version of the resource,
 			// which NGF cannot reliably provide - for example, after NGF restarts).
-			// https://github.com/kubernetes-sigs/gateway-api/blob/v0.8.1/apis/v1/validation/gatewayclass.go#L28
+			// https://github.com/kubernetes-sigs/gateway-api/blob/v1.0.0-rc2/apis/v1/validation/gatewayclass.go#L28
 			case *v1.Gateway:
 				err = gwapivalidation.ValidateGateway(o).ToAggregate()
 			case *v1.HTTPRoute:

--- a/internal/mode/static/state/change_processor_test.go
+++ b/internal/mode/static/state/change_processor_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -37,42 +38,42 @@ func createRoute(
 	name string,
 	gateway string,
 	hostname string,
-	backendRefs ...v1beta1.HTTPBackendRef,
-) *v1beta1.HTTPRoute {
-	return &v1beta1.HTTPRoute{
+	backendRefs ...v1.HTTPBackendRef,
+) *v1.HTTPRoute {
+	return &v1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "test",
 			Name:       name,
 			Generation: 1,
 		},
-		Spec: v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: v1beta1.CommonRouteSpec{
-				ParentRefs: []v1beta1.ParentReference{
+		Spec: v1.HTTPRouteSpec{
+			CommonRouteSpec: v1.CommonRouteSpec{
+				ParentRefs: []v1.ParentReference{
 					{
-						Namespace: (*v1beta1.Namespace)(helpers.GetPointer("test")),
-						Name:      v1beta1.ObjectName(gateway),
-						SectionName: (*v1beta1.SectionName)(
+						Namespace: (*v1.Namespace)(helpers.GetPointer("test")),
+						Name:      v1.ObjectName(gateway),
+						SectionName: (*v1.SectionName)(
 							helpers.GetPointer("listener-80-1"),
 						),
 					},
 					{
-						Namespace: (*v1beta1.Namespace)(helpers.GetPointer("test")),
-						Name:      v1beta1.ObjectName(gateway),
-						SectionName: (*v1beta1.SectionName)(
+						Namespace: (*v1.Namespace)(helpers.GetPointer("test")),
+						Name:      v1.ObjectName(gateway),
+						SectionName: (*v1.SectionName)(
 							helpers.GetPointer("listener-443-1"),
 						),
 					},
 				},
 			},
-			Hostnames: []v1beta1.Hostname{
-				v1beta1.Hostname(hostname),
+			Hostnames: []v1.Hostname{
+				v1.Hostname(hostname),
 			},
-			Rules: []v1beta1.HTTPRouteRule{
+			Rules: []v1.HTTPRouteRule{
 				{
-					Matches: []v1beta1.HTTPRouteMatch{
+					Matches: []v1.HTTPRouteMatch{
 						{
-							Path: &v1beta1.HTTPPathMatch{
-								Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+							Path: &v1.HTTPPathMatch{
+								Type:  helpers.GetPointer(v1.PathMatchPathPrefix),
 								Value: helpers.GetPointer("/"),
 							},
 						},
@@ -84,42 +85,42 @@ func createRoute(
 	}
 }
 
-func createGateway(name string) *v1beta1.Gateway {
-	return &v1beta1.Gateway{
+func createGateway(name string) *v1.Gateway {
+	return &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "test",
 			Name:       name,
 			Generation: 1,
 		},
-		Spec: v1beta1.GatewaySpec{
+		Spec: v1.GatewaySpec{
 			GatewayClassName: gcName,
-			Listeners: []v1beta1.Listener{
+			Listeners: []v1.Listener{
 				{
 					Name:     "listener-80-1",
 					Hostname: nil,
 					Port:     80,
-					Protocol: v1beta1.HTTPProtocolType,
+					Protocol: v1.HTTPProtocolType,
 				},
 			},
 		},
 	}
 }
 
-func createGatewayWithTLSListener(name string, tlsSecret *apiv1.Secret) *v1beta1.Gateway {
+func createGatewayWithTLSListener(name string, tlsSecret *apiv1.Secret) *v1.Gateway {
 	gw := createGateway(name)
 
-	l := v1beta1.Listener{
+	l := v1.Listener{
 		Name:     "listener-443-1",
 		Hostname: nil,
 		Port:     443,
-		Protocol: v1beta1.HTTPSProtocolType,
-		TLS: &v1beta1.GatewayTLSConfig{
-			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
-			CertificateRefs: []v1beta1.SecretObjectReference{
+		Protocol: v1.HTTPSProtocolType,
+		TLS: &v1.GatewayTLSConfig{
+			Mode: helpers.GetPointer(v1.TLSModeTerminate),
+			CertificateRefs: []v1.SecretObjectReference{
 				{
-					Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
-					Name:      v1beta1.ObjectName(tlsSecret.Name),
-					Namespace: (*v1beta1.Namespace)(&tlsSecret.Namespace),
+					Kind:      (*v1.Kind)(helpers.GetPointer("Secret")),
+					Name:      v1.ObjectName(tlsSecret.Name),
+					Namespace: (*v1.Namespace)(&tlsSecret.Namespace),
 				},
 			},
 		},
@@ -131,20 +132,20 @@ func createGatewayWithTLSListener(name string, tlsSecret *apiv1.Secret) *v1beta1
 
 func createRouteWithMultipleRules(
 	name, gateway, hostname string,
-	rules []v1beta1.HTTPRouteRule,
-) *v1beta1.HTTPRoute {
+	rules []v1.HTTPRouteRule,
+) *v1.HTTPRoute {
 	hr := createRoute(name, gateway, hostname)
 	hr.Spec.Rules = rules
 
 	return hr
 }
 
-func createHTTPRule(path string, backendRefs ...v1beta1.HTTPBackendRef) v1beta1.HTTPRouteRule {
-	return v1beta1.HTTPRouteRule{
-		Matches: []v1beta1.HTTPRouteMatch{
+func createHTTPRule(path string, backendRefs ...v1.HTTPBackendRef) v1.HTTPRouteRule {
+	return v1.HTTPRouteRule{
+		Matches: []v1.HTTPRouteMatch{
 			{
-				Path: &v1beta1.HTTPPathMatch{
-					Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+				Path: &v1.HTTPPathMatch{
+					Type:  helpers.GetPointer(v1.PathMatchPathPrefix),
 					Value: &path,
 				},
 			},
@@ -154,17 +155,17 @@ func createHTTPRule(path string, backendRefs ...v1beta1.HTTPBackendRef) v1beta1.
 }
 
 func createBackendRef(
-	kind *v1beta1.Kind,
-	name v1beta1.ObjectName,
-	namespace *v1beta1.Namespace,
-) v1beta1.HTTPBackendRef {
-	return v1beta1.HTTPBackendRef{
-		BackendRef: v1beta1.BackendRef{
-			BackendObjectReference: v1beta1.BackendObjectReference{
+	kind *v1.Kind,
+	name v1.ObjectName,
+	namespace *v1.Namespace,
+) v1.HTTPBackendRef {
+	return v1.HTTPBackendRef{
+		BackendRef: v1.BackendRef{
+			BackendObjectReference: v1.BackendObjectReference{
 				Kind:      kind,
 				Name:      name,
 				Namespace: namespace,
-				Port:      helpers.GetPointer[v1beta1.PortNumber](80),
+				Port:      helpers.GetPointer[v1.PortNumber](80),
 			},
 		},
 	}
@@ -181,6 +182,7 @@ func createAlwaysValidValidators() validation.Validators {
 func createScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
+	utilruntime.Must(v1.AddToScheme(scheme))
 	utilruntime.Must(v1beta1.AddToScheme(scheme))
 	utilruntime.Must(apiv1.AddToScheme(scheme))
 	utilruntime.Must(discoveryV1.AddToScheme(scheme))
@@ -243,12 +245,12 @@ var _ = Describe("ChangeProcessor", func() {
 	format.MaxLength = 0
 	Describe("Normal cases of processing changes", func() {
 		var (
-			gc = &v1beta1.GatewayClass{
+			gc = &v1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       gcName,
 					Generation: 1,
 				},
-				Spec: v1beta1.GatewayClassSpec{
+				Spec: v1.GatewayClassSpec{
 					ControllerName: controllerName,
 				},
 			}
@@ -268,10 +270,10 @@ var _ = Describe("ChangeProcessor", func() {
 
 		Describe("Process gateway resources", Ordered, func() {
 			var (
-				gcUpdated                        *v1beta1.GatewayClass
+				gcUpdated                        *v1.GatewayClass
 				diffNsTLSSecret, sameNsTLSSecret *apiv1.Secret
-				hr1, hr1Updated, hr2             *v1beta1.HTTPRoute
-				gw1, gw1Updated, gw2             *v1beta1.Gateway
+				hr1, hr1Updated, hr2             *v1.HTTPRoute
+				gw1, gw1Updated, gw2             *v1.Gateway
 				refGrant1, refGrant2             *v1beta1.ReferenceGrant
 				expGraph                         *graph.Graph
 				expRouteHR1, expRouteHR2         *graph.Route
@@ -281,13 +283,13 @@ var _ = Describe("ChangeProcessor", func() {
 				gcUpdated = gc.DeepCopy()
 				gcUpdated.Generation++
 
-				crossNsBackendRef := v1beta1.HTTPBackendRef{
-					BackendRef: v1beta1.BackendRef{
-						BackendObjectReference: v1beta1.BackendObjectReference{
-							Kind:      helpers.GetPointer[v1beta1.Kind]("Service"),
+				crossNsBackendRef := v1.HTTPBackendRef{
+					BackendRef: v1.BackendRef{
+						BackendObjectReference: v1.BackendObjectReference{
+							Kind:      helpers.GetPointer[v1.Kind]("Service"),
 							Name:      "service",
-							Namespace: helpers.GetPointer[v1beta1.Namespace]("service-ns"),
-							Port:      helpers.GetPointer[v1beta1.PortNumber](80),
+							Namespace: helpers.GetPointer[v1.Namespace]("service-ns"),
+							Port:      helpers.GetPointer[v1.PortNumber](80),
 						},
 					},
 				}
@@ -309,7 +311,7 @@ var _ = Describe("ChangeProcessor", func() {
 					Spec: v1beta1.ReferenceGrantSpec{
 						From: []v1beta1.ReferenceGrantFrom{
 							{
-								Group:     v1beta1.GroupName,
+								Group:     v1.GroupName,
 								Kind:      "Gateway",
 								Namespace: "test",
 							},
@@ -330,7 +332,7 @@ var _ = Describe("ChangeProcessor", func() {
 					Spec: v1beta1.ReferenceGrantSpec{
 						From: []v1beta1.ReferenceGrantFrom{
 							{
-								Group:     v1beta1.GroupName,
+								Group:     v1.GroupName,
 								Kind:      "HTTPRoute",
 								Namespace: "test",
 							},
@@ -452,7 +454,7 @@ var _ = Describe("ChangeProcessor", func() {
 								Routes: map[types.NamespacedName]*graph.Route{
 									{Namespace: "test", Name: "hr-1"}: expRouteHR1,
 								},
-								SupportedKinds: []v1beta1.RouteGroupKind{{Kind: "HTTPRoute"}},
+								SupportedKinds: []v1.RouteGroupKind{{Kind: "HTTPRoute"}},
 							},
 							"listener-443-1": {
 								Source: gw1.Spec.Listeners[1],
@@ -461,12 +463,12 @@ var _ = Describe("ChangeProcessor", func() {
 									{Namespace: "test", Name: "hr-1"}: expRouteHR1,
 								},
 								ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(diffNsTLSSecret)),
-								SupportedKinds: []v1beta1.RouteGroupKind{{Kind: "HTTPRoute"}},
+								SupportedKinds: []v1.RouteGroupKind{{Kind: "HTTPRoute"}},
 							},
 						},
 						Valid: true,
 					},
-					IgnoredGateways: map[types.NamespacedName]*v1beta1.Gateway{},
+					IgnoredGateways: map[types.NamespacedName]*v1.Gateway{},
 					Routes: map[types.NamespacedName]*graph.Route{
 						{Namespace: "test", Name: "hr-1"}: expRouteHR1,
 					},
@@ -547,7 +549,7 @@ var _ = Describe("ChangeProcessor", func() {
 						Conditions: staticConds.NewListenerRefNotPermitted(
 							"Certificate ref to secret cert-ns/different-ns-tls-secret not permitted by any ReferenceGrant",
 						),
-						SupportedKinds: []v1beta1.RouteGroupKind{{Kind: "HTTPRoute"}},
+						SupportedKinds: []v1.RouteGroupKind{{Kind: "HTTPRoute"}},
 					}
 
 					expAttachment := &graph.ParentRefAttachmentStatus{
@@ -718,7 +720,7 @@ var _ = Describe("ChangeProcessor", func() {
 				It("returns populated graph using first gateway", func() {
 					processor.CaptureUpsertChange(gw2)
 
-					expGraph.IgnoredGateways = map[types.NamespacedName]*v1beta1.Gateway{
+					expGraph.IgnoredGateways = map[types.NamespacedName]*v1.Gateway{
 						{Namespace: "test", Name: "gateway-2"}: gw2,
 					}
 					expGraph.ReferencedSecrets[client.ObjectKeyFromObject(diffNsTLSSecret)] = &graph.Secret{
@@ -734,7 +736,7 @@ var _ = Describe("ChangeProcessor", func() {
 				It("returns populated graph", func() {
 					processor.CaptureUpsertChange(hr2)
 
-					expGraph.IgnoredGateways = map[types.NamespacedName]*v1beta1.Gateway{
+					expGraph.IgnoredGateways = map[types.NamespacedName]*v1.Gateway{
 						{Namespace: "test", Name: "gateway-2"}: gw2,
 					}
 					expGraph.Routes[hr2Name] = expRouteHR2
@@ -758,7 +760,7 @@ var _ = Describe("ChangeProcessor", func() {
 			When("the first Gateway is deleted", func() {
 				It("returns updated graph", func() {
 					processor.CaptureDeleteChange(
-						&v1beta1.Gateway{},
+						&v1.Gateway{},
 						types.NamespacedName{Namespace: "test", Name: "gateway-1"},
 					)
 
@@ -787,7 +789,7 @@ var _ = Describe("ChangeProcessor", func() {
 			When("the second HTTPRoute is deleted", func() {
 				It("returns updated graph", func() {
 					processor.CaptureDeleteChange(
-						&v1beta1.HTTPRoute{},
+						&v1.HTTPRoute{},
 						types.NamespacedName{Namespace: "test", Name: "hr-2"},
 					)
 
@@ -813,7 +815,7 @@ var _ = Describe("ChangeProcessor", func() {
 			When("the GatewayClass is deleted", func() {
 				It("returns updated graph", func() {
 					processor.CaptureDeleteChange(
-						&v1beta1.GatewayClass{},
+						&v1.GatewayClass{},
 						types.NamespacedName{Name: gcName},
 					)
 
@@ -833,7 +835,7 @@ var _ = Describe("ChangeProcessor", func() {
 			When("the second Gateway is deleted", func() {
 				It("returns empty graph", func() {
 					processor.CaptureDeleteChange(
-						&v1beta1.Gateway{},
+						&v1.Gateway{},
 						types.NamespacedName{Namespace: "test", Name: "gateway-2"},
 					)
 
@@ -845,7 +847,7 @@ var _ = Describe("ChangeProcessor", func() {
 			When("the first HTTPRoute is deleted", func() {
 				It("returns empty graph", func() {
 					processor.CaptureDeleteChange(
-						&v1beta1.HTTPRoute{},
+						&v1.HTTPRoute{},
 						types.NamespacedName{Namespace: "test", Name: "hr-1"},
 					)
 
@@ -857,7 +859,7 @@ var _ = Describe("ChangeProcessor", func() {
 		})
 		Describe("Process services and endpoints", Ordered, func() {
 			var (
-				hr1, hr2, hr3, hrInvalidBackendRef, hrMultipleRules                 *v1beta1.HTTPRoute
+				hr1, hr2, hr3, hrInvalidBackendRef, hrMultipleRules                 *v1.HTTPRoute
 				hr1svc, sharedSvc, bazSvc1, bazSvc2, bazSvc3, invalidSvc, notRefSvc *apiv1.Service
 				hr1slice1, hr1slice2, noRefSlice, missingSvcNameSlice               *discoveryV1.EndpointSlice
 			)
@@ -882,9 +884,9 @@ var _ = Describe("ChangeProcessor", func() {
 			}
 
 			BeforeAll(func() {
-				testNamespace := v1beta1.Namespace("test")
-				kindService := v1beta1.Kind("Service")
-				kindInvalid := v1beta1.Kind("Invalid")
+				testNamespace := v1.Namespace("test")
+				kindService := v1.Kind("Service")
+				kindInvalid := v1.Kind("Invalid")
 
 				// backend Refs
 				fooRef := createBackendRef(&kindService, "foo-svc", &testNamespace)
@@ -904,7 +906,7 @@ var _ = Describe("ChangeProcessor", func() {
 					"hr-multiple-rules",
 					"gw",
 					"mutli.example.com",
-					[]v1beta1.HTTPRouteRule{
+					[]v1.HTTPRouteRule{
 						createHTTPRule("/baz-v1", baz1NilNamespace),
 						createHTTPRule("/baz-v2", baz2Ref),
 						createHTTPRule("/baz-v3", baz3Ref),
@@ -1198,16 +1200,16 @@ var _ = Describe("ChangeProcessor", func() {
 							},
 						},
 					}
-					gw := &v1beta1.Gateway{
+					gw := &v1.Gateway{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "gw",
 						},
-						Spec: v1beta1.GatewaySpec{
-							Listeners: []v1beta1.Listener{
+						Spec: v1.GatewaySpec{
+							Listeners: []v1.Listener{
 								{
-									AllowedRoutes: &v1beta1.AllowedRoutes{
-										Namespaces: &v1beta1.RouteNamespaces{
-											From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+									AllowedRoutes: &v1.AllowedRoutes{
+										Namespaces: &v1.RouteNamespaces{
+											From: helpers.GetPointer(v1.NamespacesFromSelector),
 											Selector: &metav1.LabelSelector{
 												MatchLabels: map[string]string{
 													"app": "allowed",
@@ -1246,9 +1248,9 @@ var _ = Describe("ChangeProcessor", func() {
 			fakeRelationshipCapturer                          *relationshipfakes.FakeCapturer
 			gcNsName, gwNsName, hrNsName, hr2NsName, rgNsName types.NamespacedName
 			svcNsName, sliceNsName, secretNsName              types.NamespacedName
-			gc, gcUpdated                                     *v1beta1.GatewayClass
-			gw1, gw1Updated, gw2                              *v1beta1.Gateway
-			hr1, hr1Updated, hr2                              *v1beta1.HTTPRoute
+			gc, gcUpdated                                     *v1.GatewayClass
+			gw1, gw1Updated, gw2                              *v1.Gateway
+			hr1, hr1Updated, hr2                              *v1.HTTPRoute
 			rg1, rg1Updated, rg2                              *v1beta1.ReferenceGrant
 			svc                                               *apiv1.Service
 			slice                                             *discoveryV1.EndpointSlice
@@ -1268,11 +1270,11 @@ var _ = Describe("ChangeProcessor", func() {
 
 			gcNsName = types.NamespacedName{Name: "my-class"}
 
-			gc = &v1beta1.GatewayClass{
+			gc = &v1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: gcNsName.Name,
 				},
-				Spec: v1beta1.GatewayClassSpec{
+				Spec: v1.GatewayClassSpec{
 					ControllerName: "test.controller",
 				},
 			}
@@ -1282,7 +1284,7 @@ var _ = Describe("ChangeProcessor", func() {
 
 			gwNsName = types.NamespacedName{Namespace: "test", Name: "gw-1"}
 
-			gw1 = &v1beta1.Gateway{
+			gw1 = &v1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: gwNsName.Namespace,
 					Name:      gwNsName.Name,
@@ -1297,7 +1299,7 @@ var _ = Describe("ChangeProcessor", func() {
 
 			hrNsName = types.NamespacedName{Namespace: "test", Name: "hr-1"}
 
-			hr1 = &v1beta1.HTTPRoute{
+			hr1 = &v1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: hrNsName.Namespace,
 					Name:      hrNsName.Name,
@@ -1410,9 +1412,9 @@ var _ = Describe("ChangeProcessor", func() {
 			When("resources are deleted followed by upserts with the same generations", func() {
 				It("should report changed", func() {
 					// these are changing changes
-					processor.CaptureDeleteChange(&v1beta1.GatewayClass{}, gcNsName)
-					processor.CaptureDeleteChange(&v1beta1.Gateway{}, gwNsName)
-					processor.CaptureDeleteChange(&v1beta1.HTTPRoute{}, hrNsName)
+					processor.CaptureDeleteChange(&v1.GatewayClass{}, gcNsName)
+					processor.CaptureDeleteChange(&v1.Gateway{}, gwNsName)
+					processor.CaptureDeleteChange(&v1.HTTPRoute{}, hrNsName)
 					processor.CaptureDeleteChange(&v1beta1.ReferenceGrant{}, rgNsName)
 
 					// these are non-changing changes
@@ -1425,7 +1427,7 @@ var _ = Describe("ChangeProcessor", func() {
 				})
 			})
 			It("should report changed after deleting resources", func() {
-				processor.CaptureDeleteChange(&v1beta1.HTTPRoute{}, hr2NsName)
+				processor.CaptureDeleteChange(&v1.HTTPRoute{}, hr2NsName)
 
 				changed, _ := processor.Process()
 				Expect(changed).To(BeTrue())
@@ -1433,10 +1435,10 @@ var _ = Describe("ChangeProcessor", func() {
 		})
 		Describe("Deleting non-existing Gateway API resource", func() {
 			It("should not report changed after deleting non-existing", func() {
-				processor.CaptureDeleteChange(&v1beta1.GatewayClass{}, gcNsName)
-				processor.CaptureDeleteChange(&v1beta1.Gateway{}, gwNsName)
-				processor.CaptureDeleteChange(&v1beta1.HTTPRoute{}, hrNsName)
-				processor.CaptureDeleteChange(&v1beta1.HTTPRoute{}, hr2NsName)
+				processor.CaptureDeleteChange(&v1.GatewayClass{}, gcNsName)
+				processor.CaptureDeleteChange(&v1.Gateway{}, gwNsName)
+				processor.CaptureDeleteChange(&v1.HTTPRoute{}, hrNsName)
+				processor.CaptureDeleteChange(&v1.HTTPRoute{}, hr2NsName)
 				processor.CaptureDeleteChange(&v1beta1.ReferenceGrant{}, rgNsName)
 
 				changed, _ := processor.Process()
@@ -1602,11 +1604,11 @@ var _ = Describe("ChangeProcessor", func() {
 			processor         state.ChangeProcessor
 			fakeEventRecorder *record.FakeRecorder
 
-			gc *v1beta1.GatewayClass
+			gc *v1.GatewayClass
 
 			gwNsName, hrNsName types.NamespacedName
-			gw, gwInvalid      *v1beta1.Gateway
-			hr, hrInvalid      *v1beta1.HTTPRoute
+			gw, gwInvalid      *v1.Gateway
+			hr, hrInvalid      *v1.HTTPRoute
 		)
 		BeforeAll(func() {
 			fakeEventRecorder = record.NewFakeRecorder(2 /* number of buffered events */)
@@ -1621,12 +1623,12 @@ var _ = Describe("ChangeProcessor", func() {
 				Scheme:               createScheme(),
 			})
 
-			gc = &v1beta1.GatewayClass{
+			gc = &v1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       gcName,
 					Generation: 1,
 				},
-				Spec: v1beta1.GatewayClassSpec{
+				Spec: v1.GatewayClassSpec{
 					ControllerName: controllerName,
 				},
 			}
@@ -1634,19 +1636,19 @@ var _ = Describe("ChangeProcessor", func() {
 			gwNsName = types.NamespacedName{Namespace: "test", Name: "gateway"}
 			hrNsName = types.NamespacedName{Namespace: "test", Name: "hr"}
 
-			gw = &v1beta1.Gateway{
+			gw = &v1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: gwNsName.Namespace,
 					Name:      gwNsName.Name,
 				},
-				Spec: v1beta1.GatewaySpec{
+				Spec: v1.GatewaySpec{
 					GatewayClassName: gcName,
-					Listeners: []v1beta1.Listener{
+					Listeners: []v1.Listener{
 						{
 							Name:     "listener-80-1",
-							Hostname: helpers.GetPointer[v1beta1.Hostname]("foo.example.com"),
+							Hostname: helpers.GetPointer[v1.Hostname]("foo.example.com"),
 							Port:     80,
-							Protocol: v1beta1.HTTPProtocolType,
+							Protocol: v1.HTTPProtocolType,
 						},
 					},
 				},
@@ -1654,34 +1656,34 @@ var _ = Describe("ChangeProcessor", func() {
 
 			gwInvalid = gw.DeepCopy()
 			// cannot have hostname for TCP protocol
-			gwInvalid.Spec.Listeners[0].Protocol = v1beta1.TCPProtocolType
+			gwInvalid.Spec.Listeners[0].Protocol = v1.TCPProtocolType
 
-			hr = &v1beta1.HTTPRoute{
+			hr = &v1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: hrNsName.Namespace,
 					Name:      hrNsName.Name,
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
 							{
-								Namespace: (*v1beta1.Namespace)(&gw.Namespace),
-								Name:      v1beta1.ObjectName(gw.Name),
-								SectionName: (*v1beta1.SectionName)(
+								Namespace: (*v1.Namespace)(&gw.Namespace),
+								Name:      v1.ObjectName(gw.Name),
+								SectionName: (*v1.SectionName)(
 									helpers.GetPointer("listener-80-1"),
 								),
 							},
 						},
 					},
-					Hostnames: []v1beta1.Hostname{
+					Hostnames: []v1.Hostname{
 						"foo.example.com",
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []v1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []v1.HTTPRouteMatch{
 								{
-									Path: &v1beta1.HTTPPathMatch{
-										Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+									Path: &v1.HTTPPathMatch{
+										Type:  helpers.GetPointer(v1.PathMatchPathPrefix),
 										Value: helpers.GetPointer("/"),
 									},
 								},
@@ -1795,22 +1797,22 @@ var _ = Describe("ChangeProcessor", func() {
 				})
 			})
 
-			createInvalidHTTPRoute := func(invalidator func(hr *v1beta1.HTTPRoute)) *v1beta1.HTTPRoute {
+			createInvalidHTTPRoute := func(invalidator func(hr *v1.HTTPRoute)) *v1.HTTPRoute {
 				hr := createRoute(
 					"hr",
 					"gateway",
 					"foo.example.com",
 					createBackendRef(
-						helpers.GetPointer[v1beta1.Kind]("Service"),
+						helpers.GetPointer[v1.Kind]("Service"),
 						"test",
-						helpers.GetPointer[v1beta1.Namespace]("namespace"),
+						helpers.GetPointer[v1.Namespace]("namespace"),
 					),
 				)
 				invalidator(hr)
 				return hr
 			}
 
-			createInvalidGateway := func(invalidator func(gw *v1beta1.Gateway)) *v1beta1.Gateway {
+			createInvalidGateway := func(invalidator func(gw *v1.Gateway)) *v1.Gateway {
 				gw := createGateway("gateway")
 				invalidator(gw)
 				return gw
@@ -1821,7 +1823,7 @@ var _ = Describe("ChangeProcessor", func() {
 			}
 
 			DescribeTable("Invalid HTTPRoutes",
-				func(hr *v1beta1.HTTPRoute) {
+				func(hr *v1.HTTPRoute) {
 					processor.CaptureUpsertChange(hr)
 
 					changed, graphCfg := processor.Process()
@@ -1833,39 +1835,39 @@ var _ = Describe("ChangeProcessor", func() {
 				},
 				Entry(
 					"duplicate parentRefs",
-					createInvalidHTTPRoute(func(hr *v1beta1.HTTPRoute) {
+					createInvalidHTTPRoute(func(hr *v1.HTTPRoute) {
 						hr.Spec.ParentRefs = append(hr.Spec.ParentRefs, hr.Spec.ParentRefs[len(hr.Spec.ParentRefs)-1])
 					}),
 				),
 				Entry(
 					"nil path.Type",
-					createInvalidHTTPRoute(func(hr *v1beta1.HTTPRoute) {
+					createInvalidHTTPRoute(func(hr *v1.HTTPRoute) {
 						hr.Spec.Rules[0].Matches[0].Path.Type = nil
 					}),
 				),
 				Entry("nil path.Value",
-					createInvalidHTTPRoute(func(hr *v1beta1.HTTPRoute) {
+					createInvalidHTTPRoute(func(hr *v1.HTTPRoute) {
 						hr.Spec.Rules[0].Matches[0].Path.Value = nil
 					}),
 				),
 				Entry(
 					"nil request.Redirect",
-					createInvalidHTTPRoute(func(hr *v1beta1.HTTPRoute) {
-						hr.Spec.Rules[0].Filters = append(hr.Spec.Rules[0].Filters, v1beta1.HTTPRouteFilter{
-							Type:            v1beta1.HTTPRouteFilterRequestRedirect,
+					createInvalidHTTPRoute(func(hr *v1.HTTPRoute) {
+						hr.Spec.Rules[0].Filters = append(hr.Spec.Rules[0].Filters, v1.HTTPRouteFilter{
+							Type:            v1.HTTPRouteFilterRequestRedirect,
 							RequestRedirect: nil,
 						})
 					}),
 				),
 				Entry("nil port in BackendRef",
-					createInvalidHTTPRoute(func(hr *v1beta1.HTTPRoute) {
+					createInvalidHTTPRoute(func(hr *v1.HTTPRoute) {
 						hr.Spec.Rules[0].BackendRefs[0].Port = nil
 					}),
 				),
 			)
 
 			DescribeTable("Invalid Gateway resources",
-				func(gw *v1beta1.Gateway) {
+				func(gw *v1.Gateway) {
 					processor.CaptureUpsertChange(gw)
 
 					changed, graphCfg := processor.Process()
@@ -1876,32 +1878,32 @@ var _ = Describe("ChangeProcessor", func() {
 					assertRejectedEvent()
 				},
 				Entry("tls in HTTP listener",
-					createInvalidGateway(func(gw *v1beta1.Gateway) {
-						gw.Spec.Listeners[0].TLS = &v1beta1.GatewayTLSConfig{}
+					createInvalidGateway(func(gw *v1.Gateway) {
+						gw.Spec.Listeners[0].TLS = &v1.GatewayTLSConfig{}
 					}),
 				),
 				Entry("tls is nil in HTTPS listener",
-					createInvalidGateway(func(gw *v1beta1.Gateway) {
-						gw.Spec.Listeners[0].Protocol = v1beta1.HTTPSProtocolType
+					createInvalidGateway(func(gw *v1.Gateway) {
+						gw.Spec.Listeners[0].Protocol = v1.HTTPSProtocolType
 						gw.Spec.Listeners[0].TLS = nil
 					}),
 				),
 				Entry("zero certificateRefs in HTTPS listener",
-					createInvalidGateway(func(gw *v1beta1.Gateway) {
-						gw.Spec.Listeners[0].Protocol = v1beta1.HTTPSProtocolType
-						gw.Spec.Listeners[0].TLS = &v1beta1.GatewayTLSConfig{
-							Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
+					createInvalidGateway(func(gw *v1.Gateway) {
+						gw.Spec.Listeners[0].Protocol = v1.HTTPSProtocolType
+						gw.Spec.Listeners[0].TLS = &v1.GatewayTLSConfig{
+							Mode:            helpers.GetPointer(v1.TLSModeTerminate),
 							CertificateRefs: nil,
 						}
 					}),
 				),
 				Entry("listener hostnames conflict",
-					createInvalidGateway(func(gw *v1beta1.Gateway) {
-						gw.Spec.Listeners = append(gw.Spec.Listeners, v1beta1.Listener{
+					createInvalidGateway(func(gw *v1.Gateway) {
+						gw.Spec.Listeners = append(gw.Spec.Listeners, v1.Listener{
 							Name:     "listener-80-2",
 							Hostname: nil,
 							Port:     80,
-							Protocol: v1beta1.HTTPProtocolType,
+							Protocol: v1.HTTPProtocolType,
 						})
 					}),
 				),

--- a/internal/mode/static/state/conditions/conditions.go
+++ b/internal/mode/static/state/conditions/conditions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
@@ -13,7 +13,7 @@ import (
 const (
 	// ListenerReasonUnsupportedValue is used with the "Accepted" condition when a value of a field in a Listener
 	// is invalid or not supported.
-	ListenerReasonUnsupportedValue v1beta1.ListenerConditionReason = "UnsupportedValue"
+	ListenerReasonUnsupportedValue v1.ListenerConditionReason = "UnsupportedValue"
 
 	// ListenerMessageFailedNginxReload is a message used with ListenerConditionProgrammed (false)
 	// when nginx fails to reload.
@@ -29,23 +29,23 @@ const (
 	RouteReasonInvalidGateway = "InvalidGateway"
 
 	// RouteReasonInvalidListener is used with the "Accepted" condition when the Route references an invalid listener.
-	RouteReasonInvalidListener v1beta1.RouteConditionReason = "InvalidListener"
+	RouteReasonInvalidListener v1.RouteConditionReason = "InvalidListener"
 
 	// RouteReasonGatewayNotProgrammed is used when the associated Gateway is not programmed.
 	// Used with Accepted (false).
-	RouteReasonGatewayNotProgrammed v1beta1.RouteConditionReason = "GatewayNotProgrammed"
+	RouteReasonGatewayNotProgrammed v1.RouteConditionReason = "GatewayNotProgrammed"
 
 	// GatewayReasonGatewayConflict indicates there are multiple Gateway resources to choose from,
 	// and we ignored the resource in question and picked another Gateway as the winner.
 	// This reason is used with GatewayConditionAccepted (false).
-	GatewayReasonGatewayConflict v1beta1.GatewayConditionReason = "GatewayConflict"
+	GatewayReasonGatewayConflict v1.GatewayConditionReason = "GatewayConflict"
 
 	// GatewayMessageGatewayConflict is a message that describes GatewayReasonGatewayConflict.
 	GatewayMessageGatewayConflict = "The resource is ignored due to a conflicting Gateway resource"
 
 	// GatewayReasonUnsupportedValue is used with GatewayConditionAccepted (false) when a value of a field in a Gateway
 	// is invalid or not supported.
-	GatewayReasonUnsupportedValue v1beta1.GatewayConditionReason = "UnsupportedValue"
+	GatewayReasonUnsupportedValue v1.GatewayConditionReason = "UnsupportedValue"
 
 	// GatewayMessageFailedNginxReload is a message used with GatewayConditionProgrammed (false)
 	// when nginx fails to reload.
@@ -62,7 +62,7 @@ const (
 	//
 	// FIXME(bjee19): Update to Gateway sig v1 version when released.
 	// https://github.com/nginxinc/nginx-gateway-fabric/issues/1168
-	RouteConditionPartiallyInvalid v1beta1.RouteConditionType = "PartiallyInvalid"
+	RouteConditionPartiallyInvalid v1.RouteConditionType = "PartiallyInvalid"
 )
 
 // DeduplicateConditions removes duplicate conditions based on the condition type.
@@ -119,9 +119,9 @@ func NewDefaultRouteConditions() []conditions.Condition {
 // any listener.
 func NewRouteNotAllowedByListeners() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionAccepted),
+		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.RouteReasonNotAllowedByListeners),
+		Reason:  string(v1.RouteReasonNotAllowedByListeners),
 		Message: "HTTPRoute is not allowed by any listener",
 	}
 }
@@ -130,9 +130,9 @@ func NewRouteNotAllowedByListeners() conditions.Condition {
 // does not match the hostnames of the HTTPRoute.
 func NewRouteNoMatchingListenerHostname() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionAccepted),
+		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.RouteReasonNoMatchingListenerHostname),
+		Reason:  string(v1.RouteReasonNoMatchingListenerHostname),
 		Message: "Listener hostname does not match the HTTPRoute hostnames",
 	}
 }
@@ -140,9 +140,9 @@ func NewRouteNoMatchingListenerHostname() conditions.Condition {
 // NewRouteAccepted returns a Condition that indicates that the HTTPRoute is accepted.
 func NewRouteAccepted() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionAccepted),
+		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.RouteReasonAccepted),
+		Reason:  string(v1.RouteReasonAccepted),
 		Message: "The route is accepted",
 	}
 }
@@ -150,9 +150,9 @@ func NewRouteAccepted() conditions.Condition {
 // NewRouteUnsupportedValue returns a Condition that indicates that the HTTPRoute includes an unsupported value.
 func NewRouteUnsupportedValue(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionAccepted),
+		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.RouteReasonUnsupportedValue),
+		Reason:  string(v1.RouteReasonUnsupportedValue),
 		Message: msg,
 	}
 }
@@ -167,7 +167,7 @@ func NewRoutePartiallyInvalid(msg string) conditions.Condition {
 	return conditions.Condition{
 		Type:    string(RouteConditionPartiallyInvalid),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.RouteReasonUnsupportedValue),
+		Reason:  string(v1.RouteReasonUnsupportedValue),
 		Message: "Dropped Rule(s): " + msg,
 	}
 }
@@ -176,7 +176,7 @@ func NewRoutePartiallyInvalid(msg string) conditions.Condition {
 // invalid listener.
 func NewRouteInvalidListener() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionAccepted),
+		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
 		Reason:  string(RouteReasonInvalidListener),
 		Message: "Listener is invalid for this parent ref",
@@ -186,9 +186,9 @@ func NewRouteInvalidListener() conditions.Condition {
 // NewRouteResolvedRefs returns a Condition that indicates that all the references on the Route are resolved.
 func NewRouteResolvedRefs() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionResolvedRefs),
+		Type:    string(v1.RouteConditionResolvedRefs),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.RouteReasonResolvedRefs),
+		Reason:  string(v1.RouteReasonResolvedRefs),
 		Message: "All references are resolved",
 	}
 }
@@ -197,9 +197,9 @@ func NewRouteResolvedRefs() conditions.Condition {
 // invalid kind.
 func NewRouteBackendRefInvalidKind(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionResolvedRefs),
+		Type:    string(v1.RouteConditionResolvedRefs),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.RouteReasonInvalidKind),
+		Reason:  string(v1.RouteReasonInvalidKind),
 		Message: msg,
 	}
 }
@@ -208,9 +208,9 @@ func NewRouteBackendRefInvalidKind(msg string) conditions.Condition {
 // is not permitted.
 func NewRouteBackendRefRefNotPermitted(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionResolvedRefs),
+		Type:    string(v1.RouteConditionResolvedRefs),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.RouteReasonRefNotPermitted),
+		Reason:  string(v1.RouteReasonRefNotPermitted),
 		Message: msg,
 	}
 }
@@ -219,9 +219,9 @@ func NewRouteBackendRefRefNotPermitted(msg string) conditions.Condition {
 // points to non-existing backend.
 func NewRouteBackendRefRefBackendNotFound(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionResolvedRefs),
+		Type:    string(v1.RouteConditionResolvedRefs),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.RouteReasonBackendNotFound),
+		Reason:  string(v1.RouteReasonBackendNotFound),
 		Message: msg,
 	}
 }
@@ -230,7 +230,7 @@ func NewRouteBackendRefRefBackendNotFound(msg string) conditions.Condition {
 // an unsupported value.
 func NewRouteBackendRefUnsupportedValue(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionResolvedRefs),
+		Type:    string(v1.RouteConditionResolvedRefs),
 		Status:  metav1.ConditionFalse,
 		Reason:  RouteReasonBackendRefUnsupportedValue,
 		Message: msg,
@@ -241,7 +241,7 @@ func NewRouteBackendRefUnsupportedValue(msg string) conditions.Condition {
 // references is invalid.
 func NewRouteInvalidGateway() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionAccepted),
+		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
 		Reason:  RouteReasonInvalidGateway,
 		Message: "Gateway is invalid",
@@ -252,9 +252,9 @@ func NewRouteInvalidGateway() conditions.Condition {
 // it specifies a Port and/or SectionName that does not match any Listeners in the Gateway.
 func NewRouteNoMatchingParent() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionAccepted),
+		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.RouteReasonNoMatchingParent),
+		Reason:  string(v1.RouteReasonNoMatchingParent),
 		Message: "Listener is not found for this parent ref",
 	}
 }
@@ -263,7 +263,7 @@ func NewRouteNoMatchingParent() conditions.Condition {
 // which does not guarantee that the HTTPRoute has been configured.
 func NewRouteGatewayNotProgrammed(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.RouteConditionAccepted),
+		Type:    string(v1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
 		Reason:  string(RouteReasonGatewayNotProgrammed),
 		Message: msg,
@@ -283,9 +283,9 @@ func NewDefaultListenerConditions() []conditions.Condition {
 // NewListenerAccepted returns a Condition that indicates that the Listener is accepted.
 func NewListenerAccepted() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.ListenerConditionAccepted),
+		Type:    string(v1.ListenerConditionAccepted),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.ListenerReasonAccepted),
+		Reason:  string(v1.ListenerReasonAccepted),
 		Message: "Listener is accepted",
 	}
 }
@@ -293,9 +293,9 @@ func NewListenerAccepted() conditions.Condition {
 // NewListenerProgrammed returns a Condition that indicates the Listener is programmed.
 func NewListenerProgrammed() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.ListenerConditionProgrammed),
+		Type:    string(v1.ListenerConditionProgrammed),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.ListenerReasonProgrammed),
+		Reason:  string(v1.ListenerReasonProgrammed),
 		Message: "Listener is programmed",
 	}
 }
@@ -303,9 +303,9 @@ func NewListenerProgrammed() conditions.Condition {
 // NewListenerResolvedRefs returns a Condition that indicates that all references in a Listener are resolved.
 func NewListenerResolvedRefs() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.ListenerConditionResolvedRefs),
+		Type:    string(v1.ListenerConditionResolvedRefs),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.ListenerReasonResolvedRefs),
+		Reason:  string(v1.ListenerReasonResolvedRefs),
 		Message: "All references are resolved",
 	}
 }
@@ -313,9 +313,9 @@ func NewListenerResolvedRefs() conditions.Condition {
 // NewListenerNoConflicts returns a Condition that indicates that there are no conflicts in a Listener.
 func NewListenerNoConflicts() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.ListenerConditionConflicted),
+		Type:    string(v1.ListenerConditionConflicted),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.ListenerReasonNoConflicts),
+		Reason:  string(v1.ListenerReasonNoConflicts),
 		Message: "No conflicts",
 	}
 }
@@ -324,9 +324,9 @@ func NewListenerNoConflicts() conditions.Condition {
 // semantically or syntactically invalid. The provided message contains the details of why the Listener is invalid.
 func NewListenerNotProgrammedInvalid(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.ListenerConditionProgrammed),
+		Type:    string(v1.ListenerConditionProgrammed),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.ListenerReasonInvalid),
+		Reason:  string(v1.ListenerReasonInvalid),
 		Message: msg,
 	}
 }
@@ -336,7 +336,7 @@ func NewListenerNotProgrammedInvalid(msg string) conditions.Condition {
 func NewListenerUnsupportedValue(msg string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.ListenerConditionAccepted),
+			Type:    string(v1.ListenerConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(ListenerReasonUnsupportedValue),
 			Message: msg,
@@ -349,15 +349,15 @@ func NewListenerUnsupportedValue(msg string) []conditions.Condition {
 func NewListenerInvalidCertificateRef(msg string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.ListenerConditionAccepted),
+			Type:    string(v1.ListenerConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonInvalidCertificateRef),
+			Reason:  string(v1.ListenerReasonInvalidCertificateRef),
 			Message: msg,
 		},
 		{
-			Type:    string(v1beta1.ListenerReasonResolvedRefs),
+			Type:    string(v1.ListenerReasonResolvedRefs),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonInvalidCertificateRef),
+			Reason:  string(v1.ListenerReasonInvalidCertificateRef),
 			Message: msg,
 		},
 		NewListenerNotProgrammedInvalid(msg),
@@ -369,9 +369,9 @@ func NewListenerInvalidCertificateRef(msg string) []conditions.Condition {
 func NewListenerInvalidRouteKinds(msg string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.ListenerReasonResolvedRefs),
+			Type:    string(v1.ListenerReasonResolvedRefs),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonInvalidRouteKinds),
+			Reason:  string(v1.ListenerReasonInvalidRouteKinds),
 			Message: msg,
 		},
 		NewListenerNotProgrammedInvalid(msg),
@@ -383,15 +383,15 @@ func NewListenerInvalidRouteKinds(msg string) []conditions.Condition {
 func NewListenerProtocolConflict(msg string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.ListenerConditionAccepted),
+			Type:    string(v1.ListenerConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonProtocolConflict),
+			Reason:  string(v1.ListenerReasonProtocolConflict),
 			Message: msg,
 		},
 		{
-			Type:    string(v1beta1.ListenerConditionConflicted),
+			Type:    string(v1.ListenerConditionConflicted),
 			Status:  metav1.ConditionTrue,
-			Reason:  string(v1beta1.ListenerReasonProtocolConflict),
+			Reason:  string(v1.ListenerReasonProtocolConflict),
 			Message: msg,
 		},
 		NewListenerNotProgrammedInvalid(msg),
@@ -402,9 +402,9 @@ func NewListenerProtocolConflict(msg string) []conditions.Condition {
 func NewListenerUnsupportedProtocol(msg string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.ListenerConditionAccepted),
+			Type:    string(v1.ListenerConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonUnsupportedProtocol),
+			Reason:  string(v1.ListenerReasonUnsupportedProtocol),
 			Message: msg,
 		},
 		NewListenerNotProgrammedInvalid(msg),
@@ -416,15 +416,15 @@ func NewListenerUnsupportedProtocol(msg string) []conditions.Condition {
 func NewListenerRefNotPermitted(msg string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.ListenerConditionAccepted),
+			Type:    string(v1.ListenerConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonRefNotPermitted),
+			Reason:  string(v1.ListenerReasonRefNotPermitted),
 			Message: msg,
 		},
 		{
-			Type:    string(v1beta1.ListenerReasonResolvedRefs),
+			Type:    string(v1.ListenerReasonResolvedRefs),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonRefNotPermitted),
+			Reason:  string(v1.ListenerReasonRefNotPermitted),
 			Message: msg,
 		},
 		NewListenerNotProgrammedInvalid(msg),
@@ -434,9 +434,9 @@ func NewListenerRefNotPermitted(msg string) []conditions.Condition {
 // NewGatewayClassInvalidParameters returns a Condition that indicates that the GatewayClass has invalid parameters.
 func NewGatewayClassInvalidParameters(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.GatewayClassConditionStatusAccepted),
+		Type:    string(v1.GatewayClassConditionStatusAccepted),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.GatewayClassReasonInvalidParameters),
+		Reason:  string(v1.GatewayClassReasonInvalidParameters),
 		Message: msg,
 	}
 }
@@ -452,9 +452,9 @@ func NewDefaultGatewayConditions() []conditions.Condition {
 // NewGatewayAccepted returns a Condition that indicates the Gateway is accepted.
 func NewGatewayAccepted() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.GatewayConditionAccepted),
+		Type:    string(v1.GatewayConditionAccepted),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.GatewayReasonAccepted),
+		Reason:  string(v1.GatewayReasonAccepted),
 		Message: "Gateway is accepted",
 	}
 }
@@ -463,7 +463,7 @@ func NewGatewayAccepted() conditions.Condition {
 func NewGatewayConflict() []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.GatewayConditionAccepted),
+			Type:    string(v1.GatewayConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(GatewayReasonGatewayConflict),
 			Message: GatewayMessageGatewayConflict,
@@ -476,9 +476,9 @@ func NewGatewayConflict() []conditions.Condition {
 // but has at least one listener that is invalid.
 func NewGatewayAcceptedListenersNotValid() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.GatewayConditionAccepted),
+		Type:    string(v1.GatewayConditionAccepted),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.GatewayReasonListenersNotValid),
+		Reason:  string(v1.GatewayReasonListenersNotValid),
 		Message: "Gateway has at least one valid listener",
 	}
 }
@@ -489,9 +489,9 @@ func NewGatewayNotAcceptedListenersNotValid() []conditions.Condition {
 	msg := "Gateway has no valid listeners"
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.GatewayConditionAccepted),
+			Type:    string(v1.GatewayConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.GatewayReasonListenersNotValid),
+			Reason:  string(v1.GatewayReasonListenersNotValid),
 			Message: msg,
 		},
 		NewGatewayNotProgrammedInvalid(msg),
@@ -503,9 +503,9 @@ func NewGatewayNotAcceptedListenersNotValid() []conditions.Condition {
 func NewGatewayInvalid(msg string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.GatewayConditionAccepted),
+			Type:    string(v1.GatewayConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.GatewayReasonInvalid),
+			Reason:  string(v1.GatewayReasonInvalid),
 			Message: msg,
 		},
 		NewGatewayNotProgrammedInvalid(msg),
@@ -517,13 +517,13 @@ func NewGatewayInvalid(msg string) []conditions.Condition {
 func NewGatewayUnsupportedValue(msg string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    string(v1beta1.GatewayConditionAccepted),
+			Type:    string(v1.GatewayConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(GatewayReasonUnsupportedValue),
 			Message: msg,
 		},
 		{
-			Type:    string(v1beta1.GatewayConditionProgrammed),
+			Type:    string(v1.GatewayConditionProgrammed),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(GatewayReasonUnsupportedValue),
 			Message: msg,
@@ -534,9 +534,9 @@ func NewGatewayUnsupportedValue(msg string) []conditions.Condition {
 // NewGatewayProgrammed returns a Condition that indicates the Gateway is programmed.
 func NewGatewayProgrammed() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.GatewayConditionProgrammed),
+		Type:    string(v1.GatewayConditionProgrammed),
 		Status:  metav1.ConditionTrue,
-		Reason:  string(v1beta1.GatewayReasonProgrammed),
+		Reason:  string(v1.GatewayReasonProgrammed),
 		Message: "Gateway is programmed",
 	}
 }
@@ -546,9 +546,9 @@ func NewGatewayProgrammed() conditions.Condition {
 // why the Gateway is invalid.
 func NewGatewayNotProgrammedInvalid(msg string) conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.GatewayConditionProgrammed),
+		Type:    string(v1.GatewayConditionProgrammed),
 		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.GatewayReasonInvalid),
+		Reason:  string(v1.GatewayReasonInvalid),
 		Message: msg,
 	}
 }
@@ -557,7 +557,7 @@ func NewGatewayNotProgrammedInvalid(msg string) conditions.Condition {
 // conflict with another Gateway.
 func NewGatewayConflictNotProgrammed() conditions.Condition {
 	return conditions.Condition{
-		Type:    string(v1beta1.GatewayConditionProgrammed),
+		Type:    string(v1.GatewayConditionProgrammed),
 		Status:  metav1.ConditionFalse,
 		Reason:  string(GatewayReasonGatewayConflict),
 		Message: GatewayMessageGatewayConflict,

--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/graph"
@@ -25,13 +25,13 @@ func TestBuildConfiguration(t *testing.T) {
 		invalidFiltersPath = "/not-valid-filters"
 	)
 
-	createRoute := func(name, hostname, listenerName string, paths ...pathAndType) *v1beta1.HTTPRoute {
-		rules := make([]v1beta1.HTTPRouteRule, 0, len(paths))
+	createRoute := func(name, hostname, listenerName string, paths ...pathAndType) *v1.HTTPRoute {
+		rules := make([]v1.HTTPRouteRule, 0, len(paths))
 		for _, p := range paths {
-			rules = append(rules, v1beta1.HTTPRouteRule{
-				Matches: []v1beta1.HTTPRouteMatch{
+			rules = append(rules, v1.HTTPRouteRule{
+				Matches: []v1.HTTPRouteMatch{
 					{
-						Path: &v1beta1.HTTPPathMatch{
+						Path: &v1.HTTPPathMatch{
 							Value: helpers.GetPointer(p.path),
 							Type:  helpers.GetPointer(p.pathType),
 						},
@@ -39,30 +39,30 @@ func TestBuildConfiguration(t *testing.T) {
 				},
 			})
 		}
-		return &v1beta1.HTTPRoute{
+		return &v1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test",
 				Name:      name,
 			},
-			Spec: v1beta1.HTTPRouteSpec{
-				CommonRouteSpec: v1beta1.CommonRouteSpec{
-					ParentRefs: []v1beta1.ParentReference{
+			Spec: v1.HTTPRouteSpec{
+				CommonRouteSpec: v1.CommonRouteSpec{
+					ParentRefs: []v1.ParentReference{
 						{
-							Namespace:   (*v1beta1.Namespace)(helpers.GetPointer("test")),
+							Namespace:   (*v1.Namespace)(helpers.GetPointer("test")),
 							Name:        "gateway",
-							SectionName: (*v1beta1.SectionName)(helpers.GetPointer(listenerName)),
+							SectionName: (*v1.SectionName)(helpers.GetPointer(listenerName)),
 						},
 					},
 				},
-				Hostnames: []v1beta1.Hostname{
-					v1beta1.Hostname(hostname),
+				Hostnames: []v1.Hostname{
+					v1.Hostname(hostname),
 				},
 				Rules: rules,
 			},
 		}
 	}
 
-	addFilters := func(hr *v1beta1.HTTPRoute, filters []v1beta1.HTTPRouteFilter) {
+	addFilters := func(hr *v1.HTTPRoute, filters []v1.HTTPRouteFilter) {
 		for i := range hr.Spec.Rules {
 			hr.Spec.Rules[i].Filters = filters
 		}
@@ -108,7 +108,7 @@ func TestBuildConfiguration(t *testing.T) {
 		return []graph.BackendRef{validBackendRef}
 	}
 
-	createRules := func(hr *v1beta1.HTTPRoute, paths []pathAndType) []graph.Rule {
+	createRules := func(hr *v1.HTTPRoute, paths []pathAndType) []graph.Rule {
 		rules := make([]graph.Rule, len(hr.Spec.Rules))
 
 		for i := range paths {
@@ -127,7 +127,7 @@ func TestBuildConfiguration(t *testing.T) {
 	}
 
 	createInternalRoute := func(
-		source *v1beta1.HTTPRoute,
+		source *v1.HTTPRoute,
 		listenerName string,
 		paths []pathAndType,
 	) *graph.Route {
@@ -171,7 +171,7 @@ func TestBuildConfiguration(t *testing.T) {
 	}
 
 	createTestResources := func(name, hostname, listenerName string, paths ...pathAndType) (
-		*v1beta1.HTTPRoute, []BackendGroup, *graph.Route,
+		*v1.HTTPRoute, []BackendGroup, *graph.Route,
 	) {
 		hr := createRoute(name, hostname, listenerName, paths...)
 		route := createInternalRoute(hr, listenerName, paths)
@@ -179,7 +179,7 @@ func TestBuildConfiguration(t *testing.T) {
 		return hr, groups, route
 	}
 
-	prefix := v1beta1.PathMatchPathPrefix
+	prefix := v1.PathMatchPathPrefix
 
 	hr1, expHR1Groups, routeHR1 := createTestResources(
 		"hr-1",
@@ -215,13 +215,13 @@ func TestBuildConfiguration(t *testing.T) {
 		pathAndType{path: "/", pathType: prefix}, pathAndType{path: invalidFiltersPath, pathType: prefix},
 	)
 
-	redirect := v1beta1.HTTPRouteFilter{
-		Type: v1beta1.HTTPRouteFilterRequestRedirect,
-		RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-			Hostname: (*v1beta1.PreciseHostname)(helpers.GetPointer("foo.example.com")),
+	redirect := v1.HTTPRouteFilter{
+		Type: v1.HTTPRouteFilterRequestRedirect,
+		RequestRedirect: &v1.HTTPRequestRedirectFilter{
+			Hostname: (*v1.PreciseHostname)(helpers.GetPointer("foo.example.com")),
 		},
 	}
-	addFilters(hr5, []v1beta1.HTTPRouteFilter{redirect})
+	addFilters(hr5, []v1.HTTPRouteFilter{redirect})
 	expRedirect := HTTPRequestRedirectFilter{
 		Hostname: helpers.GetPointer("foo.example.com"),
 	}
@@ -237,7 +237,7 @@ func TestBuildConfiguration(t *testing.T) {
 		"hr-7",
 		"foo.example.com",
 		"listener-80-1",
-		pathAndType{path: "/valid", pathType: prefix}, pathAndType{path: "/valid", pathType: v1beta1.PathMatchExact},
+		pathAndType{path: "/valid", pathType: prefix}, pathAndType{path: "/valid", pathType: v1.PathMatchExact},
 	)
 
 	hr8, expHR8Groups, routeHR8 := createTestResources(
@@ -327,85 +327,85 @@ func TestBuildConfiguration(t *testing.T) {
 		},
 	}
 
-	listener80 := v1beta1.Listener{
+	listener80 := v1.Listener{
 		Name:     "listener-80-1",
 		Hostname: nil,
 		Port:     80,
-		Protocol: v1beta1.HTTPProtocolType,
+		Protocol: v1.HTTPProtocolType,
 	}
 
-	listener8080 := v1beta1.Listener{
+	listener8080 := v1.Listener{
 		Name:     "listener-8080",
 		Hostname: nil,
 		Port:     8080,
-		Protocol: v1beta1.HTTPProtocolType,
+		Protocol: v1.HTTPProtocolType,
 	}
 
-	listener443 := v1beta1.Listener{
+	listener443 := v1.Listener{
 		Name:     "listener-443-1",
 		Hostname: nil,
 		Port:     443,
-		Protocol: v1beta1.HTTPSProtocolType,
-		TLS: &v1beta1.GatewayTLSConfig{
-			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
-			CertificateRefs: []v1beta1.SecretObjectReference{
+		Protocol: v1.HTTPSProtocolType,
+		TLS: &v1.GatewayTLSConfig{
+			Mode: helpers.GetPointer(v1.TLSModeTerminate),
+			CertificateRefs: []v1.SecretObjectReference{
 				{
-					Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
-					Namespace: helpers.GetPointer(v1beta1.Namespace(secret1NsName.Namespace)),
-					Name:      v1beta1.ObjectName(secret1NsName.Name),
+					Kind:      (*v1.Kind)(helpers.GetPointer("Secret")),
+					Namespace: helpers.GetPointer(v1.Namespace(secret1NsName.Namespace)),
+					Name:      v1.ObjectName(secret1NsName.Name),
 				},
 			},
 		},
 	}
 
-	listener8443 := v1beta1.Listener{
+	listener8443 := v1.Listener{
 		Name:     "listener-8443",
 		Hostname: nil,
 		Port:     8443,
-		Protocol: v1beta1.HTTPSProtocolType,
-		TLS: &v1beta1.GatewayTLSConfig{
-			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
-			CertificateRefs: []v1beta1.SecretObjectReference{
+		Protocol: v1.HTTPSProtocolType,
+		TLS: &v1.GatewayTLSConfig{
+			Mode: helpers.GetPointer(v1.TLSModeTerminate),
+			CertificateRefs: []v1.SecretObjectReference{
 				{
-					Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
-					Namespace: helpers.GetPointer(v1beta1.Namespace(secret2NsName.Namespace)),
-					Name:      v1beta1.ObjectName(secret2NsName.Name),
+					Kind:      (*v1.Kind)(helpers.GetPointer("Secret")),
+					Namespace: helpers.GetPointer(v1.Namespace(secret2NsName.Namespace)),
+					Name:      v1.ObjectName(secret2NsName.Name),
 				},
 			},
 		},
 	}
 
-	hostname := v1beta1.Hostname("example.com")
+	hostname := v1.Hostname("example.com")
 
-	listener443WithHostname := v1beta1.Listener{
+	listener443WithHostname := v1.Listener{
 		Name:     "listener-443-with-hostname",
 		Hostname: &hostname,
 		Port:     443,
-		Protocol: v1beta1.HTTPSProtocolType,
-		TLS: &v1beta1.GatewayTLSConfig{
-			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
-			CertificateRefs: []v1beta1.SecretObjectReference{
+		Protocol: v1.HTTPSProtocolType,
+		TLS: &v1.GatewayTLSConfig{
+			Mode: helpers.GetPointer(v1.TLSModeTerminate),
+			CertificateRefs: []v1.SecretObjectReference{
 				{
-					Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
-					Namespace: helpers.GetPointer(v1beta1.Namespace(secret2NsName.Namespace)),
-					Name:      v1beta1.ObjectName(secret2NsName.Name),
+					Kind:      (*v1.Kind)(helpers.GetPointer("Secret")),
+					Namespace: helpers.GetPointer(v1.Namespace(secret2NsName.Namespace)),
+					Name:      v1.ObjectName(secret2NsName.Name),
 				},
 			},
 		},
 	}
 
-	invalidListener := v1beta1.Listener{
+	invalidListener := v1.Listener{
 		Name:     "invalid-listener",
 		Hostname: nil,
 		Port:     443,
-		Protocol: v1beta1.HTTPSProtocolType,
-		TLS: &v1beta1.GatewayTLSConfig{
+		Protocol: v1.HTTPSProtocolType,
+		TLS: &v1.GatewayTLSConfig{
 			// Mode is missing, that's why invalid
-			CertificateRefs: []v1beta1.SecretObjectReference{
+			CertificateRefs: []v1.SecretObjectReference{
 				{
-					Kind:      helpers.GetPointer[v1beta1.Kind]("Secret"),
-					Namespace: helpers.GetPointer(v1beta1.Namespace(secret1NsName.Namespace)),
-					Name:      v1beta1.ObjectName(secret1NsName.Name),
+					Kind:      helpers.GetPointer[v1.Kind]("Secret"),
+					Namespace: helpers.GetPointer(v1.Namespace(secret1NsName.Namespace)),
+					Name:      v1.ObjectName(secret1NsName.Name),
 				},
 			},
 		},
@@ -419,11 +419,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source:    &v1beta1.Gateway{},
+					Source:    &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{},
 				},
 				Routes: map[types.NamespacedName]*graph.Route{},
@@ -438,11 +438,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -468,11 +468,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-443-1": {
 							Source:         listener443, // nil hostname
@@ -528,11 +528,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"invalid-listener": {
 							Source:         invalidListener,
@@ -559,11 +559,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -629,11 +629,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-443-1": {
 							Source: listener443,
@@ -746,11 +746,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -903,11 +903,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -1112,11 +1112,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  false,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -1138,7 +1138,7 @@ func TestBuildConfiguration(t *testing.T) {
 			graph: &graph.Graph{
 				GatewayClass: nil,
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -1159,7 +1159,7 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: nil,
@@ -1171,11 +1171,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -1239,11 +1239,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -1338,11 +1338,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-80-1": {
 							Source: listener80,
@@ -1400,11 +1400,11 @@ func TestBuildConfiguration(t *testing.T) {
 		{
 			graph: &graph.Graph{
 				GatewayClass: &graph.GatewayClass{
-					Source: &v1beta1.GatewayClass{},
+					Source: &v1.GatewayClass{},
 					Valid:  true,
 				},
 				Gateway: &graph.Gateway{
-					Source: &v1beta1.Gateway{},
+					Source: &v1.Gateway{},
 					Listeners: map[string]*graph.Listener{
 						"listener-443-with-hostname": {
 							Source: listener443WithHostname,
@@ -1502,12 +1502,12 @@ func TestBuildConfiguration(t *testing.T) {
 
 func TestGetPath(t *testing.T) {
 	tests := []struct {
-		path     *v1beta1.HTTPPathMatch
+		path     *v1.HTTPPathMatch
 		expected string
 		msg      string
 	}{
 		{
-			path:     &v1beta1.HTTPPathMatch{Value: helpers.GetPointer("/abc")},
+			path:     &v1.HTTPPathMatch{Value: helpers.GetPointer("/abc")},
 			expected: "/abc",
 			msg:      "normal case",
 		},
@@ -1517,12 +1517,12 @@ func TestGetPath(t *testing.T) {
 			msg:      "nil path",
 		},
 		{
-			path:     &v1beta1.HTTPPathMatch{Value: nil},
+			path:     &v1.HTTPPathMatch{Value: nil},
 			expected: "/",
 			msg:      "nil value",
 		},
 		{
-			path:     &v1beta1.HTTPPathMatch{Value: helpers.GetPointer("")},
+			path:     &v1.HTTPPathMatch{Value: helpers.GetPointer("")},
 			expected: "/",
 			msg:      "empty value",
 		},
@@ -1538,22 +1538,22 @@ func TestGetPath(t *testing.T) {
 }
 
 func TestCreateFilters(t *testing.T) {
-	redirect1 := v1beta1.HTTPRouteFilter{
-		Type: v1beta1.HTTPRouteFilterRequestRedirect,
-		RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-			Hostname: helpers.GetPointer[v1beta1.PreciseHostname]("foo.example.com"),
+	redirect1 := v1.HTTPRouteFilter{
+		Type: v1.HTTPRouteFilterRequestRedirect,
+		RequestRedirect: &v1.HTTPRequestRedirectFilter{
+			Hostname: helpers.GetPointer[v1.PreciseHostname]("foo.example.com"),
 		},
 	}
-	redirect2 := v1beta1.HTTPRouteFilter{
-		Type: v1beta1.HTTPRouteFilterRequestRedirect,
-		RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-			Hostname: helpers.GetPointer[v1beta1.PreciseHostname]("bar.example.com"),
+	redirect2 := v1.HTTPRouteFilter{
+		Type: v1.HTTPRouteFilterRequestRedirect,
+		RequestRedirect: &v1.HTTPRequestRedirectFilter{
+			Hostname: helpers.GetPointer[v1.PreciseHostname]("bar.example.com"),
 		},
 	}
-	requestHeaderModifiers1 := v1beta1.HTTPRouteFilter{
-		Type: v1beta1.HTTPRouteFilterRequestHeaderModifier,
-		RequestHeaderModifier: &v1beta1.HTTPHeaderFilter{
-			Set: []v1beta1.HTTPHeader{
+	requestHeaderModifiers1 := v1.HTTPRouteFilter{
+		Type: v1.HTTPRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &v1.HTTPHeaderFilter{
+			Set: []v1.HTTPHeader{
 				{
 					Name:  "MyBespokeHeader",
 					Value: "my-value",
@@ -1561,10 +1561,10 @@ func TestCreateFilters(t *testing.T) {
 			},
 		},
 	}
-	requestHeaderModifiers2 := v1beta1.HTTPRouteFilter{
-		Type: v1beta1.HTTPRouteFilterRequestHeaderModifier,
-		RequestHeaderModifier: &v1beta1.HTTPHeaderFilter{
-			Add: []v1beta1.HTTPHeader{
+	requestHeaderModifiers2 := v1.HTTPRouteFilter{
+		Type: v1.HTTPRouteFilterRequestHeaderModifier,
+		RequestHeaderModifier: &v1.HTTPHeaderFilter{
+			Add: []v1.HTTPHeader{
 				{
 					Name:  "Content-Accepted",
 					Value: "gzip",
@@ -1588,15 +1588,15 @@ func TestCreateFilters(t *testing.T) {
 	tests := []struct {
 		expected HTTPFilters
 		msg      string
-		filters  []v1beta1.HTTPRouteFilter
+		filters  []v1.HTTPRouteFilter
 	}{
 		{
-			filters:  []v1beta1.HTTPRouteFilter{},
+			filters:  []v1.HTTPRouteFilter{},
 			expected: HTTPFilters{},
 			msg:      "no filters",
 		},
 		{
-			filters: []v1beta1.HTTPRouteFilter{
+			filters: []v1.HTTPRouteFilter{
 				redirect1,
 			},
 			expected: HTTPFilters{
@@ -1605,7 +1605,7 @@ func TestCreateFilters(t *testing.T) {
 			msg: "one filter",
 		},
 		{
-			filters: []v1beta1.HTTPRouteFilter{
+			filters: []v1.HTTPRouteFilter{
 				redirect1,
 				redirect2,
 			},
@@ -1615,7 +1615,7 @@ func TestCreateFilters(t *testing.T) {
 			msg: "two filters, first wins",
 		},
 		{
-			filters: []v1beta1.HTTPRouteFilter{
+			filters: []v1.HTTPRouteFilter{
 				redirect1,
 				redirect2,
 				requestHeaderModifiers1,
@@ -1627,7 +1627,7 @@ func TestCreateFilters(t *testing.T) {
 			msg: "two redirect filters, one request header modifier, first redirect wins",
 		},
 		{
-			filters: []v1beta1.HTTPRouteFilter{
+			filters: []v1.HTTPRouteFilter{
 				redirect1,
 				redirect2,
 				requestHeaderModifiers1,
@@ -1652,11 +1652,11 @@ func TestCreateFilters(t *testing.T) {
 }
 
 func TestGetListenerHostname(t *testing.T) {
-	var emptyHostname v1beta1.Hostname
-	var hostname v1beta1.Hostname = "example.com"
+	var emptyHostname v1.Hostname
+	var hostname v1.Hostname = "example.com"
 
 	tests := []struct {
-		hostname *v1beta1.Hostname
+		hostname *v1.Hostname
 		expected string
 		msg      string
 	}{
@@ -1948,50 +1948,50 @@ func TestBuildBackendGroups(t *testing.T) {
 
 func TestHostnameMoreSpecific(t *testing.T) {
 	tests := []struct {
-		host1     *v1beta1.Hostname
-		host2     *v1beta1.Hostname
+		host1     *v1.Hostname
+		host2     *v1.Hostname
 		msg       string
 		host1Wins bool
 	}{
 		{
 			host1:     nil,
-			host2:     helpers.GetPointer(v1beta1.Hostname("")),
+			host2:     helpers.GetPointer(v1.Hostname("")),
 			host1Wins: true,
 			msg:       "host1 nil; host2 empty",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("")),
+			host1:     helpers.GetPointer(v1.Hostname("")),
 			host2:     nil,
 			host1Wins: true,
 			msg:       "host1 empty; host2 nil",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("")),
-			host2:     helpers.GetPointer(v1beta1.Hostname("")),
+			host1:     helpers.GetPointer(v1.Hostname("")),
+			host2:     helpers.GetPointer(v1.Hostname("")),
 			host1Wins: true,
 			msg:       "both hosts empty",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("example.com")),
-			host2:     helpers.GetPointer(v1beta1.Hostname("")),
+			host1:     helpers.GetPointer(v1.Hostname("example.com")),
+			host2:     helpers.GetPointer(v1.Hostname("")),
 			host1Wins: true,
 			msg:       "host1 has value; host2 empty",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("")),
-			host2:     helpers.GetPointer(v1beta1.Hostname("example.com")),
+			host1:     helpers.GetPointer(v1.Hostname("")),
+			host2:     helpers.GetPointer(v1.Hostname("example.com")),
 			host1Wins: false,
 			msg:       "host2 has value; host1 empty",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("foo.example.com")),
-			host2:     helpers.GetPointer(v1beta1.Hostname("*.example.com")),
+			host1:     helpers.GetPointer(v1.Hostname("foo.example.com")),
+			host2:     helpers.GetPointer(v1.Hostname("*.example.com")),
 			host1Wins: true,
 			msg:       "host1 more specific than host2",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("*.example.com")),
-			host2:     helpers.GetPointer(v1beta1.Hostname("foo.example.com")),
+			host1:     helpers.GetPointer(v1.Hostname("*.example.com")),
+			host2:     helpers.GetPointer(v1.Hostname("foo.example.com")),
 			host1Wins: false,
 			msg:       "host2 more specific than host1",
 		},

--- a/internal/mode/static/state/dataplane/convert.go
+++ b/internal/mode/static/state/dataplane/convert.go
@@ -3,10 +3,10 @@ package dataplane
 import (
 	"fmt"
 
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func convertMatch(m v1beta1.HTTPRouteMatch) Match {
+func convertMatch(m v1.HTTPRouteMatch) Match {
 	match := Match{}
 
 	if m.Method != nil {
@@ -37,7 +37,7 @@ func convertMatch(m v1beta1.HTTPRouteMatch) Match {
 	return match
 }
 
-func convertHTTPRequestRedirectFilter(filter *v1beta1.HTTPRequestRedirectFilter) *HTTPRequestRedirectFilter {
+func convertHTTPRequestRedirectFilter(filter *v1.HTTPRequestRedirectFilter) *HTTPRequestRedirectFilter {
 	return &HTTPRequestRedirectFilter{
 		Scheme:     filter.Scheme,
 		Hostname:   (*string)(filter.Hostname),
@@ -46,7 +46,7 @@ func convertHTTPRequestRedirectFilter(filter *v1beta1.HTTPRequestRedirectFilter)
 	}
 }
 
-func convertHTTPHeaderFilter(filter *v1beta1.HTTPHeaderFilter) *HTTPHeaderFilter {
+func convertHTTPHeaderFilter(filter *v1.HTTPHeaderFilter) *HTTPHeaderFilter {
 	result := &HTTPHeaderFilter{
 		Remove: filter.Remove,
 	}
@@ -68,11 +68,11 @@ func convertHTTPHeaderFilter(filter *v1beta1.HTTPHeaderFilter) *HTTPHeaderFilter
 	return result
 }
 
-func convertPathType(pathType v1beta1.PathMatchType) PathType {
+func convertPathType(pathType v1.PathMatchType) PathType {
 	switch pathType {
-	case v1beta1.PathMatchPathPrefix:
+	case v1.PathMatchPathPrefix:
 		return PathTypePrefix
-	case v1beta1.PathMatchExact:
+	case v1.PathMatchExact:
 		return PathTypeExact
 	default:
 		panic(fmt.Sprintf("unsupported path type: %s", pathType))

--- a/internal/mode/static/state/dataplane/convert_test.go
+++ b/internal/mode/static/state/dataplane/convert_test.go
@@ -4,33 +4,33 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 )
 
 func TestConvertMatch(t *testing.T) {
-	path := v1beta1.HTTPPathMatch{
-		Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+	path := v1.HTTPPathMatch{
+		Type:  helpers.GetPointer(v1.PathMatchPathPrefix),
 		Value: helpers.GetPointer("/"),
 	}
 
 	tests := []struct {
-		match    v1beta1.HTTPRouteMatch
+		match    v1.HTTPRouteMatch
 		name     string
 		expected Match
 	}{
 		{
-			match: v1beta1.HTTPRouteMatch{
+			match: v1.HTTPRouteMatch{
 				Path: &path,
 			},
 			expected: Match{},
 			name:     "path only",
 		},
 		{
-			match: v1beta1.HTTPRouteMatch{
+			match: v1.HTTPRouteMatch{
 				Path:   &path,
-				Method: helpers.GetPointer(v1beta1.HTTPMethodGet),
+				Method: helpers.GetPointer(v1.HTTPMethodGet),
 			},
 			expected: Match{
 				Method: helpers.GetPointer("GET"),
@@ -38,9 +38,9 @@ func TestConvertMatch(t *testing.T) {
 			name: "path and method",
 		},
 		{
-			match: v1beta1.HTTPRouteMatch{
+			match: v1.HTTPRouteMatch{
 				Path: &path,
-				Headers: []v1beta1.HTTPHeaderMatch{
+				Headers: []v1.HTTPHeaderMatch{
 					{
 						Name:  "Test-Header",
 						Value: "test-header-value",
@@ -58,9 +58,9 @@ func TestConvertMatch(t *testing.T) {
 			name: "path and header",
 		},
 		{
-			match: v1beta1.HTTPRouteMatch{
+			match: v1.HTTPRouteMatch{
 				Path: &path,
-				QueryParams: []v1beta1.HTTPQueryParamMatch{
+				QueryParams: []v1.HTTPQueryParamMatch{
 					{
 						Name:  "Test-Param",
 						Value: "test-param-value",
@@ -78,16 +78,16 @@ func TestConvertMatch(t *testing.T) {
 			name: "path and query param",
 		},
 		{
-			match: v1beta1.HTTPRouteMatch{
+			match: v1.HTTPRouteMatch{
 				Path:   &path,
-				Method: helpers.GetPointer(v1beta1.HTTPMethodGet),
-				Headers: []v1beta1.HTTPHeaderMatch{
+				Method: helpers.GetPointer(v1.HTTPMethodGet),
+				Headers: []v1.HTTPHeaderMatch{
 					{
 						Name:  "Test-Header",
 						Value: "test-header-value",
 					},
 				},
-				QueryParams: []v1beta1.HTTPQueryParamMatch{
+				QueryParams: []v1.HTTPQueryParamMatch{
 					{
 						Name:  "Test-Param",
 						Value: "test-param-value",
@@ -125,20 +125,20 @@ func TestConvertMatch(t *testing.T) {
 
 func TestConvertHTTPRequestRedirectFilter(t *testing.T) {
 	tests := []struct {
-		filter   *v1beta1.HTTPRequestRedirectFilter
+		filter   *v1.HTTPRequestRedirectFilter
 		expected *HTTPRequestRedirectFilter
 		name     string
 	}{
 		{
-			filter:   &v1beta1.HTTPRequestRedirectFilter{},
+			filter:   &v1.HTTPRequestRedirectFilter{},
 			expected: &HTTPRequestRedirectFilter{},
 			name:     "empty",
 		},
 		{
-			filter: &v1beta1.HTTPRequestRedirectFilter{
+			filter: &v1.HTTPRequestRedirectFilter{
 				Scheme:     helpers.GetPointer("https"),
-				Hostname:   helpers.GetPointer[v1beta1.PreciseHostname]("example.com"),
-				Port:       helpers.GetPointer[v1beta1.PortNumber](8443),
+				Hostname:   helpers.GetPointer[v1.PreciseHostname]("example.com"),
+				Port:       helpers.GetPointer[v1.PortNumber](8443),
 				StatusCode: helpers.GetPointer(302),
 			},
 			expected: &HTTPRequestRedirectFilter{
@@ -163,22 +163,22 @@ func TestConvertHTTPRequestRedirectFilter(t *testing.T) {
 
 func TestConvertHTTPHeaderFilter(t *testing.T) {
 	tests := []struct {
-		filter   *v1beta1.HTTPHeaderFilter
+		filter   *v1.HTTPHeaderFilter
 		expected *HTTPHeaderFilter
 		name     string
 	}{
 		{
-			filter:   &v1beta1.HTTPHeaderFilter{},
+			filter:   &v1.HTTPHeaderFilter{},
 			expected: &HTTPHeaderFilter{},
 			name:     "empty",
 		},
 		{
-			filter: &v1beta1.HTTPHeaderFilter{
-				Set: []v1beta1.HTTPHeader{{
+			filter: &v1.HTTPHeaderFilter{
+				Set: []v1.HTTPHeader{{
 					Name:  "My-Set-Header",
 					Value: "my-value",
 				}},
-				Add: []v1beta1.HTTPHeader{{
+				Add: []v1.HTTPHeader{{
 					Name:  "My-Add-Header",
 					Value: "my-value",
 				}},
@@ -213,20 +213,20 @@ func TestConvertPathType(t *testing.T) {
 	g := NewWithT(t)
 
 	tests := []struct {
-		pathType v1beta1.PathMatchType
+		pathType v1.PathMatchType
 		expected PathType
 		panic    bool
 	}{
 		{
 			expected: PathTypePrefix,
-			pathType: v1beta1.PathMatchPathPrefix,
+			pathType: v1.PathMatchPathPrefix,
 		},
 		{
 			expected: PathTypeExact,
-			pathType: v1beta1.PathMatchExact,
+			pathType: v1.PathMatchExact,
 		},
 		{
-			pathType: v1beta1.PathMatchRegularExpression,
+			pathType: v1.PathMatchRegularExpression,
 			panic:    true,
 		},
 	}

--- a/internal/mode/static/state/graph/backend_refs.go
+++ b/internal/mode/static/state/graph/backend_refs.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
 	staticConds "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/conditions"
@@ -85,7 +85,7 @@ func addBackendRefsToRules(
 }
 
 func createBackendRef(
-	ref v1beta1.HTTPBackendRef,
+	ref gatewayv1.HTTPBackendRef,
 	sourceNamespace string,
 	refGrantResolver *referenceGrantResolver,
 	services map[types.NamespacedName]*v1.Service,
@@ -138,7 +138,7 @@ func createBackendRef(
 }
 
 func getServiceAndPortFromRef(
-	ref v1beta1.BackendRef,
+	ref gatewayv1.BackendRef,
 	routeNamespace string,
 	services map[types.NamespacedName]*v1.Service,
 	refPath *field.Path,
@@ -160,7 +160,7 @@ func getServiceAndPortFromRef(
 }
 
 func validateHTTPBackendRef(
-	ref v1beta1.HTTPBackendRef,
+	ref gatewayv1.HTTPBackendRef,
 	routeNs string,
 	refGrantResolver *referenceGrantResolver,
 	path *field.Path,
@@ -176,7 +176,7 @@ func validateHTTPBackendRef(
 }
 
 func validateBackendRef(
-	ref v1beta1.BackendRef,
+	ref gatewayv1.BackendRef,
 	routeNs string,
 	refGrantResolver *referenceGrantResolver,
 	path *field.Path,

--- a/internal/mode/static/state/graph/gateway.go
+++ b/internal/mode/static/state/graph/gateway.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
 	ngfsort "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/sort"
@@ -16,7 +16,7 @@ import (
 // Gateway represents the winning Gateway resource.
 type Gateway struct {
 	// Source is the corresponding Gateway resource.
-	Source *v1beta1.Gateway
+	Source *v1.Gateway
 	// Listeners include the listeners of the Gateway.
 	Listeners map[string]*Listener
 	// Conditions holds the conditions for the Gateway.
@@ -27,8 +27,8 @@ type Gateway struct {
 
 // processedGateways holds the resources that belong to NGF.
 type processedGateways struct {
-	Winner  *v1beta1.Gateway
-	Ignored map[types.NamespacedName]*v1beta1.Gateway
+	Winner  *v1.Gateway
+	Ignored map[types.NamespacedName]*v1.Gateway
 }
 
 // GetAllNsNames returns all the NamespacedNames of the Gateway resources that belong to NGF
@@ -57,10 +57,10 @@ func (gws processedGateways) GetAllNsNames() []types.NamespacedName {
 
 // processGateways determines which Gateway resource belong to NGF (determined by the Gateway GatewayClassName field).
 func processGateways(
-	gws map[types.NamespacedName]*v1beta1.Gateway,
+	gws map[types.NamespacedName]*v1.Gateway,
 	gcName string,
 ) processedGateways {
-	referencedGws := make([]*v1beta1.Gateway, 0, len(gws))
+	referencedGws := make([]*v1.Gateway, 0, len(gws))
 
 	for _, gw := range gws {
 		if string(gw.Spec.GatewayClassName) != gcName {
@@ -78,7 +78,7 @@ func processGateways(
 		return ngfsort.LessObjectMeta(&referencedGws[i].ObjectMeta, &referencedGws[j].ObjectMeta)
 	})
 
-	ignoredGws := make(map[types.NamespacedName]*v1beta1.Gateway)
+	ignoredGws := make(map[types.NamespacedName]*v1.Gateway)
 
 	for _, gw := range referencedGws[1:] {
 		ignoredGws[client.ObjectKeyFromObject(gw)] = gw
@@ -91,7 +91,7 @@ func processGateways(
 }
 
 func buildGateway(
-	gw *v1beta1.Gateway,
+	gw *v1.Gateway,
 	secretResolver *secretResolver,
 	gc *GatewayClass,
 	refGrantResolver *referenceGrantResolver,
@@ -118,7 +118,7 @@ func buildGateway(
 	}
 }
 
-func validateGateway(gw *v1beta1.Gateway, gc *GatewayClass) []conditions.Condition {
+func validateGateway(gw *v1.Gateway, gc *GatewayClass) []conditions.Condition {
 	var conds []conditions.Condition
 
 	if gc == nil {

--- a/internal/mode/static/state/graph/gateway_listener_test.go
+++ b/internal/mode/static/state/graph/gateway_listener_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
@@ -17,26 +17,26 @@ func TestValidateHTTPListener(t *testing.T) {
 	protectedPorts := ProtectedPorts{9113: "MetricsPort"}
 
 	tests := []struct {
-		l        v1beta1.Listener
+		l        v1.Listener
 		name     string
 		expected []conditions.Condition
 	}{
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 80,
 			},
 			expected: nil,
 			name:     "valid",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 0,
 			},
 			expected: staticConds.NewListenerUnsupportedValue(`port: Invalid value: 0: port must be between 1-65535`),
 			name:     "invalid port",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 9113,
 			},
 			expected: staticConds.NewListenerUnsupportedValue(
@@ -62,60 +62,60 @@ func TestValidateHTTPListener(t *testing.T) {
 func TestValidateHTTPSListener(t *testing.T) {
 	secretNs := "secret-ns"
 
-	validSecretRef := v1beta1.SecretObjectReference{
-		Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
+	validSecretRef := v1.SecretObjectReference{
+		Kind:      (*v1.Kind)(helpers.GetPointer("Secret")),
 		Name:      "secret",
-		Namespace: (*v1beta1.Namespace)(helpers.GetPointer(secretNs)),
+		Namespace: (*v1.Namespace)(helpers.GetPointer(secretNs)),
 	}
 
-	invalidSecretRefGroup := v1beta1.SecretObjectReference{
-		Group:     (*v1beta1.Group)(helpers.GetPointer("some-group")),
-		Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
+	invalidSecretRefGroup := v1.SecretObjectReference{
+		Group:     (*v1.Group)(helpers.GetPointer("some-group")),
+		Kind:      (*v1.Kind)(helpers.GetPointer("Secret")),
 		Name:      "secret",
-		Namespace: (*v1beta1.Namespace)(helpers.GetPointer(secretNs)),
+		Namespace: (*v1.Namespace)(helpers.GetPointer(secretNs)),
 	}
 
-	invalidSecretRefKind := v1beta1.SecretObjectReference{
-		Kind:      (*v1beta1.Kind)(helpers.GetPointer("ConfigMap")),
+	invalidSecretRefKind := v1.SecretObjectReference{
+		Kind:      (*v1.Kind)(helpers.GetPointer("ConfigMap")),
 		Name:      "secret",
-		Namespace: (*v1beta1.Namespace)(helpers.GetPointer(secretNs)),
+		Namespace: (*v1.Namespace)(helpers.GetPointer(secretNs)),
 	}
 
 	protectedPorts := ProtectedPorts{9113: "MetricsPort"}
 
 	tests := []struct {
-		l        v1beta1.Listener
+		l        v1.Listener
 		name     string
 		expected []conditions.Condition
 	}{
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 443,
-				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
-					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
+				TLS: &v1.GatewayTLSConfig{
+					Mode:            helpers.GetPointer(v1.TLSModeTerminate),
+					CertificateRefs: []v1.SecretObjectReference{validSecretRef},
 				},
 			},
 			expected: nil,
 			name:     "valid",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 0,
-				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
-					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
+				TLS: &v1.GatewayTLSConfig{
+					Mode:            helpers.GetPointer(v1.TLSModeTerminate),
+					CertificateRefs: []v1.SecretObjectReference{validSecretRef},
 				},
 			},
 			expected: staticConds.NewListenerUnsupportedValue(`port: Invalid value: 0: port must be between 1-65535`),
 			name:     "invalid port",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 9113,
-				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
-					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
+				TLS: &v1.GatewayTLSConfig{
+					Mode:            helpers.GetPointer(v1.TLSModeTerminate),
+					CertificateRefs: []v1.SecretObjectReference{validSecretRef},
 				},
 			},
 			expected: staticConds.NewListenerUnsupportedValue(
@@ -124,23 +124,23 @@ func TestValidateHTTPSListener(t *testing.T) {
 			name: "invalid protected port",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 443,
-				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
-					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
-					Options:         map[v1beta1.AnnotationKey]v1beta1.AnnotationValue{"key": "val"},
+				TLS: &v1.GatewayTLSConfig{
+					Mode:            helpers.GetPointer(v1.TLSModeTerminate),
+					CertificateRefs: []v1.SecretObjectReference{validSecretRef},
+					Options:         map[v1.AnnotationKey]v1.AnnotationValue{"key": "val"},
 				},
 			},
 			expected: staticConds.NewListenerUnsupportedValue("tls.options: Forbidden: options are not supported"),
 			name:     "invalid options",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 443,
-				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetPointer(v1beta1.TLSModePassthrough),
-					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
+				TLS: &v1.GatewayTLSConfig{
+					Mode:            helpers.GetPointer(v1.TLSModePassthrough),
+					CertificateRefs: []v1.SecretObjectReference{validSecretRef},
 				},
 			},
 			expected: staticConds.NewListenerUnsupportedValue(
@@ -149,11 +149,11 @@ func TestValidateHTTPSListener(t *testing.T) {
 			name: "invalid tls mode",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 443,
-				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
-					CertificateRefs: []v1beta1.SecretObjectReference{invalidSecretRefGroup},
+				TLS: &v1.GatewayTLSConfig{
+					Mode:            helpers.GetPointer(v1.TLSModeTerminate),
+					CertificateRefs: []v1.SecretObjectReference{invalidSecretRefGroup},
 				},
 			},
 			expected: staticConds.NewListenerInvalidCertificateRef(
@@ -162,11 +162,11 @@ func TestValidateHTTPSListener(t *testing.T) {
 			name: "invalid cert ref group",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 443,
-				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
-					CertificateRefs: []v1beta1.SecretObjectReference{invalidSecretRefKind},
+				TLS: &v1.GatewayTLSConfig{
+					Mode:            helpers.GetPointer(v1.TLSModeTerminate),
+					CertificateRefs: []v1.SecretObjectReference{invalidSecretRefKind},
 				},
 			},
 			expected: staticConds.NewListenerInvalidCertificateRef(
@@ -175,11 +175,11 @@ func TestValidateHTTPSListener(t *testing.T) {
 			name: "invalid cert ref kind",
 		},
 		{
-			l: v1beta1.Listener{
+			l: v1.Listener{
 				Port: 443,
-				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
-					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef, validSecretRef},
+				TLS: &v1.GatewayTLSConfig{
+					Mode:            helpers.GetPointer(v1.TLSModeTerminate),
+					CertificateRefs: []v1.SecretObjectReference{validSecretRef, validSecretRef},
 				},
 			},
 			expected: staticConds.NewListenerUnsupportedValue(
@@ -203,7 +203,7 @@ func TestValidateHTTPSListener(t *testing.T) {
 
 func TestValidateListenerHostname(t *testing.T) {
 	tests := []struct {
-		hostname  *v1beta1.Hostname
+		hostname  *v1.Hostname
 		name      string
 		expectErr bool
 	}{
@@ -213,22 +213,22 @@ func TestValidateListenerHostname(t *testing.T) {
 			name:      "nil hostname",
 		},
 		{
-			hostname:  (*v1beta1.Hostname)(helpers.GetPointer("")),
+			hostname:  (*v1.Hostname)(helpers.GetPointer("")),
 			expectErr: false,
 			name:      "empty hostname",
 		},
 		{
-			hostname:  (*v1beta1.Hostname)(helpers.GetPointer("foo.example.com")),
+			hostname:  (*v1.Hostname)(helpers.GetPointer("foo.example.com")),
 			expectErr: false,
 			name:      "valid hostname",
 		},
 		{
-			hostname:  (*v1beta1.Hostname)(helpers.GetPointer("*.example.com")),
+			hostname:  (*v1.Hostname)(helpers.GetPointer("*.example.com")),
 			expectErr: false,
 			name:      "wildcard hostname",
 		},
 		{
-			hostname:  (*v1beta1.Hostname)(helpers.GetPointer("example$com")),
+			hostname:  (*v1.Hostname)(helpers.GetPointer("example$com")),
 			expectErr: true,
 			name:      "invalid hostname",
 		},
@@ -238,7 +238,7 @@ func TestValidateListenerHostname(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			conds := validateListenerHostname(v1beta1.Listener{Hostname: test.hostname})
+			conds := validateListenerHostname(v1.Listener{Hostname: test.hostname})
 
 			if test.expectErr {
 				g.Expect(conds).ToNot(BeEmpty())
@@ -250,85 +250,85 @@ func TestValidateListenerHostname(t *testing.T) {
 }
 
 func TestGetAndValidateListenerSupportedKinds(t *testing.T) {
-	HTTPRouteGroupKind := []v1beta1.RouteGroupKind{
+	HTTPRouteGroupKind := []v1.RouteGroupKind{
 		{
 			Kind:  "HTTPRoute",
-			Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
+			Group: helpers.GetPointer[v1.Group](v1.GroupName),
 		},
 	}
-	TCPRouteGroupKind := []v1beta1.RouteGroupKind{
+	TCPRouteGroupKind := []v1.RouteGroupKind{
 		{
 			Kind:  "TCPRoute",
-			Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
+			Group: helpers.GetPointer[v1.Group](v1.GroupName),
 		},
 	}
 	tests := []struct {
-		protocol  v1beta1.ProtocolType
+		protocol  v1.ProtocolType
 		name      string
-		kind      []v1beta1.RouteGroupKind
-		expected  []v1beta1.RouteGroupKind
+		kind      []v1.RouteGroupKind
+		expected  []v1.RouteGroupKind
 		expectErr bool
 	}{
 		{
-			protocol:  v1beta1.TCPProtocolType,
+			protocol:  v1.TCPProtocolType,
 			expectErr: false,
 			name:      "unsupported protocol is ignored",
 			kind:      TCPRouteGroupKind,
-			expected:  []v1beta1.RouteGroupKind{},
+			expected:  []v1.RouteGroupKind{},
 		},
 		{
-			protocol: v1beta1.HTTPProtocolType,
-			kind: []v1beta1.RouteGroupKind{
+			protocol: v1.HTTPProtocolType,
+			kind: []v1.RouteGroupKind{
 				{
 					Kind:  "HTTPRoute",
-					Group: helpers.GetPointer[v1beta1.Group]("bad-group"),
+					Group: helpers.GetPointer[v1.Group]("bad-group"),
 				},
 			},
 			expectErr: true,
 			name:      "invalid group",
-			expected:  []v1beta1.RouteGroupKind{},
+			expected:  []v1.RouteGroupKind{},
 		},
 		{
-			protocol:  v1beta1.HTTPProtocolType,
+			protocol:  v1.HTTPProtocolType,
 			kind:      TCPRouteGroupKind,
 			expectErr: true,
 			name:      "invalid kind",
-			expected:  []v1beta1.RouteGroupKind{},
+			expected:  []v1.RouteGroupKind{},
 		},
 		{
-			protocol:  v1beta1.HTTPProtocolType,
+			protocol:  v1.HTTPProtocolType,
 			kind:      HTTPRouteGroupKind,
 			expectErr: false,
 			name:      "valid HTTP",
 			expected:  HTTPRouteGroupKind,
 		},
 		{
-			protocol:  v1beta1.HTTPSProtocolType,
+			protocol:  v1.HTTPSProtocolType,
 			kind:      HTTPRouteGroupKind,
 			expectErr: false,
 			name:      "valid HTTPS",
 			expected:  HTTPRouteGroupKind,
 		},
 		{
-			protocol:  v1beta1.HTTPSProtocolType,
+			protocol:  v1.HTTPSProtocolType,
 			expectErr: false,
 			name:      "valid HTTPS no kind specified",
-			expected: []v1beta1.RouteGroupKind{
+			expected: []v1.RouteGroupKind{
 				{
 					Kind: "HTTPRoute",
 				},
 			},
 		},
 		{
-			protocol: v1beta1.HTTPProtocolType,
-			kind: []v1beta1.RouteGroupKind{
+			protocol: v1.HTTPProtocolType,
+			kind: []v1.RouteGroupKind{
 				{
 					Kind:  "HTTPRoute",
-					Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
+					Group: helpers.GetPointer[v1.Group](v1.GroupName),
 				},
 				{
 					Kind:  "bad-kind",
-					Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
+					Group: helpers.GetPointer[v1.Group](v1.GroupName),
 				},
 			},
 			expectErr: true,
@@ -341,12 +341,12 @@ func TestGetAndValidateListenerSupportedKinds(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			listener := v1beta1.Listener{
+			listener := v1.Listener{
 				Protocol: test.protocol,
 			}
 
 			if test.kind != nil {
-				listener.AllowedRoutes = &v1beta1.AllowedRoutes{
+				listener.AllowedRoutes = &v1.AllowedRoutes{
 					Kinds: test.kind,
 				}
 			}
@@ -365,24 +365,24 @@ func TestGetAndValidateListenerSupportedKinds(t *testing.T) {
 func TestValidateListenerLabelSelector(t *testing.T) {
 	tests := []struct {
 		selector  *metav1.LabelSelector
-		from      v1beta1.FromNamespaces
+		from      v1.FromNamespaces
 		name      string
 		expectErr bool
 	}{
 		{
-			from:      v1beta1.NamespacesFromSelector,
+			from:      v1.NamespacesFromSelector,
 			selector:  &metav1.LabelSelector{},
 			expectErr: false,
 			name:      "valid spec",
 		},
 		{
-			from:      v1beta1.NamespacesFromSelector,
+			from:      v1.NamespacesFromSelector,
 			selector:  nil,
 			expectErr: true,
 			name:      "invalid spec",
 		},
 		{
-			from:      v1beta1.NamespacesFromAll,
+			from:      v1.NamespacesFromAll,
 			selector:  nil,
 			expectErr: false,
 			name:      "ignored from type",
@@ -396,9 +396,9 @@ func TestValidateListenerLabelSelector(t *testing.T) {
 			// create iteration variable inside the loop to fix implicit memory aliasing
 			from := test.from
 
-			listener := v1beta1.Listener{
-				AllowedRoutes: &v1beta1.AllowedRoutes{
-					Namespaces: &v1beta1.RouteNamespaces{
+			listener := v1.Listener{
+				AllowedRoutes: &v1.AllowedRoutes{
+					Namespaces: &v1.RouteNamespaces{
 						From:     &from,
 						Selector: test.selector,
 					},
@@ -416,8 +416,8 @@ func TestValidateListenerLabelSelector(t *testing.T) {
 }
 
 func TestValidateListenerPort(t *testing.T) {
-	validPorts := []v1beta1.PortNumber{1, 80, 443, 1000, 50000, 65535}
-	invalidPorts := []v1beta1.PortNumber{-1, 0, 65536, 80000, 9113}
+	validPorts := []v1.PortNumber{1, 80, 443, 1000, 50000, 65535}
+	invalidPorts := []v1.PortNumber{-1, 0, 65536, 80000, 9113}
 	protectedPorts := ProtectedPorts{9113: "MetricsPort"}
 
 	for _, p := range validPorts {

--- a/internal/mode/static/state/graph/gateway_test.go
+++ b/internal/mode/static/state/graph/gateway_test.go
@@ -10,20 +10,21 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 	staticConds "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/conditions"
 )
 
 func TestProcessedGatewaysGetAllNsNames(t *testing.T) {
-	winner := &v1beta1.Gateway{
+	winner := &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 			Name:      "gateway-1",
 		},
 	}
-	loser := &v1beta1.Gateway{
+	loser := &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 			Name:      "gateway-2",
@@ -43,7 +44,7 @@ func TestProcessedGatewaysGetAllNsNames(t *testing.T) {
 		{
 			gws: processedGateways{
 				Winner: winner,
-				Ignored: map[types.NamespacedName]*v1beta1.Gateway{
+				Ignored: map[types.NamespacedName]*v1.Gateway{
 					client.ObjectKeyFromObject(loser): loser,
 				},
 			},
@@ -67,27 +68,27 @@ func TestProcessedGatewaysGetAllNsNames(t *testing.T) {
 func TestProcessGateways(t *testing.T) {
 	const gcName = "test-gc"
 
-	winner := &v1beta1.Gateway{
+	winner := &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 			Name:      "gateway-1",
 		},
-		Spec: v1beta1.GatewaySpec{
+		Spec: v1.GatewaySpec{
 			GatewayClassName: gcName,
 		},
 	}
-	loser := &v1beta1.Gateway{
+	loser := &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 			Name:      "gateway-2",
 		},
-		Spec: v1beta1.GatewaySpec{
+		Spec: v1.GatewaySpec{
 			GatewayClassName: gcName,
 		},
 	}
 
 	tests := []struct {
-		gws      map[types.NamespacedName]*v1beta1.Gateway
+		gws      map[types.NamespacedName]*v1.Gateway
 		expected processedGateways
 		name     string
 	}{
@@ -97,32 +98,32 @@ func TestProcessGateways(t *testing.T) {
 			name:     "no gateways",
 		},
 		{
-			gws: map[types.NamespacedName]*v1beta1.Gateway{
+			gws: map[types.NamespacedName]*v1.Gateway{
 				{Namespace: "test", Name: "some-gateway"}: {
-					Spec: v1beta1.GatewaySpec{GatewayClassName: "some-class"},
+					Spec: v1.GatewaySpec{GatewayClassName: "some-class"},
 				},
 			},
 			expected: processedGateways{},
 			name:     "unrelated gateway",
 		},
 		{
-			gws: map[types.NamespacedName]*v1beta1.Gateway{
+			gws: map[types.NamespacedName]*v1.Gateway{
 				{Namespace: "test", Name: "gateway-1"}: winner,
 			},
 			expected: processedGateways{
 				Winner:  winner,
-				Ignored: map[types.NamespacedName]*v1beta1.Gateway{},
+				Ignored: map[types.NamespacedName]*v1.Gateway{},
 			},
 			name: "one gateway",
 		},
 		{
-			gws: map[types.NamespacedName]*v1beta1.Gateway{
+			gws: map[types.NamespacedName]*v1.Gateway{
 				{Namespace: "test", Name: "gateway-1"}: winner,
 				{Namespace: "test", Name: "gateway-2"}: loser,
 			},
 			expected: processedGateways{
 				Winner: winner,
-				Ignored: map[types.NamespacedName]*v1beta1.Gateway{
+				Ignored: map[types.NamespacedName]*v1.Gateway{
 					{Namespace: "test", Name: "gateway-2"}: loser,
 				},
 			},
@@ -148,17 +149,17 @@ func TestBuildGateway(t *testing.T) {
 	protectedPorts := ProtectedPorts{
 		9113: "MetricsPort",
 	}
-	listenerAllowedRoutes := v1beta1.Listener{
+	listenerAllowedRoutes := v1.Listener{
 		Name:     "listener-with-allowed-routes",
-		Hostname: helpers.GetPointer[v1beta1.Hostname]("foo.example.com"),
+		Hostname: helpers.GetPointer[v1.Hostname]("foo.example.com"),
 		Port:     80,
-		Protocol: v1beta1.HTTPProtocolType,
-		AllowedRoutes: &v1beta1.AllowedRoutes{
-			Kinds: []v1beta1.RouteGroupKind{
-				{Kind: "HTTPRoute", Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName)},
+		Protocol: v1.HTTPProtocolType,
+		AllowedRoutes: &v1.AllowedRoutes{
+			Kinds: []v1.RouteGroupKind{
+				{Kind: "HTTPRoute", Group: helpers.GetPointer[v1.Group](v1.GroupName)},
 			},
-			Namespaces: &v1beta1.RouteNamespaces{
-				From:     helpers.GetPointer(v1beta1.NamespacesFromSelector),
+			Namespaces: &v1.RouteNamespaces{
+				From:     helpers.GetPointer(v1.NamespacesFromSelector),
 				Selector: &metav1.LabelSelector{MatchLabels: labelSet},
 			},
 		},
@@ -183,24 +184,24 @@ func TestBuildGateway(t *testing.T) {
 		Type: apiv1.SecretTypeTLS,
 	}
 
-	gatewayTLSConfigSameNs := &v1beta1.GatewayTLSConfig{
-		Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
-		CertificateRefs: []v1beta1.SecretObjectReference{
+	gatewayTLSConfigSameNs := &v1.GatewayTLSConfig{
+		Mode: helpers.GetPointer(v1.TLSModeTerminate),
+		CertificateRefs: []v1.SecretObjectReference{
 			{
-				Kind:      helpers.GetPointer[v1beta1.Kind]("Secret"),
-				Name:      v1beta1.ObjectName(secretSameNs.Name),
-				Namespace: (*v1beta1.Namespace)(&secretSameNs.Namespace),
+				Kind:      helpers.GetPointer[v1.Kind]("Secret"),
+				Name:      v1.ObjectName(secretSameNs.Name),
+				Namespace: (*v1.Namespace)(&secretSameNs.Namespace),
 			},
 		},
 	}
 
-	tlsConfigInvalidSecret := &v1beta1.GatewayTLSConfig{
-		Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
-		CertificateRefs: []v1beta1.SecretObjectReference{
+	tlsConfigInvalidSecret := &v1.GatewayTLSConfig{
+		Mode: helpers.GetPointer(v1.TLSModeTerminate),
+		CertificateRefs: []v1.SecretObjectReference{
 			{
-				Kind:      helpers.GetPointer[v1beta1.Kind]("Secret"),
+				Kind:      helpers.GetPointer[v1.Kind]("Secret"),
 				Name:      "does-not-exist",
-				Namespace: helpers.GetPointer[v1beta1.Namespace]("test"),
+				Namespace: helpers.GetPointer[v1.Namespace]("test"),
 			},
 		},
 	}
@@ -217,13 +218,13 @@ func TestBuildGateway(t *testing.T) {
 		Type: apiv1.SecretTypeTLS,
 	}
 
-	gatewayTLSConfigDiffNs := &v1beta1.GatewayTLSConfig{
-		Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
-		CertificateRefs: []v1beta1.SecretObjectReference{
+	gatewayTLSConfigDiffNs := &v1.GatewayTLSConfig{
+		Mode: helpers.GetPointer(v1.TLSModeTerminate),
+		CertificateRefs: []v1.SecretObjectReference{
 			{
-				Kind:      helpers.GetPointer[v1beta1.Kind]("Secret"),
-				Name:      v1beta1.ObjectName(secretDiffNamespace.Name),
-				Namespace: (*v1beta1.Namespace)(&secretDiffNamespace.Namespace),
+				Kind:      helpers.GetPointer[v1.Kind]("Secret"),
+				Name:      v1.ObjectName(secretDiffNamespace.Name),
+				Namespace: (*v1.Namespace)(&secretDiffNamespace.Namespace),
 			},
 		},
 	}
@@ -232,25 +233,25 @@ func TestBuildGateway(t *testing.T) {
 		name string,
 		hostname string,
 		port int,
-		protocol v1beta1.ProtocolType,
-		tls *v1beta1.GatewayTLSConfig,
-	) v1beta1.Listener {
-		return v1beta1.Listener{
-			Name:     v1beta1.SectionName(name),
-			Hostname: (*v1beta1.Hostname)(helpers.GetPointer(hostname)),
-			Port:     v1beta1.PortNumber(port),
+		protocol v1.ProtocolType,
+		tls *v1.GatewayTLSConfig,
+	) v1.Listener {
+		return v1.Listener{
+			Name:     v1.SectionName(name),
+			Hostname: (*v1.Hostname)(helpers.GetPointer(hostname)),
+			Port:     v1.PortNumber(port),
 			Protocol: protocol,
 			TLS:      tls,
 		}
 	}
-	createHTTPListener := func(name, hostname string, port int) v1beta1.Listener {
-		return createListener(name, hostname, port, v1beta1.HTTPProtocolType, nil)
+	createHTTPListener := func(name, hostname string, port int) v1.Listener {
+		return createListener(name, hostname, port, v1.HTTPProtocolType, nil)
 	}
-	createTCPListener := func(name, hostname string, port int) v1beta1.Listener {
-		return createListener(name, hostname, port, v1beta1.TCPProtocolType, nil)
+	createTCPListener := func(name, hostname string, port int) v1.Listener {
+		return createListener(name, hostname, port, v1.TCPProtocolType, nil)
 	}
-	createHTTPSListener := func(name, hostname string, port int, tls *v1beta1.GatewayTLSConfig) v1beta1.Listener {
-		return createListener(name, hostname, port, v1beta1.HTTPSProtocolType, tls)
+	createHTTPSListener := func(name, hostname string, port int, tls *v1.GatewayTLSConfig) v1.Listener {
+		return createListener(name, hostname, port, v1.HTTPSProtocolType, tls)
 	}
 
 	// foo http listeners
@@ -312,17 +313,17 @@ func TestBuildGateway(t *testing.T) {
 	)
 
 	type gatewayCfg struct {
-		listeners []v1beta1.Listener
-		addresses []v1beta1.GatewayAddress
+		listeners []v1.Listener
+		addresses []v1.GatewayAddress
 	}
 
-	var lastCreatedGateway *v1beta1.Gateway
-	createGateway := func(cfg gatewayCfg) *v1beta1.Gateway {
-		lastCreatedGateway = &v1beta1.Gateway{
+	var lastCreatedGateway *v1.Gateway
+	createGateway := func(cfg gatewayCfg) *v1.Gateway {
+		lastCreatedGateway = &v1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test",
 			},
-			Spec: v1beta1.GatewaySpec{
+			Spec: v1.GatewaySpec{
 				GatewayClassName: gcName,
 				Listeners:        cfg.listeners,
 				Addresses:        cfg.addresses,
@@ -330,7 +331,7 @@ func TestBuildGateway(t *testing.T) {
 		}
 		return lastCreatedGateway
 	}
-	getLastCreatedGetaway := func() *v1beta1.Gateway {
+	getLastCreatedGetaway := func() *v1.Gateway {
 		return lastCreatedGateway
 	}
 
@@ -342,14 +343,14 @@ func TestBuildGateway(t *testing.T) {
 	}
 
 	tests := []struct {
-		gateway      *v1beta1.Gateway
+		gateway      *v1.Gateway
 		gatewayClass *GatewayClass
 		refGrants    map[types.NamespacedName]*v1beta1.ReferenceGrant
 		expected     *Gateway
 		name         string
 	}{
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{foo80Listener1, foo8080Listener}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1.Listener{foo80Listener1, foo8080Listener}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
@@ -358,7 +359,7 @@ func TestBuildGateway(t *testing.T) {
 						Source: foo80Listener1,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -366,7 +367,7 @@ func TestBuildGateway(t *testing.T) {
 						Source: foo8080Listener,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -377,7 +378,7 @@ func TestBuildGateway(t *testing.T) {
 		},
 		{
 			gateway: createGateway(
-				gatewayCfg{listeners: []v1beta1.Listener{foo443HTTPSListener1, foo8443HTTPSListener}},
+				gatewayCfg{listeners: []v1.Listener{foo443HTTPSListener1, foo8443HTTPSListener}},
 			),
 			gatewayClass: validGC,
 			expected: &Gateway{
@@ -388,7 +389,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:          true,
 						Routes:         map[types.NamespacedName]*Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -397,7 +398,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:          true,
 						Routes:         map[types.NamespacedName]*Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -407,7 +408,7 @@ func TestBuildGateway(t *testing.T) {
 			name: "valid https listeners",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listenerAllowedRoutes}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1.Listener{listenerAllowedRoutes}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
@@ -417,8 +418,8 @@ func TestBuildGateway(t *testing.T) {
 						Valid:                     true,
 						AllowedRouteLabelSelector: labels.SelectorFromSet(labels.Set(labelSet)),
 						Routes:                    map[types.NamespacedName]*Route{},
-						SupportedKinds: []v1beta1.RouteGroupKind{
-							{Kind: "HTTPRoute", Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName)},
+						SupportedKinds: []v1.RouteGroupKind{
+							{Kind: "HTTPRoute", Group: helpers.GetPointer[v1.Group](v1.GroupName)},
 						},
 					},
 				},
@@ -427,7 +428,7 @@ func TestBuildGateway(t *testing.T) {
 			name: "valid http listener with allowed routes label selector",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{crossNamespaceSecretListener}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1.Listener{crossNamespaceSecretListener}}),
 			gatewayClass: validGC,
 			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
 				{Name: "ref-grant", Namespace: "diff-ns"}: {
@@ -438,7 +439,7 @@ func TestBuildGateway(t *testing.T) {
 					Spec: v1beta1.ReferenceGrantSpec{
 						From: []v1beta1.ReferenceGrantFrom{
 							{
-								Group:     v1beta1.GroupName,
+								Group:     v1.GroupName,
 								Kind:      "Gateway",
 								Namespace: "test",
 							},
@@ -447,7 +448,7 @@ func TestBuildGateway(t *testing.T) {
 							{
 								Group: "core",
 								Kind:  "Secret",
-								Name:  helpers.GetPointer[v1beta1.ObjectName]("secret"),
+								Name:  helpers.GetPointer[v1.ObjectName]("secret"),
 							},
 						},
 					},
@@ -461,7 +462,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:          true,
 						Routes:         map[types.NamespacedName]*Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretDiffNamespace)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -471,7 +472,7 @@ func TestBuildGateway(t *testing.T) {
 			name: "valid https listener with cross-namespace secret; allowed by reference grant",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{crossNamespaceSecretListener}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1.Listener{crossNamespaceSecretListener}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
@@ -483,7 +484,7 @@ func TestBuildGateway(t *testing.T) {
 							`Certificate ref to secret diff-ns/secret not permitted by any ReferenceGrant`,
 						),
 						Routes: map[types.NamespacedName]*Route{},
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -493,7 +494,7 @@ func TestBuildGateway(t *testing.T) {
 			name: "invalid https listener with cross-namespace secret; no reference grant",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listenerInvalidSelector}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1.Listener{listenerInvalidSelector}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
@@ -504,8 +505,8 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedValue(
 							`invalid label selector: "invalid" is not a valid label selector operator`,
 						),
-						SupportedKinds: []v1beta1.RouteGroupKind{
-							{Kind: "HTTPRoute", Group: helpers.GetPointer[v1beta1.Group](v1beta1.GroupName)},
+						SupportedKinds: []v1.RouteGroupKind{
+							{Kind: "HTTPRoute", Group: helpers.GetPointer[v1.Group](v1.GroupName)},
 						},
 					},
 				},
@@ -514,7 +515,7 @@ func TestBuildGateway(t *testing.T) {
 			name: "http listener with invalid label selector",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{invalidProtocolListener}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1.Listener{invalidProtocolListener}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
@@ -525,7 +526,7 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedProtocol(
 							`protocol: Unsupported value: "TCP": supported values: "HTTP", "HTTPS"`,
 						),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -537,7 +538,7 @@ func TestBuildGateway(t *testing.T) {
 		{
 			gateway: createGateway(
 				gatewayCfg{
-					listeners: []v1beta1.Listener{
+					listeners: []v1.Listener{
 						invalidPortListener,
 						invalidHTTPSPortListener,
 						invalidProtectedPortListener,
@@ -554,7 +555,7 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedValue(
 							`port: Invalid value: 0: port must be between 1-65535`,
 						),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -564,7 +565,7 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedValue(
 							`port: Invalid value: 0: port must be between 1-65535`,
 						),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -574,7 +575,7 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedValue(
 							`port: Invalid value: 9113: port is already in use as MetricsPort`,
 						),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -585,7 +586,7 @@ func TestBuildGateway(t *testing.T) {
 		},
 		{
 			gateway: createGateway(
-				gatewayCfg{listeners: []v1beta1.Listener{invalidHostnameListener, invalidHTTPSHostnameListener}},
+				gatewayCfg{listeners: []v1.Listener{invalidHostnameListener, invalidHTTPSHostnameListener}},
 			),
 			gatewayClass: validGC,
 			expected: &Gateway{
@@ -595,7 +596,7 @@ func TestBuildGateway(t *testing.T) {
 						Source:     invalidHostnameListener,
 						Valid:      false,
 						Conditions: staticConds.NewListenerUnsupportedValue(invalidHostnameMsg),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -603,7 +604,7 @@ func TestBuildGateway(t *testing.T) {
 						Source:     invalidHTTPSHostnameListener,
 						Valid:      false,
 						Conditions: staticConds.NewListenerUnsupportedValue(invalidHostnameMsg),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -613,7 +614,7 @@ func TestBuildGateway(t *testing.T) {
 			name: "invalid hostnames",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{invalidTLSConfigListener}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1.Listener{invalidTLSConfigListener}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
@@ -625,7 +626,7 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerInvalidCertificateRef(
 							`tls.certificateRefs[0]: Invalid value: test/does-not-exist: secret does not exist`,
 						),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -637,7 +638,7 @@ func TestBuildGateway(t *testing.T) {
 		{
 			gateway: createGateway(
 				gatewayCfg{
-					listeners: []v1beta1.Listener{
+					listeners: []v1.Listener{
 						foo80Listener1,
 						foo8080Listener,
 						foo8081Listener,
@@ -657,7 +658,7 @@ func TestBuildGateway(t *testing.T) {
 						Source: foo80Listener1,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -665,7 +666,7 @@ func TestBuildGateway(t *testing.T) {
 						Source: foo8080Listener,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -673,7 +674,7 @@ func TestBuildGateway(t *testing.T) {
 						Source: foo8081Listener,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -681,7 +682,7 @@ func TestBuildGateway(t *testing.T) {
 						Source: bar80Listener,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -690,7 +691,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:          true,
 						Routes:         map[types.NamespacedName]*Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -699,7 +700,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:          true,
 						Routes:         map[types.NamespacedName]*Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -708,7 +709,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:          true,
 						Routes:         map[types.NamespacedName]*Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -717,7 +718,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:          true,
 						Routes:         map[types.NamespacedName]*Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -729,7 +730,7 @@ func TestBuildGateway(t *testing.T) {
 		{
 			gateway: createGateway(
 				gatewayCfg{
-					listeners: []v1beta1.Listener{
+					listeners: []v1.Listener{
 						foo80Listener1,
 						bar80Listener,
 						foo443Listener,
@@ -748,7 +749,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:      false,
 						Routes:     map[types.NamespacedName]*Route{},
 						Conditions: staticConds.NewListenerProtocolConflict(conflict80PortMsg),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -757,7 +758,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:      false,
 						Routes:     map[types.NamespacedName]*Route{},
 						Conditions: staticConds.NewListenerProtocolConflict(conflict80PortMsg),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -766,7 +767,7 @@ func TestBuildGateway(t *testing.T) {
 						Valid:      false,
 						Routes:     map[types.NamespacedName]*Route{},
 						Conditions: staticConds.NewListenerProtocolConflict(conflict443PortMsg),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -776,7 +777,7 @@ func TestBuildGateway(t *testing.T) {
 						Routes:         map[types.NamespacedName]*Route{},
 						Conditions:     staticConds.NewListenerProtocolConflict(conflict80PortMsg),
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -786,7 +787,7 @@ func TestBuildGateway(t *testing.T) {
 						Routes:         map[types.NamespacedName]*Route{},
 						Conditions:     staticConds.NewListenerProtocolConflict(conflict443PortMsg),
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -796,7 +797,7 @@ func TestBuildGateway(t *testing.T) {
 						Routes:         map[types.NamespacedName]*Route{},
 						Conditions:     staticConds.NewListenerProtocolConflict(conflict443PortMsg),
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1beta1.RouteGroupKind{
+						SupportedKinds: []v1.RouteGroupKind{
 							{Kind: "HTTPRoute"},
 						},
 					},
@@ -808,8 +809,8 @@ func TestBuildGateway(t *testing.T) {
 		{
 			gateway: createGateway(
 				gatewayCfg{
-					listeners: []v1beta1.Listener{foo80Listener1, foo443HTTPSListener1},
-					addresses: []v1beta1.GatewayAddress{{}},
+					listeners: []v1.Listener{foo80Listener1, foo443HTTPSListener1},
+					addresses: []v1.GatewayAddress{{}},
 				},
 			),
 			gatewayClass: validGC,
@@ -829,7 +830,7 @@ func TestBuildGateway(t *testing.T) {
 		},
 		{
 			gateway: createGateway(
-				gatewayCfg{listeners: []v1beta1.Listener{foo80Listener1, invalidProtocolListener}},
+				gatewayCfg{listeners: []v1.Listener{foo80Listener1, invalidProtocolListener}},
 			),
 			gatewayClass: invalidGC,
 			expected: &Gateway{
@@ -841,7 +842,7 @@ func TestBuildGateway(t *testing.T) {
 		},
 		{
 			gateway: createGateway(
-				gatewayCfg{listeners: []v1beta1.Listener{foo80Listener1, invalidProtocolListener}},
+				gatewayCfg{listeners: []v1.Listener{foo80Listener1, invalidProtocolListener}},
 			),
 			gatewayClass: nil,
 			expected: &Gateway{

--- a/internal/mode/static/state/graph/gatewayclass.go
+++ b/internal/mode/static/state/graph/gatewayclass.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
 	staticConds "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/conditions"
@@ -13,7 +13,7 @@ import (
 // GatewayClass represents the GatewayClass resource.
 type GatewayClass struct {
 	// Source is the source resource.
-	Source *v1beta1.GatewayClass
+	Source *v1.GatewayClass
 	// Conditions include Conditions for the GatewayClass.
 	Conditions []conditions.Condition
 	// Valid shows whether the GatewayClass is valid.
@@ -22,8 +22,8 @@ type GatewayClass struct {
 
 // processedGatewayClasses holds the resources that belong to NGF.
 type processedGatewayClasses struct {
-	Winner  *v1beta1.GatewayClass
-	Ignored map[types.NamespacedName]*v1beta1.GatewayClass
+	Winner  *v1.GatewayClass
+	Ignored map[types.NamespacedName]*v1.GatewayClass
 }
 
 // processGatewayClasses returns the "Winner" GatewayClass, which is defined in
@@ -32,7 +32,7 @@ type processedGatewayClasses struct {
 // Also returns a boolean that says whether or not the GatewayClass defined
 // in the command-line argument exists, regardless of which controller it references.
 func processGatewayClasses(
-	gcs map[types.NamespacedName]*v1beta1.GatewayClass,
+	gcs map[types.NamespacedName]*v1.GatewayClass,
 	gcName string,
 	controllerName string,
 ) (processedGatewayClasses, bool) {
@@ -47,7 +47,7 @@ func processGatewayClasses(
 			}
 		} else if string(gc.Spec.ControllerName) == controllerName {
 			if processedGwClasses.Ignored == nil {
-				processedGwClasses.Ignored = make(map[types.NamespacedName]*v1beta1.GatewayClass)
+				processedGwClasses.Ignored = make(map[types.NamespacedName]*v1.GatewayClass)
 			}
 			processedGwClasses.Ignored[client.ObjectKeyFromObject(gc)] = gc
 		}
@@ -56,7 +56,7 @@ func processGatewayClasses(
 	return processedGwClasses, gcExists
 }
 
-func buildGatewayClass(gc *v1beta1.GatewayClass) *GatewayClass {
+func buildGatewayClass(gc *v1.GatewayClass) *GatewayClass {
 	if gc == nil {
 		return nil
 	}
@@ -75,7 +75,7 @@ func buildGatewayClass(gc *v1beta1.GatewayClass) *GatewayClass {
 	}
 }
 
-func validateGatewayClass(gc *v1beta1.GatewayClass) error {
+func validateGatewayClass(gc *v1.GatewayClass) error {
 	if gc.Spec.ParametersRef != nil {
 		path := field.NewPath("spec").Child("parametersRef")
 		return field.Forbidden(path, "parametersRef is not supported")

--- a/internal/mode/static/state/graph/gatewayclass_test.go
+++ b/internal/mode/static/state/graph/gatewayclass_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
@@ -17,26 +17,26 @@ import (
 func TestProcessGatewayClasses(t *testing.T) {
 	gcName := "test-gc"
 	ctlrName := "test-ctlr"
-	winner := &v1beta1.GatewayClass{
+	winner := &v1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: gcName,
 		},
-		Spec: v1beta1.GatewayClassSpec{
-			ControllerName: v1beta1.GatewayController(ctlrName),
+		Spec: v1.GatewayClassSpec{
+			ControllerName: v1.GatewayController(ctlrName),
 		},
 	}
-	ignored := &v1beta1.GatewayClass{
+	ignored := &v1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-gc-ignored",
 		},
-		Spec: v1beta1.GatewayClassSpec{
-			ControllerName: v1beta1.GatewayController(ctlrName),
+		Spec: v1.GatewayClassSpec{
+			ControllerName: v1.GatewayController(ctlrName),
 		},
 	}
 
 	tests := []struct {
 		expected processedGatewayClasses
-		gcs      map[types.NamespacedName]*v1beta1.GatewayClass
+		gcs      map[types.NamespacedName]*v1.GatewayClass
 		name     string
 		exists   bool
 	}{
@@ -46,7 +46,7 @@ func TestProcessGatewayClasses(t *testing.T) {
 			name:     "no gatewayclasses",
 		},
 		{
-			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+			gcs: map[types.NamespacedName]*v1.GatewayClass{
 				{Name: gcName}: winner,
 			},
 			expected: processedGatewayClasses{
@@ -56,13 +56,13 @@ func TestProcessGatewayClasses(t *testing.T) {
 			name:   "one valid gatewayclass",
 		},
 		{
-			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+			gcs: map[types.NamespacedName]*v1.GatewayClass{
 				{Name: gcName}: {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: gcName,
 					},
-					Spec: v1beta1.GatewayClassSpec{
-						ControllerName: v1beta1.GatewayController("not ours"),
+					Spec: v1.GatewayClassSpec{
+						ControllerName: v1.GatewayController("not ours"),
 					},
 				},
 			},
@@ -71,21 +71,21 @@ func TestProcessGatewayClasses(t *testing.T) {
 			name:     "one valid gatewayclass, but references wrong controller",
 		},
 		{
-			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+			gcs: map[types.NamespacedName]*v1.GatewayClass{
 				{Name: ignored.Name}: ignored,
 			},
 			expected: processedGatewayClasses{
-				Ignored: map[types.NamespacedName]*v1beta1.GatewayClass{
+				Ignored: map[types.NamespacedName]*v1.GatewayClass{
 					client.ObjectKeyFromObject(ignored): ignored,
 				},
 			},
 			name: "one non-referenced gatewayclass with our controller",
 		},
 		{
-			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+			gcs: map[types.NamespacedName]*v1.GatewayClass{
 				{Name: "completely ignored"}: {
-					Spec: v1beta1.GatewayClassSpec{
-						ControllerName: v1beta1.GatewayController("not ours"),
+					Spec: v1.GatewayClassSpec{
+						ControllerName: v1.GatewayController("not ours"),
 					},
 				},
 			},
@@ -93,13 +93,13 @@ func TestProcessGatewayClasses(t *testing.T) {
 			name:     "one non-referenced gatewayclass without our controller",
 		},
 		{
-			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+			gcs: map[types.NamespacedName]*v1.GatewayClass{
 				{Name: gcName}:       winner,
 				{Name: ignored.Name}: ignored,
 			},
 			expected: processedGatewayClasses{
 				Winner: winner,
-				Ignored: map[types.NamespacedName]*v1beta1.GatewayClass{
+				Ignored: map[types.NamespacedName]*v1.GatewayClass{
 					client.ObjectKeyFromObject(ignored): ignored,
 				},
 			},
@@ -119,16 +119,16 @@ func TestProcessGatewayClasses(t *testing.T) {
 }
 
 func TestBuildGatewayClass(t *testing.T) {
-	validGC := &v1beta1.GatewayClass{}
+	validGC := &v1.GatewayClass{}
 
-	invalidGC := &v1beta1.GatewayClass{
-		Spec: v1beta1.GatewayClassSpec{
-			ParametersRef: &v1beta1.ParametersReference{},
+	invalidGC := &v1.GatewayClass{
+		Spec: v1.GatewayClassSpec{
+			ParametersRef: &v1.ParametersReference{},
 		},
 	}
 
 	tests := []struct {
-		gc       *v1beta1.GatewayClass
+		gc       *v1.GatewayClass
 		expected *GatewayClass
 		name     string
 	}{

--- a/internal/mode/static/state/graph/graph.go
+++ b/internal/mode/static/state/graph/graph.go
@@ -4,6 +4,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/validation"
@@ -11,9 +12,9 @@ import (
 
 // ClusterState includes cluster resources necessary to build the Graph.
 type ClusterState struct {
-	GatewayClasses  map[types.NamespacedName]*v1beta1.GatewayClass
-	Gateways        map[types.NamespacedName]*v1beta1.Gateway
-	HTTPRoutes      map[types.NamespacedName]*v1beta1.HTTPRoute
+	GatewayClasses  map[types.NamespacedName]*gatewayv1.GatewayClass
+	Gateways        map[types.NamespacedName]*gatewayv1.Gateway
+	HTTPRoutes      map[types.NamespacedName]*gatewayv1.HTTPRoute
 	Services        map[types.NamespacedName]*v1.Service
 	Namespaces      map[types.NamespacedName]*v1.Namespace
 	ReferenceGrants map[types.NamespacedName]*v1beta1.ReferenceGrant
@@ -29,11 +30,11 @@ type Graph struct {
 	// IgnoredGatewayClasses holds the ignored GatewayClass resources, which reference NGINX Gateway Fabric in the
 	// controllerName, but are not configured via the NGINX Gateway Fabric CLI argument. It doesn't hold the GatewayClass
 	// resources that do not belong to the NGINX Gateway Fabric.
-	IgnoredGatewayClasses map[types.NamespacedName]*v1beta1.GatewayClass
+	IgnoredGatewayClasses map[types.NamespacedName]*gatewayv1.GatewayClass
 	// IgnoredGateways holds the ignored Gateway resources, which belong to the NGINX Gateway Fabric (based on the
 	// GatewayClassName field of the resource) but ignored. It doesn't hold the Gateway resources that do not belong to
 	// the NGINX Gateway Fabric.
-	IgnoredGateways map[types.NamespacedName]*v1beta1.Gateway
+	IgnoredGateways map[types.NamespacedName]*gatewayv1.Gateway
 	// Routes holds Route resources.
 	Routes map[types.NamespacedName]*Route
 	// ReferencedSecrets includes Secrets referenced by Gateway Listeners, including invalid ones.

--- a/internal/mode/static/state/graph/graph_test.go
+++ b/internal/mode/static/state/graph/graph_test.go
@@ -9,7 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/validation"
@@ -35,43 +36,43 @@ func TestBuildGraph(t *testing.T) {
 		}
 	}
 
-	createRoute := func(name string, gatewayName string, listenerName string) *v1beta1.HTTPRoute {
-		return &v1beta1.HTTPRoute{
+	createRoute := func(name string, gatewayName string, listenerName string) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test",
 				Name:      name,
 			},
-			Spec: v1beta1.HTTPRouteSpec{
-				CommonRouteSpec: v1beta1.CommonRouteSpec{
-					ParentRefs: []v1beta1.ParentReference{
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
 						{
-							Namespace:   (*v1beta1.Namespace)(helpers.GetPointer("test")),
-							Name:        v1beta1.ObjectName(gatewayName),
-							SectionName: (*v1beta1.SectionName)(helpers.GetPointer(listenerName)),
+							Namespace:   (*gatewayv1.Namespace)(helpers.GetPointer("test")),
+							Name:        gatewayv1.ObjectName(gatewayName),
+							SectionName: (*gatewayv1.SectionName)(helpers.GetPointer(listenerName)),
 						},
 					},
 				},
-				Hostnames: []v1beta1.Hostname{
+				Hostnames: []gatewayv1.Hostname{
 					"foo.example.com",
 				},
-				Rules: []v1beta1.HTTPRouteRule{
+				Rules: []gatewayv1.HTTPRouteRule{
 					{
-						Matches: []v1beta1.HTTPRouteMatch{
+						Matches: []gatewayv1.HTTPRouteMatch{
 							{
-								Path: &v1beta1.HTTPPathMatch{
-									Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+								Path: &gatewayv1.HTTPPathMatch{
+									Type:  helpers.GetPointer(gatewayv1.PathMatchPathPrefix),
 									Value: helpers.GetPointer("/"),
 								},
 							},
 						},
-						BackendRefs: []v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
 							{
-								BackendRef: v1beta1.BackendRef{
-									BackendObjectReference: v1beta1.BackendObjectReference{
-										Kind:      (*v1beta1.Kind)(helpers.GetPointer("Service")),
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Kind:      (*gatewayv1.Kind)(helpers.GetPointer("Service")),
 										Name:      "foo",
-										Namespace: (*v1beta1.Namespace)(helpers.GetPointer("service")),
-										Port:      (*v1beta1.PortNumber)(helpers.GetPointer[int32](80)),
+										Namespace: (*gatewayv1.Namespace)(helpers.GetPointer("service")),
+										Port:      (*gatewayv1.PortNumber)(helpers.GetPointer[int32](80)),
 									},
 								},
 							},
@@ -118,37 +119,37 @@ func TestBuildGraph(t *testing.T) {
 		Type: v1.SecretTypeTLS,
 	}
 
-	createGateway := func(name string) *v1beta1.Gateway {
-		return &v1beta1.Gateway{
+	createGateway := func(name string) *gatewayv1.Gateway {
+		return &gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test",
 				Name:      name,
 			},
-			Spec: v1beta1.GatewaySpec{
+			Spec: gatewayv1.GatewaySpec{
 				GatewayClassName: gcName,
-				Listeners: []v1beta1.Listener{
+				Listeners: []gatewayv1.Listener{
 					{
 						Name:     "listener-80-1",
 						Hostname: nil,
 						Port:     80,
-						Protocol: v1beta1.HTTPProtocolType,
+						Protocol: gatewayv1.HTTPProtocolType,
 					},
 
 					{
 						Name:     "listener-443-1",
 						Hostname: nil,
 						Port:     443,
-						TLS: &v1beta1.GatewayTLSConfig{
-							Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
-							CertificateRefs: []v1beta1.SecretObjectReference{
+						TLS: &gatewayv1.GatewayTLSConfig{
+							Mode: helpers.GetPointer(gatewayv1.TLSModeTerminate),
+							CertificateRefs: []gatewayv1.SecretObjectReference{
 								{
-									Kind:      helpers.GetPointer[v1beta1.Kind]("Secret"),
-									Name:      v1beta1.ObjectName(secret.Name),
+									Kind:      helpers.GetPointer[gatewayv1.Kind]("Secret"),
+									Name:      gatewayv1.ObjectName(secret.Name),
 									Namespace: helpers.GetPointer(v1beta1.Namespace(secret.Namespace)),
 								},
 							},
 						},
-						Protocol: v1beta1.HTTPSProtocolType,
+						Protocol: gatewayv1.HTTPSProtocolType,
 					},
 				},
 			},
@@ -168,7 +169,7 @@ func TestBuildGraph(t *testing.T) {
 		Spec: v1beta1.ReferenceGrantSpec{
 			From: []v1beta1.ReferenceGrantFrom{
 				{
-					Group:     v1beta1.GroupName,
+					Group:     gatewayv1.GroupName,
 					Kind:      "Gateway",
 					Namespace: "test",
 				},
@@ -189,7 +190,7 @@ func TestBuildGraph(t *testing.T) {
 		Spec: v1beta1.ReferenceGrantSpec{
 			From: []v1beta1.ReferenceGrantFrom{
 				{
-					Group:     v1beta1.GroupName,
+					Group:     gatewayv1.GroupName,
 					Kind:      "HTTPRoute",
 					Namespace: "test",
 				},
@@ -202,16 +203,16 @@ func TestBuildGraph(t *testing.T) {
 		},
 	}
 
-	createStateWithGatewayClass := func(gc *v1beta1.GatewayClass) ClusterState {
+	createStateWithGatewayClass := func(gc *gatewayv1.GatewayClass) ClusterState {
 		return ClusterState{
-			GatewayClasses: map[types.NamespacedName]*v1beta1.GatewayClass{
+			GatewayClasses: map[types.NamespacedName]*gatewayv1.GatewayClass{
 				client.ObjectKeyFromObject(gc): gc,
 			},
-			Gateways: map[types.NamespacedName]*v1beta1.Gateway{
+			Gateways: map[types.NamespacedName]*gatewayv1.Gateway{
 				client.ObjectKeyFromObject(gw1): gw1,
 				client.ObjectKeyFromObject(gw2): gw2,
 			},
-			HTTPRoutes: map[types.NamespacedName]*v1beta1.HTTPRoute{
+			HTTPRoutes: map[types.NamespacedName]*gatewayv1.HTTPRoute{
 				client.ObjectKeyFromObject(hr1): hr1,
 				client.ObjectKeyFromObject(hr2): hr2,
 				client.ObjectKeyFromObject(hr3): hr3,
@@ -261,7 +262,7 @@ func TestBuildGraph(t *testing.T) {
 		Rules: []Rule{createValidRuleWithBackendRefs(hr3Refs)},
 	}
 
-	createExpectedGraphWithGatewayClass := func(gc *v1beta1.GatewayClass) *Graph {
+	createExpectedGraphWithGatewayClass := func(gc *gatewayv1.GatewayClass) *Graph {
 		return &Graph{
 			GatewayClass: &GatewayClass{
 				Source: gc,
@@ -276,7 +277,7 @@ func TestBuildGraph(t *testing.T) {
 						Routes: map[types.NamespacedName]*Route{
 							{Namespace: "test", Name: "hr-1"}: routeHR1,
 						},
-						SupportedKinds: []v1beta1.RouteGroupKind{{Kind: "HTTPRoute"}},
+						SupportedKinds: []gatewayv1.RouteGroupKind{{Kind: "HTTPRoute"}},
 					},
 					"listener-443-1": {
 						Source: gw1.Spec.Listeners[1],
@@ -285,12 +286,12 @@ func TestBuildGraph(t *testing.T) {
 							{Namespace: "test", Name: "hr-3"}: routeHR3,
 						},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secret)),
-						SupportedKinds: []v1beta1.RouteGroupKind{{Kind: "HTTPRoute"}},
+						SupportedKinds: []gatewayv1.RouteGroupKind{{Kind: "HTTPRoute"}},
 					},
 				},
 				Valid: true,
 			},
-			IgnoredGateways: map[types.NamespacedName]*v1beta1.Gateway{
+			IgnoredGateways: map[types.NamespacedName]*gatewayv1.Gateway{
 				{Namespace: "test", Name: "gateway-2"}: gw2,
 			},
 			Routes: map[types.NamespacedName]*Route{
@@ -305,19 +306,19 @@ func TestBuildGraph(t *testing.T) {
 		}
 	}
 
-	normalGC := &v1beta1.GatewayClass{
+	normalGC := &gatewayv1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: gcName,
 		},
-		Spec: v1beta1.GatewayClassSpec{
+		Spec: gatewayv1.GatewayClassSpec{
 			ControllerName: controllerName,
 		},
 	}
-	differentControllerGC := &v1beta1.GatewayClass{
+	differentControllerGC := &gatewayv1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: gcName,
 		},
-		Spec: v1beta1.GatewayClassSpec{
+		Spec: gatewayv1.GatewayClassSpec{
 			ControllerName: "different-controller",
 		},
 	}

--- a/internal/mode/static/state/graph/httproute_test.go
+++ b/internal/mode/static/state/graph/httproute_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
@@ -26,17 +26,17 @@ const (
 func createHTTPRoute(
 	name string,
 	refName string,
-	hostname v1beta1.Hostname,
+	hostname gatewayv1.Hostname,
 	paths ...string,
-) *v1beta1.HTTPRoute {
-	rules := make([]v1beta1.HTTPRouteRule, 0, len(paths))
+) *gatewayv1.HTTPRoute {
+	rules := make([]gatewayv1.HTTPRouteRule, 0, len(paths))
 
 	for _, path := range paths {
-		rules = append(rules, v1beta1.HTTPRouteRule{
-			Matches: []v1beta1.HTTPRouteMatch{
+		rules = append(rules, gatewayv1.HTTPRouteRule{
+			Matches: []gatewayv1.HTTPRouteMatch{
 				{
-					Path: &v1beta1.HTTPPathMatch{
-						Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+					Path: &gatewayv1.HTTPPathMatch{
+						Type:  helpers.GetPointer(gatewayv1.PathMatchPathPrefix),
 						Value: helpers.GetPointer(path),
 					},
 				},
@@ -44,28 +44,28 @@ func createHTTPRoute(
 		})
 	}
 
-	return &v1beta1.HTTPRoute{
+	return &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 			Name:      name,
 		},
-		Spec: v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: v1beta1.CommonRouteSpec{
-				ParentRefs: []v1beta1.ParentReference{
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
 					{
-						Namespace:   helpers.GetPointer[v1beta1.Namespace]("test"),
-						Name:        v1beta1.ObjectName(refName),
-						SectionName: helpers.GetPointer[v1beta1.SectionName](sectionNameOfCreateHTTPRoute),
+						Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
+						Name:        gatewayv1.ObjectName(refName),
+						SectionName: helpers.GetPointer[gatewayv1.SectionName](sectionNameOfCreateHTTPRoute),
 					},
 				},
 			},
-			Hostnames: []v1beta1.Hostname{hostname},
+			Hostnames: []gatewayv1.Hostname{hostname},
 			Rules:     rules,
 		},
 	}
 }
 
-func addFilterToPath(hr *v1beta1.HTTPRoute, path string, filter v1beta1.HTTPRouteFilter) {
+func addFilterToPath(hr *gatewayv1.HTTPRoute, path string, filter gatewayv1.HTTPRouteFilter) {
 	for i := range hr.Spec.Rules {
 		for _, match := range hr.Spec.Rules[i].Matches {
 			if match.Path == nil {
@@ -84,7 +84,7 @@ func TestBuildRoutes(t *testing.T) {
 	hr := createHTTPRoute("hr-1", gwNsName.Name, "example.com", "/")
 	hrWrongGateway := createHTTPRoute("hr-2", "some-gateway", "example.com", "/")
 
-	hrRoutes := map[types.NamespacedName]*v1beta1.HTTPRoute{
+	hrRoutes := map[types.NamespacedName]*gatewayv1.HTTPRoute{
 		client.ObjectKeyFromObject(hr):             hr,
 		client.ObjectKeyFromObject(hrWrongGateway): hrWrongGateway,
 	}
@@ -140,30 +140,30 @@ func TestBuildSectionNameRefs(t *testing.T) {
 	gwNsName1 := types.NamespacedName{Namespace: routeNamespace, Name: "gateway-1"}
 	gwNsName2 := types.NamespacedName{Namespace: routeNamespace, Name: "gateway-2"}
 
-	parentRefs := []v1beta1.ParentReference{
+	parentRefs := []gatewayv1.ParentReference{
 		{
-			Name:        v1beta1.ObjectName(gwNsName1.Name),
-			SectionName: helpers.GetPointer[v1beta1.SectionName]("one"),
+			Name:        gatewayv1.ObjectName(gwNsName1.Name),
+			SectionName: helpers.GetPointer[gatewayv1.SectionName]("one"),
 		},
 		{
-			Name:        v1beta1.ObjectName("some-other-gateway"),
-			SectionName: helpers.GetPointer[v1beta1.SectionName]("two"),
+			Name:        gatewayv1.ObjectName("some-other-gateway"),
+			SectionName: helpers.GetPointer[gatewayv1.SectionName]("two"),
 		},
 		{
-			Name:        v1beta1.ObjectName(gwNsName2.Name),
-			SectionName: helpers.GetPointer[v1beta1.SectionName]("three"),
+			Name:        gatewayv1.ObjectName(gwNsName2.Name),
+			SectionName: helpers.GetPointer[gatewayv1.SectionName]("three"),
 		},
 		{
-			Name:        v1beta1.ObjectName(gwNsName1.Name),
-			SectionName: helpers.GetPointer[v1beta1.SectionName]("same-name"),
+			Name:        gatewayv1.ObjectName(gwNsName1.Name),
+			SectionName: helpers.GetPointer[gatewayv1.SectionName]("same-name"),
 		},
 		{
-			Name:        v1beta1.ObjectName(gwNsName2.Name),
-			SectionName: helpers.GetPointer[v1beta1.SectionName]("same-name"),
+			Name:        gatewayv1.ObjectName(gwNsName2.Name),
+			SectionName: helpers.GetPointer[gatewayv1.SectionName]("same-name"),
 		},
 		{
-			Name:        v1beta1.ObjectName("some-other-gateway"),
-			SectionName: helpers.GetPointer[v1beta1.SectionName]("same-name"),
+			Name:        gatewayv1.ObjectName("some-other-gateway"),
+			SectionName: helpers.GetPointer[gatewayv1.SectionName]("same-name"),
 		},
 	}
 
@@ -199,29 +199,29 @@ func TestBuildSectionNameRefsPanicsForDuplicateParentRefs(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		parentRefs []v1beta1.ParentReference
+		parentRefs []gatewayv1.ParentReference
 	}{
 		{
-			parentRefs: []v1beta1.ParentReference{
+			parentRefs: []gatewayv1.ParentReference{
 				{
-					Name:        v1beta1.ObjectName(gwNsName.Name),
-					SectionName: helpers.GetPointer[v1beta1.SectionName]("http"),
+					Name:        gatewayv1.ObjectName(gwNsName.Name),
+					SectionName: helpers.GetPointer[gatewayv1.SectionName]("http"),
 				},
 				{
-					Name:        v1beta1.ObjectName(gwNsName.Name),
-					SectionName: helpers.GetPointer[v1beta1.SectionName]("http"),
+					Name:        gatewayv1.ObjectName(gwNsName.Name),
+					SectionName: helpers.GetPointer[gatewayv1.SectionName]("http"),
 				},
 			},
 			name: "with sectionNames",
 		},
 		{
-			parentRefs: []v1beta1.ParentReference{
+			parentRefs: []gatewayv1.ParentReference{
 				{
-					Name:        v1beta1.ObjectName(gwNsName.Name),
+					Name:        gatewayv1.ObjectName(gwNsName.Name),
 					SectionName: nil,
 				},
 				{
-					Name:        v1beta1.ObjectName(gwNsName.Name),
+					Name:        gatewayv1.ObjectName(gwNsName.Name),
 					SectionName: nil,
 				},
 			},
@@ -245,60 +245,60 @@ func TestFindGatewayForParentRef(t *testing.T) {
 	gwNsName2 := types.NamespacedName{Namespace: "test-2", Name: "gateway-2"}
 
 	tests := []struct {
-		ref              v1beta1.ParentReference
+		ref              gatewayv1.ParentReference
 		expectedGwNsName types.NamespacedName
 		name             string
 		expectedFound    bool
 	}{
 		{
-			ref: v1beta1.ParentReference{
-				Namespace: helpers.GetPointer(v1beta1.Namespace(gwNsName1.Namespace)),
-				Name:      v1beta1.ObjectName(gwNsName1.Name),
+			ref: gatewayv1.ParentReference{
+				Namespace: helpers.GetPointer(gatewayv1.Namespace(gwNsName1.Namespace)),
+				Name:      gatewayv1.ObjectName(gwNsName1.Name),
 			},
 			expectedFound:    true,
 			expectedGwNsName: gwNsName1,
 			name:             "found",
 		},
 		{
-			ref: v1beta1.ParentReference{
-				Group:     helpers.GetPointer[v1beta1.Group](v1beta1.GroupName),
-				Kind:      helpers.GetPointer[v1beta1.Kind]("Gateway"),
-				Namespace: helpers.GetPointer(v1beta1.Namespace(gwNsName1.Namespace)),
-				Name:      v1beta1.ObjectName(gwNsName1.Name),
+			ref: gatewayv1.ParentReference{
+				Group:     helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName),
+				Kind:      helpers.GetPointer[gatewayv1.Kind]("Gateway"),
+				Namespace: helpers.GetPointer(gatewayv1.Namespace(gwNsName1.Namespace)),
+				Name:      gatewayv1.ObjectName(gwNsName1.Name),
 			},
 			expectedFound:    true,
 			expectedGwNsName: gwNsName1,
 			name:             "found with explicit group and kind",
 		},
 		{
-			ref: v1beta1.ParentReference{
-				Name: v1beta1.ObjectName(gwNsName2.Name),
+			ref: gatewayv1.ParentReference{
+				Name: gatewayv1.ObjectName(gwNsName2.Name),
 			},
 			expectedFound:    true,
 			expectedGwNsName: gwNsName2,
 			name:             "found with implicit namespace",
 		},
 		{
-			ref: v1beta1.ParentReference{
-				Kind: helpers.GetPointer[v1beta1.Kind]("NotGateway"),
-				Name: v1beta1.ObjectName(gwNsName2.Name),
+			ref: gatewayv1.ParentReference{
+				Kind: helpers.GetPointer[gatewayv1.Kind]("NotGateway"),
+				Name: gatewayv1.ObjectName(gwNsName2.Name),
 			},
 			expectedFound:    false,
 			expectedGwNsName: types.NamespacedName{},
 			name:             "wrong kind",
 		},
 		{
-			ref: v1beta1.ParentReference{
-				Group: helpers.GetPointer[v1beta1.Group]("wrong-group"),
-				Name:  v1beta1.ObjectName(gwNsName2.Name),
+			ref: gatewayv1.ParentReference{
+				Group: helpers.GetPointer[gatewayv1.Group]("wrong-group"),
+				Name:  gatewayv1.ObjectName(gwNsName2.Name),
 			},
 			expectedFound:    false,
 			expectedGwNsName: types.NamespacedName{},
 			name:             "wrong group",
 		},
 		{
-			ref: v1beta1.ParentReference{
-				Namespace: helpers.GetPointer(v1beta1.Namespace(gwNsName1.Namespace)),
+			ref: gatewayv1.ParentReference{
+				Namespace: helpers.GetPointer(gatewayv1.Namespace(gwNsName1.Namespace)),
 				Name:      "some-gateway",
 			},
 			expectedFound:    false,
@@ -333,14 +333,14 @@ func TestBuildRoute(t *testing.T) {
 
 	gatewayNsName := types.NamespacedName{Namespace: "test", Name: "gateway"}
 
-	validFilter := v1beta1.HTTPRouteFilter{
-		Type:            v1beta1.HTTPRouteFilterRequestRedirect,
-		RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{},
+	validFilter := gatewayv1.HTTPRouteFilter{
+		Type:            gatewayv1.HTTPRouteFilterRequestRedirect,
+		RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{},
 	}
-	invalidFilter := v1beta1.HTTPRouteFilter{
-		Type: v1beta1.HTTPRouteFilterRequestRedirect,
-		RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-			Hostname: helpers.GetPointer[v1beta1.PreciseHostname](invalidRedirectHostname),
+	invalidFilter := gatewayv1.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+		RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+			Hostname: helpers.GetPointer[gatewayv1.PreciseHostname](invalidRedirectHostname),
 		},
 	}
 
@@ -384,7 +384,7 @@ func TestBuildRoute(t *testing.T) {
 
 	tests := []struct {
 		validator *validationfakes.FakeHTTPFieldsValidator
-		hr        *v1beta1.HTTPRoute
+		hr        *gatewayv1.HTTPRoute
 		expected  *Route
 		name      string
 	}{
@@ -608,9 +608,9 @@ func TestBindRouteToListeners(t *testing.T) {
 	// we create a new listener each time because the function under test can modify it
 	createListener := func(name string) *Listener {
 		return &Listener{
-			Source: v1beta1.Listener{
-				Name:     v1beta1.SectionName(name),
-				Hostname: (*v1beta1.Hostname)(helpers.GetPointer("foo.example.com")),
+			Source: gatewayv1.Listener{
+				Name:     gatewayv1.SectionName(name),
+				Hostname: (*gatewayv1.Hostname)(helpers.GetPointer("foo.example.com")),
 			},
 			Valid:  true,
 			Routes: map[types.NamespacedName]*Route{},
@@ -622,13 +622,13 @@ func TestBindRouteToListeners(t *testing.T) {
 		return l
 	}
 
-	gw := &v1beta1.Gateway{
+	gw := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
 			Name:      "gateway",
 		},
 	}
-	gwDiffNamespace := &v1beta1.Gateway{
+	gwDiffNamespace := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "diff-namespace",
 			Name:      "gateway",
@@ -636,45 +636,45 @@ func TestBindRouteToListeners(t *testing.T) {
 	}
 
 	createHTTPRouteWithSectionNameAndPort := func(
-		sectionName *v1beta1.SectionName,
-		port *v1beta1.PortNumber,
-	) *v1beta1.HTTPRoute {
-		return &v1beta1.HTTPRoute{
+		sectionName *gatewayv1.SectionName,
+		port *gatewayv1.PortNumber,
+	) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test",
 				Name:      "hr",
 			},
-			Spec: v1beta1.HTTPRouteSpec{
-				CommonRouteSpec: v1beta1.CommonRouteSpec{
-					ParentRefs: []v1beta1.ParentReference{
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
 						{
-							Name:        v1beta1.ObjectName(gw.Name),
+							Name:        gatewayv1.ObjectName(gw.Name),
 							SectionName: sectionName,
 							Port:        port,
 						},
 					},
 				},
-				Hostnames: []v1beta1.Hostname{
+				Hostnames: []gatewayv1.Hostname{
 					"foo.example.com",
 				},
 			},
 		}
 	}
 
-	hr := createHTTPRouteWithSectionNameAndPort(helpers.GetPointer[v1beta1.SectionName]("listener-80-1"), nil)
+	hr := createHTTPRouteWithSectionNameAndPort(helpers.GetPointer[gatewayv1.SectionName]("listener-80-1"), nil)
 	hrWithNilSectionName := createHTTPRouteWithSectionNameAndPort(nil, nil)
-	hrWithEmptySectionName := createHTTPRouteWithSectionNameAndPort(helpers.GetPointer[v1beta1.SectionName](""), nil)
+	hrWithEmptySectionName := createHTTPRouteWithSectionNameAndPort(helpers.GetPointer[gatewayv1.SectionName](""), nil)
 	hrWithPort := createHTTPRouteWithSectionNameAndPort(
-		helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
-		helpers.GetPointer[v1beta1.PortNumber](80),
+		helpers.GetPointer[gatewayv1.SectionName]("listener-80-1"),
+		helpers.GetPointer[gatewayv1.PortNumber](80),
 	)
 	hrWithNonExistingListener := createHTTPRouteWithSectionNameAndPort(
-		helpers.GetPointer[v1beta1.SectionName]("listener-80-2"),
+		helpers.GetPointer[gatewayv1.SectionName]("listener-80-2"),
 		nil,
 	)
 
 	var normalRoute *Route
-	createNormalRoute := func(gateway *v1beta1.Gateway) *Route {
+	createNormalRoute := func(gateway *gatewayv1.Gateway) *Route {
 		normalRoute = &Route{
 			Source: hr,
 			Valid:  true,
@@ -756,7 +756,7 @@ func TestBindRouteToListeners(t *testing.T) {
 		l.Valid = false
 	})
 	nonMatchingHostnameListener := createModifiedListener("", func(l *Listener) {
-		l.Source.Hostname = helpers.GetPointer[v1beta1.Hostname]("bar.example.com")
+		l.Source.Hostname = helpers.GetPointer[gatewayv1.Hostname]("bar.example.com")
 	})
 
 	tests := []struct {
@@ -1068,9 +1068,9 @@ func TestBindRouteToListeners(t *testing.T) {
 				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-							Namespaces: &v1beta1.RouteNamespaces{
-								From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+						l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: helpers.GetPointer(gatewayv1.NamespacesFromSelector),
 							},
 						}
 						allowedLabels := map[string]string{"app": "not-allowed"}
@@ -1091,9 +1091,9 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedGatewayListeners: map[string]*Listener{
 				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-						Namespaces: &v1beta1.RouteNamespaces{
-							From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+					l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: helpers.GetPointer(gatewayv1.NamespacesFromSelector),
 						},
 					}
 					allowedLabels := map[string]string{"app": "not-allowed"}
@@ -1109,9 +1109,9 @@ func TestBindRouteToListeners(t *testing.T) {
 				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-							Namespaces: &v1beta1.RouteNamespaces{
-								From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+						l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: helpers.GetPointer(gatewayv1.NamespacesFromSelector),
 							},
 						}
 						allowedLabels := map[string]string{"app": "allowed"}
@@ -1135,9 +1135,9 @@ func TestBindRouteToListeners(t *testing.T) {
 				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
 					allowedLabels := map[string]string{"app": "allowed"}
 					l.AllowedRouteLabelSelector = labels.SelectorFromSet(allowedLabels)
-					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-						Namespaces: &v1beta1.RouteNamespaces{
-							From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+					l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: helpers.GetPointer(gatewayv1.NamespacesFromSelector),
 						},
 					}
 					l.Routes = map[types.NamespacedName]*Route{
@@ -1154,9 +1154,9 @@ func TestBindRouteToListeners(t *testing.T) {
 				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-							Namespaces: &v1beta1.RouteNamespaces{
-								From: helpers.GetPointer(v1beta1.NamespacesFromSame),
+						l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: helpers.GetPointer(gatewayv1.NamespacesFromSame),
 							},
 						}
 					}),
@@ -1175,9 +1175,9 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedGatewayListeners: map[string]*Listener{
 				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-						Namespaces: &v1beta1.RouteNamespaces{
-							From: helpers.GetPointer(v1beta1.NamespacesFromSame),
+					l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: helpers.GetPointer(gatewayv1.NamespacesFromSame),
 						},
 					}
 				}),
@@ -1191,9 +1191,9 @@ func TestBindRouteToListeners(t *testing.T) {
 				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-							Namespaces: &v1beta1.RouteNamespaces{
-								From: helpers.GetPointer(v1beta1.NamespacesFromSame),
+						l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: helpers.GetPointer(gatewayv1.NamespacesFromSame),
 							},
 						}
 					}),
@@ -1213,9 +1213,9 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedGatewayListeners: map[string]*Listener{
 				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-						Namespaces: &v1beta1.RouteNamespaces{
-							From: helpers.GetPointer(v1beta1.NamespacesFromSame),
+					l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: helpers.GetPointer(gatewayv1.NamespacesFromSame),
 						},
 					}
 					l.Routes = map[types.NamespacedName]*Route{
@@ -1232,9 +1232,9 @@ func TestBindRouteToListeners(t *testing.T) {
 				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-							Namespaces: &v1beta1.RouteNamespaces{
-								From: helpers.GetPointer(v1beta1.NamespacesFromAll),
+						l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: helpers.GetPointer(gatewayv1.NamespacesFromAll),
 							},
 						}
 					}),
@@ -1254,9 +1254,9 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedGatewayListeners: map[string]*Listener{
 				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
-					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
-						Namespaces: &v1beta1.RouteNamespaces{
-							From: helpers.GetPointer(v1beta1.NamespacesFromAll),
+					l.Source.AllowedRoutes = &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: helpers.GetPointer(gatewayv1.NamespacesFromAll),
 						},
 					}
 					l.Routes = map[types.NamespacedName]*Route{
@@ -1289,15 +1289,15 @@ func TestBindRouteToListeners(t *testing.T) {
 }
 
 func TestFindAcceptedHostnames(t *testing.T) {
-	var listenerHostnameFoo v1beta1.Hostname = "foo.example.com"
-	var listenerHostnameCafe v1beta1.Hostname = "cafe.example.com"
-	var listenerHostnameWildcard v1beta1.Hostname = "*.example.com"
-	routeHostnames := []v1beta1.Hostname{"foo.example.com", "bar.example.com"}
+	var listenerHostnameFoo gatewayv1.Hostname = "foo.example.com"
+	var listenerHostnameCafe gatewayv1.Hostname = "cafe.example.com"
+	var listenerHostnameWildcard gatewayv1.Hostname = "*.example.com"
+	routeHostnames := []gatewayv1.Hostname{"foo.example.com", "bar.example.com"}
 
 	tests := []struct {
-		listenerHostname *v1beta1.Hostname
+		listenerHostname *gatewayv1.Hostname
 		msg              string
-		routeHostnames   []v1beta1.Hostname
+		routeHostnames   []gatewayv1.Hostname
 		expected         []string
 	}{
 		{
@@ -1338,7 +1338,7 @@ func TestFindAcceptedHostnames(t *testing.T) {
 		},
 		{
 			listenerHostname: &listenerHostnameFoo,
-			routeHostnames:   []v1beta1.Hostname{"*.example.com"},
+			routeHostnames:   []gatewayv1.Hostname{"*.example.com"},
 			expected:         []string{"foo.example.com"},
 			msg:              "route wildcard hostname; specific listener hostname",
 		},
@@ -1350,13 +1350,13 @@ func TestFindAcceptedHostnames(t *testing.T) {
 		},
 		{
 			listenerHostname: nil,
-			routeHostnames:   []v1beta1.Hostname{"*.example.com"},
+			routeHostnames:   []gatewayv1.Hostname{"*.example.com"},
 			expected:         []string{"*.example.com"},
 			msg:              "route wildcard hostname; nil listener hostname",
 		},
 		{
 			listenerHostname: &listenerHostnameWildcard,
-			routeHostnames:   []v1beta1.Hostname{"*.bar.example.com"},
+			routeHostnames:   []gatewayv1.Hostname{"*.bar.example.com"},
 			expected:         []string{"*.bar.example.com"},
 			msg:              "route and listener wildcard hostnames",
 		},
@@ -1372,11 +1372,11 @@ func TestFindAcceptedHostnames(t *testing.T) {
 }
 
 func TestGetHostname(t *testing.T) {
-	var emptyHostname v1beta1.Hostname
-	var hostname v1beta1.Hostname = "example.com"
+	var emptyHostname gatewayv1.Hostname
+	var hostname gatewayv1.Hostname = "example.com"
 
 	tests := []struct {
-		h        *v1beta1.Hostname
+		h        *gatewayv1.Hostname
 		expected string
 		msg      string
 	}{
@@ -1411,11 +1411,11 @@ func TestValidateHostnames(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		hostnames []v1beta1.Hostname
+		hostnames []gatewayv1.Hostname
 		expectErr bool
 	}{
 		{
-			hostnames: []v1beta1.Hostname{
+			hostnames: []gatewayv1.Hostname{
 				validHostname,
 				"example.org",
 				"foo.example.net",
@@ -1424,7 +1424,7 @@ func TestValidateHostnames(t *testing.T) {
 			name:      "multiple valid",
 		},
 		{
-			hostnames: []v1beta1.Hostname{
+			hostnames: []gatewayv1.Hostname{
 				validHostname,
 				"",
 			},
@@ -1458,42 +1458,42 @@ func TestValidateMatch(t *testing.T) {
 	}
 
 	tests := []struct {
-		match          v1beta1.HTTPRouteMatch
+		match          gatewayv1.HTTPRouteMatch
 		validator      *validationfakes.FakeHTTPFieldsValidator
 		name           string
 		expectErrCount int
 	}{
 		{
 			validator: createAllValidValidator(),
-			match: v1beta1.HTTPRouteMatch{
-				Path: &v1beta1.HTTPPathMatch{
-					Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+			match: gatewayv1.HTTPRouteMatch{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  helpers.GetPointer(gatewayv1.PathMatchPathPrefix),
 					Value: helpers.GetPointer("/"),
 				},
-				Headers: []v1beta1.HTTPHeaderMatch{
+				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.HeaderMatchExact),
+						Type:  helpers.GetPointer(gatewayv1.HeaderMatchExact),
 						Name:  "header",
 						Value: "x",
 					},
 				},
-				QueryParams: []v1beta1.HTTPQueryParamMatch{
+				QueryParams: []gatewayv1.HTTPQueryParamMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.QueryParamMatchExact),
+						Type:  helpers.GetPointer(gatewayv1.QueryParamMatchExact),
 						Name:  "param",
 						Value: "y",
 					},
 				},
-				Method: helpers.GetPointer(v1beta1.HTTPMethodGet),
+				Method: helpers.GetPointer(gatewayv1.HTTPMethodGet),
 			},
 			expectErrCount: 0,
 			name:           "valid",
 		},
 		{
 			validator: createAllValidValidator(),
-			match: v1beta1.HTTPRouteMatch{
-				Path: &v1beta1.HTTPPathMatch{
-					Type:  helpers.GetPointer(v1beta1.PathMatchExact),
+			match: gatewayv1.HTTPRouteMatch{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  helpers.GetPointer(gatewayv1.PathMatchExact),
 					Value: helpers.GetPointer("/"),
 				},
 			},
@@ -1502,9 +1502,9 @@ func TestValidateMatch(t *testing.T) {
 		},
 		{
 			validator: createAllValidValidator(),
-			match: v1beta1.HTTPRouteMatch{
-				Path: &v1beta1.HTTPPathMatch{
-					Type:  helpers.GetPointer(v1beta1.PathMatchRegularExpression),
+			match: gatewayv1.HTTPRouteMatch{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  helpers.GetPointer(gatewayv1.PathMatchRegularExpression),
 					Value: helpers.GetPointer("/"),
 				},
 			},
@@ -1517,9 +1517,9 @@ func TestValidateMatch(t *testing.T) {
 				validator.ValidatePathInMatchReturns(errors.New("invalid path value"))
 				return validator
 			}(),
-			match: v1beta1.HTTPRouteMatch{
-				Path: &v1beta1.HTTPPathMatch{
-					Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+			match: gatewayv1.HTTPRouteMatch{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  helpers.GetPointer(gatewayv1.PathMatchPathPrefix),
 					Value: helpers.GetPointer("/"),
 				},
 			},
@@ -1528,8 +1528,8 @@ func TestValidateMatch(t *testing.T) {
 		},
 		{
 			validator: createAllValidValidator(),
-			match: v1beta1.HTTPRouteMatch{
-				Headers: []v1beta1.HTTPHeaderMatch{
+			match: gatewayv1.HTTPRouteMatch{
+				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
 						Type:  nil,
 						Name:  "header",
@@ -1542,10 +1542,10 @@ func TestValidateMatch(t *testing.T) {
 		},
 		{
 			validator: createAllValidValidator(),
-			match: v1beta1.HTTPRouteMatch{
-				Headers: []v1beta1.HTTPHeaderMatch{
+			match: gatewayv1.HTTPRouteMatch{
+				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.HeaderMatchRegularExpression),
+						Type:  helpers.GetPointer(gatewayv1.HeaderMatchRegularExpression),
 						Name:  "header",
 						Value: "x",
 					},
@@ -1560,10 +1560,10 @@ func TestValidateMatch(t *testing.T) {
 				validator.ValidateHeaderNameInMatchReturns(errors.New("invalid header name"))
 				return validator
 			}(),
-			match: v1beta1.HTTPRouteMatch{
-				Headers: []v1beta1.HTTPHeaderMatch{
+			match: gatewayv1.HTTPRouteMatch{
+				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.HeaderMatchExact),
+						Type:  helpers.GetPointer(gatewayv1.HeaderMatchExact),
 						Name:  "header", // any value is invalid by the validator
 						Value: "x",
 					},
@@ -1578,10 +1578,10 @@ func TestValidateMatch(t *testing.T) {
 				validator.ValidateHeaderValueInMatchReturns(errors.New("invalid header value"))
 				return validator
 			}(),
-			match: v1beta1.HTTPRouteMatch{
-				Headers: []v1beta1.HTTPHeaderMatch{
+			match: gatewayv1.HTTPRouteMatch{
+				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.HeaderMatchExact),
+						Type:  helpers.GetPointer(gatewayv1.HeaderMatchExact),
 						Name:  "header",
 						Value: "x", // any value is invalid by the validator
 					},
@@ -1592,8 +1592,8 @@ func TestValidateMatch(t *testing.T) {
 		},
 		{
 			validator: createAllValidValidator(),
-			match: v1beta1.HTTPRouteMatch{
-				QueryParams: []v1beta1.HTTPQueryParamMatch{
+			match: gatewayv1.HTTPRouteMatch{
+				QueryParams: []gatewayv1.HTTPQueryParamMatch{
 					{
 						Type:  nil,
 						Name:  "param",
@@ -1606,10 +1606,10 @@ func TestValidateMatch(t *testing.T) {
 		},
 		{
 			validator: createAllValidValidator(),
-			match: v1beta1.HTTPRouteMatch{
-				QueryParams: []v1beta1.HTTPQueryParamMatch{
+			match: gatewayv1.HTTPRouteMatch{
+				QueryParams: []gatewayv1.HTTPQueryParamMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.QueryParamMatchRegularExpression),
+						Type:  helpers.GetPointer(gatewayv1.QueryParamMatchRegularExpression),
 						Name:  "param",
 						Value: "y",
 					},
@@ -1624,10 +1624,10 @@ func TestValidateMatch(t *testing.T) {
 				validator.ValidateQueryParamNameInMatchReturns(errors.New("invalid query param name"))
 				return validator
 			}(),
-			match: v1beta1.HTTPRouteMatch{
-				QueryParams: []v1beta1.HTTPQueryParamMatch{
+			match: gatewayv1.HTTPRouteMatch{
+				QueryParams: []gatewayv1.HTTPQueryParamMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.QueryParamMatchExact),
+						Type:  helpers.GetPointer(gatewayv1.QueryParamMatchExact),
 						Name:  "param", // any value is invalid by the validator
 						Value: "y",
 					},
@@ -1642,10 +1642,10 @@ func TestValidateMatch(t *testing.T) {
 				validator.ValidateQueryParamValueInMatchReturns(errors.New("invalid query param value"))
 				return validator
 			}(),
-			match: v1beta1.HTTPRouteMatch{
-				QueryParams: []v1beta1.HTTPQueryParamMatch{
+			match: gatewayv1.HTTPRouteMatch{
+				QueryParams: []gatewayv1.HTTPQueryParamMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.QueryParamMatchExact),
+						Type:  helpers.GetPointer(gatewayv1.QueryParamMatchExact),
 						Name:  "param",
 						Value: "y", // any value is invalid by the validator
 					},
@@ -1660,29 +1660,29 @@ func TestValidateMatch(t *testing.T) {
 				validator.ValidateMethodInMatchReturns(false, []string{"VALID_METHOD"})
 				return validator
 			}(),
-			match: v1beta1.HTTPRouteMatch{
-				Method: helpers.GetPointer(v1beta1.HTTPMethodGet), // any value is invalid by the validator
+			match: gatewayv1.HTTPRouteMatch{
+				Method: helpers.GetPointer(gatewayv1.HTTPMethodGet), // any value is invalid by the validator
 			},
 			expectErrCount: 1,
 			name:           "method is invalid",
 		},
 		{
 			validator: createAllValidValidator(),
-			match: v1beta1.HTTPRouteMatch{
-				Path: &v1beta1.HTTPPathMatch{
-					Type:  helpers.GetPointer(v1beta1.PathMatchRegularExpression), // invalid
+			match: gatewayv1.HTTPRouteMatch{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  helpers.GetPointer(gatewayv1.PathMatchRegularExpression), // invalid
 					Value: helpers.GetPointer("/"),
 				},
-				Headers: []v1beta1.HTTPHeaderMatch{
+				Headers: []gatewayv1.HTTPHeaderMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.HeaderMatchRegularExpression), // invalid
+						Type:  helpers.GetPointer(gatewayv1.HeaderMatchRegularExpression), // invalid
 						Name:  "header",
 						Value: "x",
 					},
 				},
-				QueryParams: []v1beta1.HTTPQueryParamMatch{
+				QueryParams: []gatewayv1.HTTPQueryParamMatch{
 					{
-						Type:  helpers.GetPointer(v1beta1.QueryParamMatchRegularExpression), // invalid
+						Type:  helpers.GetPointer(gatewayv1.QueryParamMatchRegularExpression), // invalid
 						Name:  "param",
 						Value: "y",
 					},
@@ -1704,29 +1704,29 @@ func TestValidateMatch(t *testing.T) {
 
 func TestValidateFilter(t *testing.T) {
 	tests := []struct {
-		filter         v1beta1.HTTPRouteFilter
+		filter         gatewayv1.HTTPRouteFilter
 		name           string
 		expectErrCount int
 	}{
 		{
-			filter: v1beta1.HTTPRouteFilter{
-				Type:            v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{},
+			filter: gatewayv1.HTTPRouteFilter{
+				Type:            gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{},
 			},
 			expectErrCount: 0,
 			name:           "valid redirect filter",
 		},
 		{
-			filter: v1beta1.HTTPRouteFilter{
-				Type:                  v1beta1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1beta1.HTTPHeaderFilter{},
+			filter: gatewayv1.HTTPRouteFilter{
+				Type:                  gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{},
 			},
 			expectErrCount: 0,
 			name:           "valid request header modifiers filter",
 		},
 		{
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterURLRewrite,
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterURLRewrite,
 			},
 			expectErrCount: 1,
 			name:           "unsupported filter",
@@ -1755,19 +1755,19 @@ func TestValidateFilterRedirect(t *testing.T) {
 	}
 
 	tests := []struct {
-		filter         v1beta1.HTTPRouteFilter
+		filter         gatewayv1.HTTPRouteFilter
 		validator      *validationfakes.FakeHTTPFieldsValidator
 		name           string
 		expectErrCount int
 	}{
 		{
 			validator: createAllValidValidator(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
 					Scheme:     helpers.GetPointer("http"),
-					Hostname:   helpers.GetPointer[v1beta1.PreciseHostname]("example.com"),
-					Port:       helpers.GetPointer[v1beta1.PortNumber](80),
+					Hostname:   helpers.GetPointer[gatewayv1.PreciseHostname]("example.com"),
+					Port:       helpers.GetPointer[gatewayv1.PortNumber](80),
 					StatusCode: helpers.GetPointer(301),
 				},
 			},
@@ -1776,9 +1776,9 @@ func TestValidateFilterRedirect(t *testing.T) {
 		},
 		{
 			validator: createAllValidValidator(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type:            v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{},
+			filter: gatewayv1.HTTPRouteFilter{
+				Type:            gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{},
 			},
 			expectErrCount: 0,
 			name:           "valid redirect filter with no fields set",
@@ -1789,9 +1789,9 @@ func TestValidateFilterRedirect(t *testing.T) {
 				validator.ValidateRedirectSchemeReturns(false, []string{"valid-scheme"})
 				return validator
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
 					Scheme: helpers.GetPointer("http"), // any value is invalid by the validator
 				},
 			},
@@ -1804,10 +1804,10 @@ func TestValidateFilterRedirect(t *testing.T) {
 				validator.ValidateRedirectHostnameReturns(errors.New("invalid hostname"))
 				return validator
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-					Hostname: helpers.GetPointer[v1beta1.PreciseHostname](
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					Hostname: helpers.GetPointer[gatewayv1.PreciseHostname](
 						"example.com",
 					), // any value is invalid by the validator
 				},
@@ -1821,10 +1821,10 @@ func TestValidateFilterRedirect(t *testing.T) {
 				validator.ValidateRedirectPortReturns(errors.New("invalid port"))
 				return validator
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-					Port: helpers.GetPointer[v1beta1.PortNumber](80), // any value is invalid by the validator
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					Port: helpers.GetPointer[gatewayv1.PortNumber](80), // any value is invalid by the validator
 				},
 			},
 			expectErrCount: 1,
@@ -1832,10 +1832,10 @@ func TestValidateFilterRedirect(t *testing.T) {
 		},
 		{
 			validator: createAllValidValidator(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-					Path: &v1beta1.HTTPPathModifier{},
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					Path: &gatewayv1.HTTPPathModifier{},
 				},
 			},
 			expectErrCount: 1,
@@ -1847,9 +1847,9 @@ func TestValidateFilterRedirect(t *testing.T) {
 				validator.ValidateRedirectStatusCodeReturns(false, []string{"200"})
 				return validator
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
 					StatusCode: helpers.GetPointer(301), // any value is invalid by the validator
 				},
 			},
@@ -1863,13 +1863,13 @@ func TestValidateFilterRedirect(t *testing.T) {
 				validator.ValidateRedirectPortReturns(errors.New("invalid port"))
 				return validator
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-					Hostname: helpers.GetPointer[v1beta1.PreciseHostname](
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					Hostname: helpers.GetPointer[gatewayv1.PreciseHostname](
 						"example.com",
 					), // any value is invalid by the validator
-					Port: helpers.GetPointer[v1beta1.PortNumber](
+					Port: helpers.GetPointer[gatewayv1.PortNumber](
 						80,
 					), // any value is invalid by the validator
 				},
@@ -1897,20 +1897,20 @@ func TestValidateFilterRequestHeaderModifier(t *testing.T) {
 	}
 
 	tests := []struct {
-		filter         v1beta1.HTTPRouteFilter
+		filter         gatewayv1.HTTPRouteFilter
 		validator      *validationfakes.FakeHTTPFieldsValidator
 		name           string
 		expectErrCount int
 	}{
 		{
 			validator: createAllValidValidator(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1beta1.HTTPHeaderFilter{
-					Set: []v1beta1.HTTPHeader{
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
 						{Name: "MyBespokeHeader", Value: "my-value"},
 					},
-					Add: []v1beta1.HTTPHeader{
+					Add: []gatewayv1.HTTPHeader{
 						{Name: "Accept-Encoding", Value: "gzip"},
 					},
 					Remove: []string{"Cache-Control"},
@@ -1925,10 +1925,10 @@ func TestValidateFilterRequestHeaderModifier(t *testing.T) {
 				v.ValidateRequestHeaderNameReturns(errors.New("Invalid header"))
 				return v
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1beta1.HTTPHeaderFilter{
-					Add: []v1beta1.HTTPHeader{
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
 						{Name: "$var_name", Value: "gzip"},
 					},
 				},
@@ -1942,9 +1942,9 @@ func TestValidateFilterRequestHeaderModifier(t *testing.T) {
 				v.ValidateRequestHeaderNameReturns(errors.New("Invalid header"))
 				return v
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1beta1.HTTPHeaderFilter{
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
 					Remove: []string{"$var-name"},
 				},
 			},
@@ -1957,10 +1957,10 @@ func TestValidateFilterRequestHeaderModifier(t *testing.T) {
 				v.ValidateRequestHeaderValueReturns(errors.New("Invalid header value"))
 				return v
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1beta1.HTTPHeaderFilter{
-					Add: []v1beta1.HTTPHeader{
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
 						{Name: "Accept-Encoding", Value: "yhu$"},
 					},
 				},
@@ -1975,13 +1975,13 @@ func TestValidateFilterRequestHeaderModifier(t *testing.T) {
 				v.ValidateRequestHeaderNameReturns(errors.New("Invalid header"))
 				return v
 			}(),
-			filter: v1beta1.HTTPRouteFilter{
-				Type: v1beta1.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &v1beta1.HTTPHeaderFilter{
-					Set: []v1beta1.HTTPHeader{
+			filter: gatewayv1.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
 						{Name: "Host", Value: "my_host"},
 					},
-					Add: []v1beta1.HTTPHeader{
+					Add: []gatewayv1.HTTPHeader{
 						{Name: "}90yh&$", Value: "gzip$"},
 						{Name: "}67yh&$", Value: "compress$"},
 					},

--- a/internal/mode/static/state/graph/reference_grant.go
+++ b/internal/mode/static/state/graph/reference_grant.go
@@ -2,7 +2,8 @@ package graph
 
 import (
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // referenceGrantResolver resolves references from one resource to another.
@@ -17,7 +18,7 @@ type allowedReference struct {
 }
 
 // toResource represents the resource that the ReferenceGrant is granting access to.
-// Maps to the v1beta1.ReferenceGrantTo.
+// Maps to the v1.ReferenceGrantTo.
 type toResource struct {
 	// if group is core, this should be set to "".
 	group     string
@@ -27,7 +28,7 @@ type toResource struct {
 }
 
 // fromResource represents the resource that the ReferenceGrant is granting access from.
-// Maps to the v1beta1.ReferenceGrantFrom.
+// Maps to the v1.ReferenceGrantFrom.
 type fromResource struct {
 	group     string
 	kind      string
@@ -56,7 +57,7 @@ func toService(nsname types.NamespacedName) toResource {
 
 func fromGateway(namespace string) fromResource {
 	return fromResource{
-		group:     v1beta1.GroupName,
+		group:     v1.GroupName,
 		kind:      "Gateway",
 		namespace: namespace,
 	}
@@ -64,7 +65,7 @@ func fromGateway(namespace string) fromResource {
 
 func fromHTTPRoute(namespace string) fromResource {
 	return fromResource{
-		group:     v1beta1.GroupName,
+		group:     v1.GroupName,
 		kind:      "HTTPRoute",
 		namespace: namespace,
 	}

--- a/internal/mode/static/state/relationship/relationships_test.go
+++ b/internal/mode/static/state/relationship/relationships_test.go
@@ -6,21 +6,21 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 )
 
 func TestGetBackendServiceNamesFromRoute(t *testing.T) {
-	getNormalRefs := func(svcName v1beta1.ObjectName) []v1beta1.HTTPBackendRef {
-		return []v1beta1.HTTPBackendRef{
+	getNormalRefs := func(svcName v1.ObjectName) []v1.HTTPBackendRef {
+		return []v1.HTTPBackendRef{
 			{
-				BackendRef: v1beta1.BackendRef{
-					BackendObjectReference: v1beta1.BackendObjectReference{
-						Kind:      (*v1beta1.Kind)(helpers.GetPointer("Service")),
+				BackendRef: v1.BackendRef{
+					BackendObjectReference: v1.BackendObjectReference{
+						Kind:      (*v1.Kind)(helpers.GetPointer("Service")),
 						Name:      svcName,
-						Namespace: (*v1beta1.Namespace)(helpers.GetPointer("test")),
-						Port:      (*v1beta1.PortNumber)(helpers.GetPointer[int32](80)),
+						Namespace: (*v1.Namespace)(helpers.GetPointer("test")),
+						Port:      (*v1.PortNumber)(helpers.GetPointer[int32](80)),
 					},
 				},
 			},
@@ -28,16 +28,16 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 	}
 
 	getModifiedRefs := func(
-		svcName v1beta1.ObjectName,
-		mod func([]v1beta1.HTTPBackendRef) []v1beta1.HTTPBackendRef,
-	) []v1beta1.HTTPBackendRef {
+		svcName v1.ObjectName,
+		mod func([]v1.HTTPBackendRef) []v1.HTTPBackendRef,
+	) []v1.HTTPBackendRef {
 		return mod(getNormalRefs(svcName))
 	}
 
-	hr := &v1beta1.HTTPRoute{
+	hr := &v1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "test"},
-		Spec: v1beta1.HTTPRouteSpec{
-			Rules: []v1beta1.HTTPRouteRule{
+		Spec: v1.HTTPRouteSpec{
+			Rules: []v1.HTTPRouteRule{
 				{
 					BackendRefs: getNormalRefs("svc1"),
 				},
@@ -47,8 +47,8 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 				{
 					BackendRefs: getModifiedRefs(
 						"invalid-kind",
-						func(refs []v1beta1.HTTPBackendRef) []v1beta1.HTTPBackendRef {
-							refs[0].Kind = (*v1beta1.Kind)(helpers.GetPointer("Invalid"))
+						func(refs []v1.HTTPBackendRef) []v1.HTTPBackendRef {
+							refs[0].Kind = (*v1.Kind)(helpers.GetPointer("Invalid"))
 							return refs
 						},
 					),
@@ -56,7 +56,7 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 				{
 					BackendRefs: getModifiedRefs(
 						"nil-namespace",
-						func(refs []v1beta1.HTTPBackendRef) []v1beta1.HTTPBackendRef {
+						func(refs []v1.HTTPBackendRef) []v1.HTTPBackendRef {
 							refs[0].Namespace = nil
 							return refs
 						},
@@ -65,8 +65,8 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 				{
 					BackendRefs: getModifiedRefs(
 						"diff-namespace",
-						func(refs []v1beta1.HTTPBackendRef) []v1beta1.HTTPBackendRef {
-							refs[0].Namespace = (*v1beta1.Namespace)(
+						func(refs []v1.HTTPBackendRef) []v1.HTTPBackendRef {
+							refs[0].Namespace = (*v1.Namespace)(
 								helpers.GetPointer("not-test"),
 							)
 							return refs
@@ -82,18 +82,18 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 				{
 					BackendRefs: getModifiedRefs(
 						"multiple-refs",
-						func(refs []v1beta1.HTTPBackendRef) []v1beta1.HTTPBackendRef {
-							return append(refs, v1beta1.HTTPBackendRef{
-								BackendRef: v1beta1.BackendRef{
-									BackendObjectReference: v1beta1.BackendObjectReference{
-										Kind: (*v1beta1.Kind)(
+						func(refs []v1.HTTPBackendRef) []v1.HTTPBackendRef {
+							return append(refs, v1.HTTPBackendRef{
+								BackendRef: v1.BackendRef{
+									BackendObjectReference: v1.BackendObjectReference{
+										Kind: (*v1.Kind)(
 											helpers.GetPointer("Service"),
 										),
 										Name: "multiple-refs2",
-										Namespace: (*v1beta1.Namespace)(
+										Namespace: (*v1.Namespace)(
 											helpers.GetPointer("test"),
 										),
-										Port: (*v1beta1.PortNumber)(
+										Port: (*v1.PortNumber)(
 											helpers.GetPointer[int32](80),
 										),
 									},

--- a/internal/mode/static/state/store.go
+++ b/internal/mode/static/state/store.go
@@ -26,7 +26,7 @@ type objectStore interface {
 }
 
 // objectStoreMapAdapter wraps maps of types.NamespacedName to Kubernetes resources
-// (e.g. map[types.NamespacedName]*v1beta1.Gateway) so that they can be used through objectStore interface.
+// (e.g. map[types.NamespacedName]*v1.Gateway) so that they can be used through objectStore interface.
 type objectStoreMapAdapter[T client.Object] struct {
 	objects map[types.NamespacedName]T
 }

--- a/tests/dataplane-performance/manifests/cafe-routes.yaml
+++ b/tests/dataplane-performance/manifests/cafe-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -32,7 +32,7 @@ spec:
     - name: coffee-svc
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/tests/dataplane-performance/manifests/gateway.yaml
+++ b/tests/dataplane-performance/manifests/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: cafe

--- a/tests/longevity/manifests/cafe-routes.yaml
+++ b/tests/longevity/manifests/cafe-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -17,7 +17,7 @@ spec:
     - name: coffee
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/tests/longevity/manifests/gateway.yaml
+++ b/tests/longevity/manifests/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/tests/reconfig/scripts/cafe-routes.yaml
+++ b/tests/reconfig/scripts/cafe-routes.yaml
@@ -1,10 +1,10 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: cafe-tls-redirect
 spec:
   parentRefs:
-  - name: gateway.networking.k8s.io/v1beta1
+  - name: gateway.networking.k8s.io/v1
     namespace: default
     sectionName: http
   hostnames:
@@ -16,7 +16,7 @@ spec:
         scheme: https
         port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -36,7 +36,7 @@ spec:
     - name: coffee
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/tests/reconfig/scripts/gateway.yaml
+++ b/tests/reconfig/scripts/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/tests/scale/generate_manifests.go
+++ b/tests/scale/generate_manifests.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 )
 
-var gwTmplTxt = `apiVersion: gateway.networking.k8s.io/v1beta1
+var gwTmplTxt = `apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -33,7 +33,7 @@ spec:
 	{{- end -}}
 {{- end -}}`
 
-var hrTmplTxt = `apiVersion: gateway.networking.k8s.io/v1beta1
+var hrTmplTxt = `apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ .Name }}

--- a/tests/scale/manifests/scale-matches.yaml
+++ b/tests/scale/manifests/scale-matches.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -42,7 +42,7 @@ spec:
   selector:
     app: backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: route

--- a/tests/scale/manifests/scale-upstreams.yaml
+++ b/tests/scale/manifests/scale-upstreams.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -10,7 +10,7 @@ spec:
     port: 80
     protocol: HTTP
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: route

--- a/tests/zero-downtime-upgrades/manifests/cafe-routes.yaml
+++ b/tests/zero-downtime-upgrades/manifests/cafe-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coffee
@@ -17,7 +17,7 @@ spec:
     - name: coffee
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tea

--- a/tests/zero-downtime-upgrades/manifests/gateway-updated.yaml
+++ b/tests/zero-downtime-upgrades/manifests/gateway-updated.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/tests/zero-downtime-upgrades/manifests/gateway.yaml
+++ b/tests/zero-downtime-upgrades/manifests/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway


### PR DESCRIPTION
### Proposed changes

Problem:
Uncertainty if an upgrade Gateway API v1.0.0-rc2 breaks anything

Solution:

- Update the Gateway API dependency to v1.0.0-rc2
- Update GatewayClass, Gateway, and HTTPRoute to v1
- Update conformance related files

Testing:
Ran unit-tests, conformance tests, and checked all examples work (using both v1beta1 and v1 manifests)

One conformance test is failing - `TestConformance/GatewayWithAttachedRoutes/Gateway_listener_should_have_AttachedRoutes_set_even_when_Gateway_has_unresolved_refs`. We have a ticket to address this: #1148 .

Note: ReferenceGrant is _not_ moving to v1 with this bump

Note: As I mostly did a copy and replace of a lot of the v1beta1 references in the code, many of the docs changes etc are also included here. We can hopefully use this branch as a starting point when we do bump to v1.

Closes #1144 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
