### PR TITLE
docs: update the readme with correct compatibility doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and `UDPRoute` -- to configure an HTTP or TCP/UDP load balancer, reverse-proxy, 
 on Kubernetes. NGINX Gateway Fabric supports a subset of the Gateway API.
 
 For a list of supported Gateway API resources and features, see
-the [Gateway API Compatibility](https://docs.nginx.com/nginx-gateway-fabric/gateway-api-compatibility/) doc.
+the [Gateway API Compatibility](https://docs.nginx.com/nginx-gateway-fabric/overview/gateway-api-compatibility/) doc.
 
 Learn about our [design principles](/docs/developer/design-principles.md) and [architecture](https://docs.nginx.com/nginx-gateway-fabric/overview/gateway-architecture/).
 


### PR DESCRIPTION
### Proposed changes

Problem: The Compatability Document references in README.md pointed to a broken link.

Solution: This PR updates it to the correct one. 

Testing: Manually tested the README.md, which works with the newer link. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
