### PR TITLE
Extend resource validation doc to include NGINX Gateway Fabric resources

### DIFF
--- a/site/content/overview/resource-validation.md
+++ b/site/content/overview/resource-validation.md
@@ -164,7 +164,7 @@ The NginxGateway "nginx-gateway-config" is invalid: spec.logging.level: Unsuppor
 
 ### Step 2 - Validation by NGINX Gateway Fabric
 
-This step validates the settings in the NGINX Gateway Fabric CRDs and rejects invalid resources. The validation error is reported via the status and as an event. For example:
+This step validates the settings in the NGINX Gateway Fabric CRDs and rejects invalid resources. The validation error is reported via the status and as an Event. For example:
 
 ```shell
 kubectl describe nginxgateways.gateway.nginx.org nginx-gateway-config


### PR DESCRIPTION
### Proposed changes

Problem: The resource validation doc does not include any information on how we validate NGINX Gateway Fabric resources. 

Solution: Add a section on NGINX Gateway Fabric resources to the resource validation doc.

Please focus on (optional): Even though we only have one CRD with a single field right now, I tried to make the information generic so we don't have to modify it too much in the future.

Closes #970 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
