### PR TITLE
Fix Helm tests on release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
   helm-tests:
     name: Helm Tests
     runs-on: ubuntu-22.04
-    needs: [vars, binary]
+    needs: [vars]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           kube_config=${{ github.workspace }}/deploy/helm-chart/kube-${{ github.run_id }}-helm
           make create-kind-cluster KIND_KUBE_CONFIG=${kube_config}
           echo "KUBECONFIG=${kube_config}" >> "$GITHUB_ENV"
-          kind load docker-image ${{ steps.ngf-meta.outputs.tags }} ${{ steps.nginx-meta.outputs.tags }}
+          kind load docker-image ghcr.io/nginxinc/nginx-gateway-fabric:${{ steps.ngf-meta.outputs.version }} ghcr.io/nginxinc/nginx-gateway-fabric/nginx:${{ steps.nginx-meta.outputs.version }}
           kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
 
       - name: Install Chart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
   helm-tests:
     name: Helm Tests
     runs-on: ubuntu-22.04
-    needs: [vars]
+    needs: [vars, binary]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -244,7 +244,7 @@ jobs:
   build:
     name: Build Image
     runs-on: ubuntu-22.04
-    needs: [vars]
+    needs: [vars, binary]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,15 +227,15 @@ jobs:
       - name: Install Chart
         run: >
           helm install
-          helm-$(echo ${{ steps.ngf-meta.outputs.tags }} | tr '.' '-' | cut -d ":" -f 2)
+          helm-$(echo ${{ steps.nginx-meta.outputs.version }} | tr '.' '-')
           .
           --wait
           --create-namespace
-          --set nginxGateway.image.repository=$(echo ${{ steps.ngf-meta.outputs.tags }} | cut -d ":" -f 1)
-          --set nginxGateway.image.tag=$(echo ${{ steps.ngf-meta.outputs.tags }} | cut -d ":" -f 2)
+          --set nginxGateway.image.repository=ghcr.io/nginxinc/nginx-gateway-fabric
+          --set nginxGateway.image.tag=${{ steps.ngf-meta.outputs.version }}
           --set nginxGateway.image.pullPolicy=Never
-          --set nginx.image.repository=$(echo ${{ steps.nginx-meta.outputs.tags }} | cut -d ":" -f 1)
-          --set nginx.image.tag=$(echo ${{ steps.nginx-meta.outputs.tags }} | cut -d ":" -f 2)
+          --set nginx.image.repository=ghcr.io/nginxinc/nginx-gateway-fabric/nginx
+          --set nginx.image.tag=${{ steps.nginx-meta.outputs.version }}
           --set nginx.image.pullPolicy=Never
           --set service.type=NodePort
           -n nginx-gateway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
   build:
     name: Build Image
     runs-on: ubuntu-22.04
-    needs: [vars, binary]
+    needs: [vars]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -72,9 +72,9 @@ jobs:
 
       - name: Prepare NGF files
         run: |
-          ngf_prefix=$(echo ${{ steps.ngf-meta.outputs.tags }} | cut -d ":" -f 1)
-          ngf_tag=$(echo ${{ steps.ngf-meta.outputs.tags }} | cut -d ":" -f 2)
-          make update-ngf-manifest PREFIX=${ngf_prefix} TAG=${ngf_tag}
+          ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
+          ngf_tag=${{ steps.ngf-meta.outputs.version }}
+          make update-ngf-manifest NGF_PREFIX=${ngf_prefix} NGF_TAG=${ngf_tag}
         working-directory: ./conformance
 
       - name: Build binary
@@ -142,8 +142,8 @@ jobs:
 
       - name: Setup conformance tests
         run: |
-          ngf_prefix=$(echo ${{ steps.ngf-meta.outputs.tags }} | cut -d ":" -f 1)
-          ngf_tag=$(echo ${{ steps.ngf-meta.outputs.tags }} | cut -d ":" -f 2)
+          ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
+          ngf_tag=${{ steps.ngf-meta.outputs.version }}
           if [ ${{ github.event_name }} == "schedule" ]; then export GW_API_VERSION=main; fi
           if [ ${{ startsWith(matrix.k8s-version, '1.23') ||  startsWith(matrix.k8s-version, '1.24') }} == "true" ]; then export INSTALL_WEBHOOK=true; fi
           make install-ngf-local-no-build PREFIX=${ngf_prefix} TAG=${ngf_tag}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,30 +28,30 @@ sboms:
     documents:
       - "${artifact}.spdx.json"
 
-# blobs:
-#  - provider: azblob
-#    bucket: '{{.Env.AZURE_BUCKET_NAME}}'
-#
-# signs:
-#  - cmd: cosign
-#    artifacts: checksum
-#    output: true
-#    certificate: '${artifact}.pem'
-#    args:
-#      - sign-blob
-#      - "--output-signature=${signature}"
-#      - "--output-certificate=${certificate}"
-#      - "${artifact}"
-#      - "--yes"
-#
-# announce:
-#  slack:
-#    enabled: true
-#    channel: '#announcements'
-#    message_template: 'NGINX Gateway Fabric {{ .Tag }} is out! Check it out: {{ .ReleaseURL }}'
-#
-# milestones:
-#  - close: true
+blobs:
+  - provider: azblob
+    bucket: '{{.Env.AZURE_BUCKET_NAME}}'
+
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    certificate: '${artifact}.pem'
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes"
+
+announce:
+  slack:
+    enabled: true
+    channel: '#announcements'
+    message_template: 'NGINX Gateway Fabric {{ .Tag }} is out! Check it out: {{ .ReleaseURL }}'
+
+milestones:
+  - close: true
 
 snapshot:
   name_template: 'edge'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,30 +28,30 @@ sboms:
     documents:
       - "${artifact}.spdx.json"
 
-blobs:
-  - provider: azblob
-    bucket: '{{.Env.AZURE_BUCKET_NAME}}'
-
-signs:
-  - cmd: cosign
-    artifacts: checksum
-    output: true
-    certificate: '${artifact}.pem'
-    args:
-      - sign-blob
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
-      - "${artifact}"
-      - "--yes"
-
-announce:
-  slack:
-    enabled: true
-    channel: '#announcements'
-    message_template: 'NGINX Gateway Fabric {{ .Tag }} is out! Check it out: {{ .ReleaseURL }}'
-
-milestones:
-  - close: true
+# blobs:
+#  - provider: azblob
+#    bucket: '{{.Env.AZURE_BUCKET_NAME}}'
+#
+# signs:
+#  - cmd: cosign
+#    artifacts: checksum
+#    output: true
+#    certificate: '${artifact}.pem'
+#    args:
+#      - sign-blob
+#      - "--output-signature=${signature}"
+#      - "--output-certificate=${certificate}"
+#      - "${artifact}"
+#      - "--yes"
+#
+# announce:
+#  slack:
+#    enabled: true
+#    channel: '#announcements'
+#    message_template: 'NGINX Gateway Fabric {{ .Tag }} is out! Check it out: {{ .ReleaseURL }}'
+#
+# milestones:
+#  - close: true
 
 snapshot:
   name_template: 'edge'


### PR DESCRIPTION
Fix Helm tests on release tag and replace `cut` commands.

Problem: Helm tests fail on release tag because the `kind load` command did not work when the provided images spanned multiple lines. Also, `cut` commands did not work as input was not a single value.

Solution: Instead of using `steps.*.outputs.tags` which can output multiple lines, changed to use the hardcoded path to the image and a specific version. 

Testing: Manually verified on fork that the change works on a release tag. 

Closes #1190 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
