### PR TITLE
Fix pre-commit and action linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,6 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           args: --timeout 10m0s
-          only-new-issues: true
 
   njs-lint:
     name: NJS Lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters-settings:
       - name: blank-imports
       - name: context-as-argument
       - name: context-keys-type
-      - name: dot-imports
       - name: empty-block
       - name: error-naming
       - name: error-return

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,15 +34,6 @@ repos:
         types:
           - javascript
 
-  - repo: local
-    hooks:
-      - id: golang-diff
-        name: create-go-diff
-        entry: bash -c 'git diff -p origin/main > /tmp/diff.patch'
-        language: system
-        types: [go]
-        pass_filenames: false
-
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.55.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,10 +44,9 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.54.2
+    rev: v1.55.0
     hooks:
-      - id: golangci-lint
-        args: [--new-from-patch=/tmp/diff.patch]
+      - id: golangci-lint-full
 
   # Rules are in .markdownlint-cli2.yaml file
   # See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md for rule descriptions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,5 +54,5 @@ repos:
       - id: yamllint
 
 ci:
-  skip: [golang-diff, golangci-lint, prettier, markdownlint-cli2-fix, yamllint]
+  skip: [golangci-lint-full, prettier, markdownlint-cli2-fix, yamllint]
   autofix_prs: false


### PR DESCRIPTION
Problem: Linting errors were not being caught before being merged to main.

Solution: Ensure that the pre commit hook runs on the full repo and not just the diff. Also disabled a the "only-new-issues" check in the pipeline to ensure everything is caught.

Closes #1136

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
