### PR TITLE
Ensure failed conformance tests are caught in pipeline & fix local make command

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -153,7 +153,7 @@ jobs:
           make run-conformance-tests TAG=${{ github.sha }} VERSION=${{ github.ref_name }}
           core_result=$(cat conformance-profile.yaml | yq '.profiles[0].core.result')
           extended_result=$(cat conformance-profile.yaml | yq '.profiles[0].extended.result')
-          [ ${core_result} != "failure" ] && [ ${extended_result} != "failure" ] || echo "Conformance test failed, see above for details."; exit 2
+          if [ "${core_result}" != "failure" ] && [ "${extended_result}" != "failure" ]; then :; else echo "Conformance test failed, see above for details." && exit 2; fi
         working-directory: ./conformance
 
       - name: Upload profile to release

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -153,7 +153,7 @@ jobs:
           make run-conformance-tests TAG=${{ github.sha }} VERSION=${{ github.ref_name }}
           core_result=$(cat conformance-profile.yaml | yq '.profiles[0].core.result')
           extended_result=$(cat conformance-profile.yaml | yq '.profiles[0].extended.result')
-          if [ "${core_result}" != "failure" ] && [ "${extended_result}" != "failure" ]; then :; else echo "Conformance test failed, see above for details." && exit 2; fi
+          if [ "${core_result}" == "failure" ] || [ "${extended_result}" == "failure" ]; then echo "Conformance test failed, see above for details." && exit 2; fi
         working-directory: ./conformance
 
       - name: Upload profile to release

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -149,7 +149,11 @@ jobs:
         working-directory: ./conformance
 
       - name: Run conformance tests
-        run: make run-conformance-tests TAG=${{ github.sha }} VERSION=${{ github.ref_name }}
+        run: |
+          make run-conformance-tests TAG=${{ github.sha }} VERSION=${{ github.ref_name }}
+          core_result=$(cat conformance-profile.yaml | yq '.profiles[0].core.result')
+          extended_result=$(cat conformance-profile.yaml | yq '.profiles[0].extended.result')
+          [ ${core_result} != "failure" ] && [ ${extended_result} != "failure" ] || echo "Conformance test failed, see above for details."; exit 2
         working-directory: ./conformance
 
       - name: Upload profile to release

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -79,9 +79,8 @@ run-conformance-tests: ## Run conformance tests
 								--report-output=output.txt; cat output.txt" | tee output.txt
 	sed -e '1,/CONFORMANCE PROFILE/d' output.txt > conformance-profile.yaml
 	rm output.txt
-	$(eval result_core=$(shell cat conformance-profile.yaml | yq '.profiles[0].core.result'))
-	$(eval result_extended=$(shell cat conformance-profile.yaml | yq '.profiles[0].extended.result'))
-	[ "$(result_core)" != "failure" ] && [ "$(result_extended)" != "failure" ] || exit 2
+	[ $(shell cat conformance-profile.yaml | yq '.profiles[0].core.result') != "failure" ] \
+		&& [ $(shell cat conformance-profile.yaml | yq '.profiles[0].extended.result') != "failure" ] || exit 2
 
 .PHONY: cleanup-conformance-tests
 cleanup-conformance-tests: ## Clean up conformance tests fixtures


### PR DESCRIPTION
### Proposed changes

Problem: The variables in the make target for running conformance tests are not being properly evaluated in the pipeline. This means we're missing failed conformance tests in the pipeline at the moment because we always return green even if there was a conformance test failure. 

Solution: This PR fixes that by checking if there was a failure in the test run and exiting the CI job with the exit code 2 if there is a failure. Also fixes the case where the target make variables are not being set correctly when the `make run-conformance-tests` are being ran locally.

Testing: Tested locally and in https://github.com/nginxinc/nginx-gateway-fabric/pull/1169 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
