### PR TITLE
[Doc] Mention minimum Go version required for development

### DIFF
--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -10,6 +10,17 @@ Follow these steps to set up your development environment.
 
 1. Install:
     - [Go](https://golang.org/doc/install)
+
+      ```shell
+      # `go.mod` requires Go 1.21.3.
+      go install golang.org/dl/go1.21.3@latest
+      go1.21.3 download
+      export GOROOT=$(go1.21.3 env GOROOT)
+      export PATH="$GOROOT/bin:$PATH"
+      # Verify the installation.
+      go version
+      ```
+
     - [Docker](https://docs.docker.com/get-docker/) v18.09+
     - [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
     - [Helm](https://helm.sh/docs/intro/quickstart/#install-helm)

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -10,17 +10,6 @@ Follow these steps to set up your development environment.
 
 1. Install:
     - [Go](https://golang.org/doc/install) v1.21.0+
-
-      ```shell
-      # Install Go X.Y.Z, which needs to be version 1.21.0 or higher (e.g. 1.21.4).
-      go install golang.org/dl/goX.Y.Z@latest
-      goX.Y.Z download
-      export GOROOT=$(goX.Y.Z env GOROOT)
-      export PATH="$GOROOT/bin:$PATH"
-      # Verify the installation.
-      go version
-      ```
-
     - [Docker](https://docs.docker.com/get-docker/) v18.09+
     - [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
     - [Helm](https://helm.sh/docs/intro/quickstart/#install-helm)

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -9,13 +9,13 @@ fully prepared development environment that allows you to contribute to the proj
 Follow these steps to set up your development environment.
 
 1. Install:
-    - [Go](https://golang.org/doc/install)
+    - [Go](https://golang.org/doc/install) v1.21.0+
 
       ```shell
-      # `go.mod` requires Go 1.21.3.
-      go install golang.org/dl/go1.21.3@latest
-      go1.21.3 download
-      export GOROOT=$(go1.21.3 env GOROOT)
+      # Install Go X.Y.Z, which needs to be version 1.21.0 or higher (e.g. 1.21.4).
+      go install golang.org/dl/goX.Y.Z@latest
+      goX.Y.Z download
+      export GOROOT=$(goX.Y.Z env GOROOT)
       export PATH="$GOROOT/bin:$PATH"
       # Verify the installation.
       go version


### PR DESCRIPTION
### Proposed changes

My devbox uses Go 1.20.11 by default, so I got some compilation errors when I ran `make build`. In addition, [go.mod](https://github.com/nginxinc/nginx-gateway-fabric/blob/61bb3f1fbf0f652ac2158aee864b5ba492404504/go.mod#L3) requires 1.21.3, but the doc does not mention it.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

![Screen Shot 2023-11-29 at 10 30 07 PM](https://github.com/nginxinc/nginx-gateway-fabric/assets/20109646/84bc8b07-88bf-4084-9697-bf65f74723f4)

