### PR TITLE
[DRAFT] - feat : path support for RequestRedirectFilter

### DIFF
--- a/internal/mode/static/nginx/config/validation/http_filters.go
+++ b/internal/mode/static/nginx/config/validation/http_filters.go
@@ -54,6 +54,24 @@ func (HTTPRedirectValidator) ValidateHostname(hostname string) error {
 	return validateEscapedStringNoVarExpansion(hostname, hostnameExamples)
 }
 
+// ValidateRedirectPath validates a path used in a request redirect filter.
+func (HTTPRedirectValidator) ValidateRedirectPath(path string) error {
+	if path == "" {
+		return nil
+	}
+
+	if !pathRegexp.MatchString(path) {
+		msg := k8svalidation.RegexError(pathErrMsg, pathFmt, pathExamples...)
+		return errors.New(msg)
+	}
+
+	if strings.Contains(path, "$") {
+		return errors.New("cannot contain $")
+	}
+
+	return nil
+}
+
 // ValidateRewritePath validates a path used in a URL Rewrite filter.
 func (HTTPURLRewriteValidator) ValidateRewritePath(path string) error {
 	if path == "" {

--- a/internal/mode/static/state/dataplane/convert.go
+++ b/internal/mode/static/state/dataplane/convert.go
@@ -43,6 +43,7 @@ func convertHTTPRequestRedirectFilter(filter *v1.HTTPRequestRedirectFilter) *HTT
 		Hostname:   (*string)(filter.Hostname),
 		Port:       (*int32)(filter.Port),
 		StatusCode: filter.StatusCode,
+		Path: convertPathModifier(filter.Path),
 	}
 }
 

--- a/internal/mode/static/state/dataplane/types.go
+++ b/internal/mode/static/state/dataplane/types.go
@@ -131,6 +131,8 @@ type HTTPRequestRedirectFilter struct {
 	Port *int32
 	// StatusCode is the HTTP status code of the redirect.
 	StatusCode *int
+	// Path is the path of the redirect
+	Path *HTTPPathModifier
 }
 
 // HTTPURLRewriteFilter rewrites HTTP requests.

