### PR TITLE
Use latest stable version of Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Output Variables
         id: vars
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Run Tests
         run: make unit-test
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Create/Update Draft
         uses: lucacome/draft-release@785af55296512c907875513e397320ae3f1306bb # v1.0.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
         if: matrix.language == 'go'
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Set GOPATH
         run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Lint Code
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0


### PR DESCRIPTION
### Proposed changes

Problem: Since Go changed the versioning in go.mod to specify a patch release in 1.21, we don't use the latest go version when building the binary anymore.
Before with 1.20 in go.mod we would use the latest version of 1.20.x, but now since we specify 1.21.3 in go.mod we use that fixed version and not 1.21.4 for example, and future updates.

Solution: Update the pipeline to always use the latest stable version of Go in the pipeline.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
