### PR TITLE
Correct header name validation

### DIFF
--- a/internal/mode/static/nginx/config/validation/http_njs_match.go
+++ b/internal/mode/static/nginx/config/validation/http_njs_match.go
@@ -46,6 +46,10 @@ func (HTTPNJSMatchValidator) ValidatePathInMatch(path string) error {
 }
 
 func (HTTPNJSMatchValidator) ValidateHeaderNameInMatch(name string) error {
+	if err := k8svalidation.IsHTTPHeaderName(name); err != nil {
+		return fmt.Errorf(err[0])
+	}
+
 	return validateNJSHeaderPart(name)
 }
 

--- a/internal/mode/static/nginx/config/validation/http_njs_match.go
+++ b/internal/mode/static/nginx/config/validation/http_njs_match.go
@@ -47,7 +47,7 @@ func (HTTPNJSMatchValidator) ValidatePathInMatch(path string) error {
 
 func (HTTPNJSMatchValidator) ValidateHeaderNameInMatch(name string) error {
 	if err := k8svalidation.IsHTTPHeaderName(name); err != nil {
-		return fmt.Errorf(err[0])
+		return errors.New(err[0])
 	}
 
 	return validateNJSHeaderPart(name)

--- a/internal/mode/static/nginx/config/validation/http_njs_match_test.go
+++ b/internal/mode/static/nginx/config/validation/http_njs_match_test.go
@@ -57,6 +57,7 @@ func TestValidateHeaderValueInMatch(t *testing.T) {
 		validator.ValidateHeaderValueInMatch,
 		"value",
 		"version%!",
+		"version-2",
 	)
 	testInvalidValuesForSimpleValidator(
 		t,

--- a/internal/mode/static/nginx/config/validation/http_njs_match_test.go
+++ b/internal/mode/static/nginx/config/validation/http_njs_match_test.go
@@ -34,12 +34,18 @@ func TestValidateHeaderNameInMatch(t *testing.T) {
 		t,
 		validator.ValidateHeaderNameInMatch,
 		"header",
+		"version",
+		"version-2",
 	)
 	testInvalidValuesForSimpleValidator(
 		t,
 		validator.ValidateHeaderNameInMatch,
 		":",
 		"",
+		"version%!",
+		"version_2",
+		"hello$world",
+		"   ",
 	)
 }
 
@@ -50,12 +56,15 @@ func TestValidateHeaderValueInMatch(t *testing.T) {
 		t,
 		validator.ValidateHeaderValueInMatch,
 		"value",
+		"version%!",
 	)
 	testInvalidValuesForSimpleValidator(
 		t,
 		validator.ValidateHeaderValueInMatch,
 		":",
 		"",
+		"hello$world",
+		"   ",
 	)
 }
 


### PR DESCRIPTION
### Proposed changes

Correct header name validation.

Problem: Header name validation was not being implemented by NGF thus any problems would be caught by nginx and would not be as visible.

Solution: NGF now validates header names and will show an error in the HTTPRoute status.

Testing: Added unit tests and manually tested that if trying to apply an HTTPRoute with an invalid header name, the HTTPRoute status is correctly showing the error.

Closes #766

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