--- a/internal/mode/static/state/graph/httproute_test.go
+++ b/internal/mode/static/state/graph/httproute_test.go
@@ -1893,12 +1893,13 @@ func TestValidateFilter(t *testing.T) {
 }
 
 func TestValidateFilterRedirect(t *testing.T) {
+	//refactor createAllValidValidator function
 	createAllValidValidator := func() *validationfakes.FakeHTTPFieldsValidator {
 		v := &validationfakes.FakeHTTPFieldsValidator{}
 
 		v.ValidateRedirectSchemeReturns(true, nil)
 		v.ValidateRedirectStatusCodeReturns(true, nil)
-
+		//v.ValidateRedirectPathReturns(errors.New("invalid path"));
 		return v
 	}
 
@@ -2019,6 +2020,7 @@ func TestValidateFilterRedirect(t *testing.T) {
 				validator := createAllValidValidator()
 				validator.ValidateHostnameReturns(errors.New("invalid hostname"))
 				validator.ValidateRedirectPortReturns(errors.New("invalid port"))
+				validator.ValidateRedirectPathReturns(errors.New("Invalid redirect path"))
 				return validator
 			}(),
 			filter: gatewayv1.HTTPRouteFilter{

--- a/internal/mode/static/state/validation/validationfakes/fake_httpfields_validator.go
+++ b/internal/mode/static/state/validation/validationfakes/fake_httpfields_validator.go
@@ -124,6 +124,17 @@ type FakeHTTPFieldsValidator struct {
 		result1 bool
 		result2 []string
 	}
+	ValidateRedirectPathStub        func(string) error
+	validateRedirectPathMutex       sync.RWMutex
+	validateRedirectPathArgsForCall []struct {
+		arg1 string
+	}
+	validateRedirectPathReturns struct {
+		result1 error
+	}
+	validateRedirectPathReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ValidateRequestHeaderNameStub        func(string) error
 	validateRequestHeaderNameMutex       sync.RWMutex
 	validateRequestHeaderNameArgsForCall []struct {
@@ -780,6 +791,67 @@ func (fake *FakeHTTPFieldsValidator) ValidateRedirectStatusCodeReturnsOnCall(i i
 	}{result1, result2}
 }
 
+func (fake *FakeHTTPFieldsValidator) ValidateRedirectPath(arg1 string) error {
+	fake.validateRedirectPathMutex.Lock()
+	ret, specificReturn := fake.validateRedirectPathReturnsOnCall[len(fake.validateRedirectPathArgsForCall)]
+	fake.validateRedirectPathArgsForCall = append(fake.validateRedirectPathArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ValidateRedirectPathStub
+	fakeReturns := fake.validateRedirectPathReturns
+	fake.recordInvocation("ValidateRedirectPath", []interface{}{arg1})
+	fake.validateRedirectPathMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeHTTPFieldsValidator) ValidateRedirectPathCallCount() int {
+	fake.validateRedirectPathMutex.RLock()
+	defer fake.validateRedirectPathMutex.RUnlock()
+	return len(fake.validateRedirectPathArgsForCall)
+}
+
+func (fake *FakeHTTPFieldsValidator) ValidateRedirectPathCalls(stub func(string) error) {
+	fake.validateRedirectPathMutex.Lock()
+	defer fake.validateRedirectPathMutex.Unlock()
+	fake.ValidateRedirectPathStub = stub
+}
+
+func (fake *FakeHTTPFieldsValidator) ValidateRedirectPathArgsForCall(i int) string {
+	fake.validateRedirectPathMutex.RLock()
+	defer fake.validateRedirectPathMutex.RUnlock()
+	argsForCall := fake.validateRedirectPathArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeHTTPFieldsValidator) ValidateRedirectPathReturns(result1 error) {
+	fake.validateRedirectPathMutex.Lock()
+	defer fake.validateRedirectPathMutex.Unlock()
+	fake.ValidateRedirectPathStub = nil
+	fake.validateRedirectPathReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeHTTPFieldsValidator) ValidateRedirectPathReturnsOnCall(i int, result1 error) {
+	fake.validateRedirectPathMutex.Lock()
+	defer fake.validateRedirectPathMutex.Unlock()
+	fake.ValidateRedirectPathStub = nil
+	if fake.validateRedirectPathReturnsOnCall == nil {
+		fake.validateRedirectPathReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validateRedirectPathReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeHTTPFieldsValidator) ValidateRequestHeaderName(arg1 string) error {
 	fake.validateRequestHeaderNameMutex.Lock()
 	ret, specificReturn := fake.validateRequestHeaderNameReturnsOnCall[len(fake.validateRequestHeaderNameArgsForCall)]
@@ -986,6 +1058,8 @@ func (fake *FakeHTTPFieldsValidator) Invocations() map[string][][]interface{} {
 	defer fake.validateRedirectSchemeMutex.RUnlock()
 	fake.validateRedirectStatusCodeMutex.RLock()
 	defer fake.validateRedirectStatusCodeMutex.RUnlock()
+	fake.validateRedirectPathMutex.RLock()
+	defer fake.validateRedirectPathMutex.RUnlock()
 	fake.validateRequestHeaderNameMutex.RLock()
 	defer fake.validateRequestHeaderNameMutex.RUnlock()
 	fake.validateRequestHeaderValueMutex.RLock()
@@ -1000,6 +1074,7 @@ func (fake *FakeHTTPFieldsValidator) Invocations() map[string][][]interface{} {
 }
 
 func (fake *FakeHTTPFieldsValidator) recordInvocation(key string, args []interface{}) {
+
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {

--- a/internal/mode/static/state/validation/validator.go
+++ b/internal/mode/static/state/validation/validator.go
@@ -22,6 +22,7 @@ type HTTPFieldsValidator interface {
 	ValidateRedirectScheme(scheme string) (valid bool, supportedValues []string)
 	ValidateRedirectPort(port int32) error
 	ValidateRedirectStatusCode(statusCode int) (valid bool, supportedValues []string)
+	ValidateRedirectPath(path string) error
 	ValidateHostname(hostname string) error
 	ValidateRewritePath(path string) error
 	ValidateRequestHeaderName(name string) error


### PR DESCRIPTION
### Proposed changes


**Problem**:  Path support for RequestRedirectFilter feature (https://github.com/nginxinc/nginx-gateway-fabric/issues/1413).

**Solution**: 
- Added Path for the HTTPRequestRedirectFilter struct
- Get Path to the `createReturnValForRedirectFilter` function & make changes of the path.(match with filter(HTTPRequestRedirectFilter) path type)

**Testing**: 

**Please focus on (optional)**: I will draft the PR to fix the issue. I am noob for the k8s & nginx ecosystem. I am happy to hear your thought of this PR & will make some necessary changes.

@sjberman @pleshakov 

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
