### PR TITLE
Remove usage info from log output

### DIFF
--- a/cmd/gateway/commands.go
+++ b/cmd/gateway/commands.go
@@ -30,7 +30,9 @@ const (
 
 func createRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use: "gateway",
+		Use:           "gateway",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -93,9 +95,8 @@ func createStaticModeCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:          "static-mode",
-		Short:        "Configure NGINX in the scope of a single Gateway resource",
-		SilenceUsage: true,
+		Use:   "static-mode",
+		Short: "Configure NGINX in the scope of a single Gateway resource",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			atom := zap.NewAtomicLevel()
 

--- a/cmd/gateway/commands.go
+++ b/cmd/gateway/commands.go
@@ -93,8 +93,9 @@ func createStaticModeCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "static-mode",
-		Short: "Configure NGINX in the scope of a single Gateway resource",
+		Use:          "static-mode",
+		Short:        "Configure NGINX in the scope of a single Gateway resource",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			atom := zap.NewAtomicLevel()
 


### PR DESCRIPTION
Remove usage info from log output.

Problem: When a critical error occurs at startup, usage information for the binary is dumped into the log output.

Solution: Set `SilenceUsage` and `SilenceErrors` to true in the root `cobra.Command`. This problem was discussed [here](https://github.com/spf13/cobra/issues/340) in an older discussion on cobra's github page.

Testing: Manually tested these cases (usage is there before the change and is no longer there after the change):
- Running `docker restart kind-control-plane` which displayed the error recorded in a non-functional test [here](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/tests/graceful-recovery/results/1.0.0/1.0.0.md).
- Not creating the NginxGateway CRD on startup.

Please focus on (optional): Should I set SilenceUsage in `createProvisionerModeCommand`? Currently its just in the StaticModeCommand. Also, as described in the discussion linked above, it mentions possibly setting `SilenceUsage` in the root command, should I instead put that in `createRootCommand`? 

Closes #1105

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
