### PR TITLE
Revert some changes to workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Install Chart
         run: >
           helm install
-          helm-$(echo ${{ steps.nginx-meta.outputs.version }} | tr '.' '-')
+          helm-$(echo ${{ steps.ngf-meta.outputs.version }} | tr '.' '-')
           .
           --wait
           --create-namespace

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
-          make update-ngf-manifest NGF_PREFIX=${ngf_prefix} NGF_TAG=${ngf_tag}
+          make update-ngf-manifest PREFIX=${ngf_prefix} TAG=${ngf_tag}
         working-directory: ./conformance
 
       - name: Build binary


### PR DESCRIPTION
Some changes were made in PR #1255 that were incorrectly rebased. 

Also, changed back to `ngf-meta` to keep things consistent with beforehand, should be identical since the line just grabs the version which should be the same.