### PR TITLE
Bump labeler to v5.0.0 and update config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,15 +15,18 @@ tech-debt:
 
 documentation:
   - head-branch: ['^docs/', '^doc/']
-  - changed-files: '**/*.md'
+  - changed-files:
+      - any-glob-to-any-file: '**/*.md'
 
 dependencies:
   - head-branch: ['^deps/', '^dep/', '^dependabot/', 'pre-commit-ci-update-config']
-  - changed-files: ['go.mod', 'go.sum']
+  - changed-files:
+      - any-glob-to-any-file: ['go.mod', 'go.sum']
 
 tests:
-  - head-branch: ['^test/', '^tests/']
+  - head-branch: ['^tests/', '^test/']
 
 helm-chart:
   - head-branch: ['^helm/', '^helm-chart/']
-  - changed-files: ['deploy/helm-chart/**/*']
+  - changed-files:
+      - any-glob-to-any-file: ['deploy/helm-chart/**/*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/labeler@4f052778de9a9b80cb16cfb9079b02287285a4cb # v5.0.0-alpha.1
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
### Proposed changes

Problem: We started using `actions/labeler` when it was in alpha and the configuration structure changed in the stable release

Solution: Update `actions/labeler` to the latest stable version and update the configuration structure accordingly

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
