### PR TITLE
fix netlify url preview

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -89,4 +89,4 @@ build-dev:
 	hugo --gc -e development
 
 deploy-preview: hugo-mod
-	hugo --gc -b ${NETLIFY_DEPLOY_URL}
+	hugo --gc -b ${NETLIFY_DEPLOY_URL}/nginx-gateway-fabric/

--- a/site/config/_default/config.toml
+++ b/site/config/_default/config.toml
@@ -1,7 +1,6 @@
 title = "NGINX Gateway Fabric"
 enableGitInfo = false
 baseURL = "/"
-publishDir = "public/nginx-gateway-fabric"
 staticDir = ["static"]
 languageCode = "en-us"
 description = "NGINX Gateway Fabric."

--- a/site/config/development/config.toml
+++ b/site/config/development/config.toml
@@ -1,3 +1,4 @@
 baseURL = "https://docs-dev.nginx.com/nginx-gateway-fabric"
 title = "DEV -- NGINX Gateway Fabric"
+publishDir = "public/nginx-gateway-fabric"
 canonifyURLs = false

--- a/site/config/production/config.toml
+++ b/site/config/production/config.toml
@@ -1,3 +1,4 @@
 baseURL = "/nginx-gateway-fabric"
 title = "NGINX Gateway Fabric"
+publishDir = "public/nginx-gateway-fabric"
 canonifyURLs = false

--- a/site/config/staging/config.toml
+++ b/site/config/staging/config.toml
@@ -1,3 +1,4 @@
 baseURL = "https://docs-staging.nginx.com/nginx-gateway-fabric"
 title = "STAGING -- NGINX Gateway Fabric"
+publishDir = "public/nginx-gateway-fabric"
 canonifyURLs = false

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   base = "site/"
   publish = "public"
+  command = "hugo --gc -b $DEPLOY_PRIME_URL/nginx-gateway-fabric"
 
 [context.production]
   command = "make all"


### PR DESCRIPTION
### Proposed changes

Problem: Netlify preview url is not rendering properly

Solution: Fix url to be postfixed with `/nginx-gateway-fabric/`

Testing: PR creation should generate a preview url.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
