### PR TITLE
Fail run conformance test make target on test failure

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -79,6 +79,9 @@ run-conformance-tests: ## Run conformance tests
 								--report-output=output.txt; cat output.txt" | tee output.txt
 	sed -e '1,/CONFORMANCE PROFILE/d' output.txt > conformance-profile.yaml
 	rm output.txt
+	$(eval result_core=$(shell cat conformance-profile.yaml | yq '.profiles[0].core.result'))
+	$(eval result_extended=$(shell cat conformance-profile.yaml | yq '.profiles[0].extended.result'))
+	[ "$(result_core)" != "failure" ] && [ "$(result_extended)" != "failure" ] || exit 2
 
 .PHONY: cleanup-conformance-tests
 cleanup-conformance-tests: ## Clean up conformance tests fixtures


### PR DESCRIPTION
### Proposed changes

Problem: The conformance tests jobs are not being marked as failed in the pipeline even when there are failed tests. This is because the last command in the pod and the Make target relate to the conformance profile report and not the tests themselves, so the exit code is always 0 as long as the job completes.

Solution: Fetch the test result from the conformance profile yaml and exit with 2 if there's a failure result

Testing: Tested the conformance tests locally and verified that the make target fails when there's a failure in the conformance tests, and doesn't fail when there isn't

Closes #1176 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
