### PR TITLE
[Bug] Remove unused data from persistedGVKs

### DIFF
--- a/internal/mode/static/state/change_processor.go
+++ b/internal/mode/static/state/change_processor.go
@@ -145,12 +145,12 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 			},
 			{
 				gvk:       extractGVK(&apiv1.Namespace{}),
-				store:     newObjectStoreMapAdapter(clusterStore.Namespaces),
+				store:     nil,
 				predicate: nil,
 			},
 			{
 				gvk:       extractGVK(&apiv1.Service{}),
-				store:     newObjectStoreMapAdapter(clusterStore.Services),
+				store:     nil,
 				predicate: nil,
 			},
 			{


### PR DESCRIPTION
### Proposed changes

I am not sure whether my understanding is correct. Please correct me if I am wrong.

Both `apiv1.Namespace` and `apiv1.Service` are stored in `persistedGVKs`. However, setting either `store` [1] or `predicate` [2] to `nil` implies that a state change will not trigger a graph rebuild. In such cases, only Capturer can trigger the graph rebuild, and Capturer does not require information from either `store` (i.e. `persistedGVKs`) or `predicate` (i.e. `stateChangedPredicates`). Therefore, store and predicate should be either both set or both unset.

* [1] `store: nil` implies that a state change will not trigger a graph rebuild.
https://github.com/nginxinc/nginx-gateway-fabric/blob/3d3882250774142517a5815080c9a74d5c307331/internal/mode/static/state/store.go#L185-L187

* [2] `predicate: nil` implies that a state change will not trigger a graph rebuild.
https://github.com/nginxinc/nginx-gateway-fabric/blob/3d3882250774142517a5815080c9a74d5c307331/internal/mode/static/state/store.go#L193-L196

This PR sets `store: nil` for both `apiv1.Namespace` and `apiv1.Service` to make both store and predicate to be nil.

![Screen Shot 2023-12-09 at 10 43 57 AM](https://github.com/nginxinc/nginx-gateway-fabric/assets/20109646/6a16f173-c7c2-4b69-95ea-2e290c061ddb)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
