### PR TITLE
Add telemetry collection of deployment replica count

### DIFF
--- a/cmd/gateway/commands.go
+++ b/cmd/gateway/commands.go
@@ -153,6 +153,7 @@ func createStaticModeCommand() *cobra.Command {
 					PodIP:       podIP,
 					ServiceName: serviceName.value,
 					Namespace:   namespace,
+					Name:        podName,
 				},
 				HealthConfig: config.HealthConfig{
 					Enabled: !disableHealth,

--- a/deploy/helm-chart/templates/rbac.yaml
+++ b/deploy/helm-chart/templates/rbac.yaml
@@ -21,13 +21,23 @@ rules:
   - namespaces
   - services
   - secrets
-  # FIXME(bjee19): make nodes permission dependent on telemetry being enabled.
-  # https://github.com/nginxinc/nginx-gateway-fabric/issues/1317.
-  - nodes
-  - pods
   verbs:
   - list
   - watch
+# FIXME(bjee19): make nodes, pods, replicasets permission dependent on telemetry being enabled.
+# https://github.com/nginxinc/nginx-gateway-fabric/issues/1317.
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -36,12 +46,11 @@ rules:
   - create
   - patch
 - apiGroups:
-    - apps
+  - apps
   resources:
-    - replicasets
+  - replicasets
   verbs:
-    - list
-    - watch
+  - get
 - apiGroups:
   - discovery.k8s.io
   resources:

--- a/deploy/helm-chart/templates/rbac.yaml
+++ b/deploy/helm-chart/templates/rbac.yaml
@@ -24,6 +24,7 @@ rules:
   # FIXME(bjee19): make nodes permission dependent on telemetry being enabled.
   # https://github.com/nginxinc/nginx-gateway-fabric/issues/1317.
   - nodes
+  - pods
   verbs:
   - list
   - watch
@@ -34,6 +35,13 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+    - "apps"
+  resources:
+    - replicasets
+  verbs:
+    - list
+    - watch
 - apiGroups:
   - discovery.k8s.io
   resources:

--- a/deploy/helm-chart/templates/rbac.yaml
+++ b/deploy/helm-chart/templates/rbac.yaml
@@ -36,7 +36,7 @@ rules:
   - create
   - patch
 - apiGroups:
-    - "apps"
+    - apps
   resources:
     - replicasets
   verbs:

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -35,6 +35,7 @@ rules:
   # FIXME(bjee19): make nodes permission dependent on telemetry being enabled.
   # https://github.com/nginxinc/nginx-gateway-fabric/issues/1317.
   - nodes
+  - pods
   verbs:
   - list
   - watch
@@ -45,6 +46,13 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+    - "apps"
+  resources:
+    - replicasets
+  verbs:
+    - list
+    - watch
 - apiGroups:
   - discovery.k8s.io
   resources:

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -47,7 +47,7 @@ rules:
   - create
   - patch
 - apiGroups:
-    - "apps"
+    - apps
   resources:
     - replicasets
   verbs:

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -32,13 +32,23 @@ rules:
   - namespaces
   - services
   - secrets
-  # FIXME(bjee19): make nodes permission dependent on telemetry being enabled.
-  # https://github.com/nginxinc/nginx-gateway-fabric/issues/1317.
-  - nodes
-  - pods
   verbs:
   - list
   - watch
+# FIXME(bjee19): make nodes, pods, replicasets permission dependent on telemetry being enabled.
+# https://github.com/nginxinc/nginx-gateway-fabric/issues/1317.
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -47,12 +57,11 @@ rules:
   - create
   - patch
 - apiGroups:
-    - apps
+  - apps
   resources:
-    - replicasets
+  - replicasets
   verbs:
-    - list
-    - watch
+  - get
 - apiGroups:
   - discovery.k8s.io
   resources:

--- a/internal/mode/static/config/config.go
+++ b/internal/mode/static/config/config.go
@@ -48,6 +48,8 @@ type GatewayPodConfig struct {
 	ServiceName string
 	// Namespace is the namespace of this Pod.
 	Namespace string
+	// Name is the name of the Pod.
+	Name string
 }
 
 // MetricsConfig specifies the metrics config.

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -216,7 +216,7 @@ func StartManager(cfg config.Config) error {
 	}
 
 	dataCollector := telemetry.NewDataCollectorImpl(telemetry.DataCollectorConfig{
-		K8sClientReader:     mgr.GetClient(),
+		K8sClientReader:     mgr.GetAPIReader(),
 		GraphGetter:         processor,
 		ConfigurationGetter: eventHandler,
 		Version:             cfg.Version,

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -222,7 +222,7 @@ func StartManager(cfg config.Config) error {
 		Version:             cfg.Version,
 		PodNSName: types.NamespacedName{
 			Namespace: cfg.GatewayPodConfig.Namespace,
-			Name:      cfg.LeaderElection.Identity,
+			Name:      cfg.GatewayPodConfig.Name,
 		},
 	})
 	if err = mgr.Add(createTelemetryJob(cfg, dataCollector, nginxChecker.getReadyCh())); err != nil {

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	ngxclient "github.com/nginxinc/nginx-plus-go-client/client"
 	"github.com/prometheus/client_golang/prometheus"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	discoveryV1 "k8s.io/api/discovery/v1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -65,6 +66,7 @@ func init() {
 	utilruntime.Must(discoveryV1.AddToScheme(scheme))
 	utilruntime.Must(ngfAPI.AddToScheme(scheme))
 	utilruntime.Must(apiext.AddToScheme(scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
 }
 
 // nolint:gocyclo
@@ -218,6 +220,10 @@ func StartManager(cfg config.Config) error {
 		GraphGetter:         processor,
 		ConfigurationGetter: eventHandler,
 		Version:             cfg.Version,
+		PodNSName: types.NamespacedName{
+			Namespace: cfg.GatewayPodConfig.Namespace,
+			Name:      cfg.LeaderElection.Identity,
+		},
 	})
 	if err = mgr.Add(createTelemetryJob(cfg, dataCollector, nginxChecker.getReadyCh())); err != nil {
 		return fmt.Errorf("cannot register telemetry job: %w", err)

--- a/internal/mode/static/telemetry/collector.go
+++ b/internal/mode/static/telemetry/collector.go
@@ -170,10 +170,10 @@ func collectNGFReplicaCount(ctx context.Context, k8sClient client.Reader, podNSN
 
 	podOwnerRefs := pod.GetOwnerReferences()
 	if podOwnerRefs == nil {
-		return 0, fmt.Errorf("could not get owner reference of NGF Pod")
+		return 0, errors.New("could not get owner reference of NGF Pod")
 	}
 	if len(podOwnerRefs) != 1 {
-		return 0, fmt.Errorf("multiple owner references of NGF Pod")
+		return 0, errors.New("multiple owner references of NGF Pod")
 	}
 
 	switch kind := podOwnerRefs[0].Kind; kind {
@@ -184,6 +184,10 @@ func collectNGFReplicaCount(ctx context.Context, k8sClient client.Reader, podNSN
 			&replicaSet,
 		); err != nil {
 			return 0, err
+		}
+
+		if replicaSet.Spec.Replicas == nil {
+			return 0, errors.New("replica set replicas was nil")
 		}
 
 		return int(*replicaSet.Spec.Replicas), nil

--- a/internal/mode/static/telemetry/collector.go
+++ b/internal/mode/static/telemetry/collector.go
@@ -115,7 +115,7 @@ func (c DataCollectorImpl) Collect(ctx context.Context) (Data, error) {
 func collectNodeCount(ctx context.Context, k8sClient client.Reader) (int, error) {
 	var nodes v1.NodeList
 	if err := k8sClient.List(ctx, &nodes); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to get NodeList: %w", err)
 	}
 
 	return len(nodes.Items), nil
@@ -166,7 +166,7 @@ func collectNGFReplicaCount(ctx context.Context, k8sClient client.Reader, podNSN
 		types.NamespacedName{Namespace: podNSName.Namespace, Name: podNSName.Name},
 		&pod,
 	); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to get NGF Pod: %w", err)
 	}
 
 	podOwnerRefs := pod.GetOwnerReferences()
@@ -184,7 +184,7 @@ func collectNGFReplicaCount(ctx context.Context, k8sClient client.Reader, podNSN
 		types.NamespacedName{Namespace: podNSName.Namespace, Name: podOwnerRefs[0].Name},
 		&replicaSet,
 	); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to get NGF Pod's ReplicaSet: %w", err)
 	}
 
 	if replicaSet.Spec.Replicas == nil {

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Collector", Ordered, func() {
 		version                 string
 		expData                 telemetry.Data
 		ctx                     context.Context
+		podNSName               types.NamespacedName
 	)
 
 	BeforeAll(func() {
@@ -60,11 +61,16 @@ var _ = Describe("Collector", Ordered, func() {
 			ProjectMetadata:   telemetry.ProjectMetadata{Name: "NGF", Version: version},
 			NodeCount:         0,
 			NGFResourceCounts: telemetry.NGFResourceCounts{},
+			NGFReplicaCount:   0,
 		}
 
 		k8sClientReader = &eventsfakes.FakeReader{}
 		fakeGraphGetter = &telemetryfakes.FakeGraphGetter{}
 		fakeConfigurationGetter = &telemetryfakes.FakeConfigurationGetter{}
+		podNSName = types.NamespacedName{
+			Namespace: "nginx-gateway",
+			Name:      "ngf-pod",
+		}
 
 		fakeGraphGetter.GetLatestGraphReturns(&graph.Graph{})
 		fakeConfigurationGetter.GetLatestConfigurationReturns(&dataplane.Configuration{})
@@ -74,6 +80,7 @@ var _ = Describe("Collector", Ordered, func() {
 			GraphGetter:         fakeGraphGetter,
 			ConfigurationGetter: fakeConfigurationGetter,
 			Version:             version,
+			PodNSName:           podNSName,
 		})
 	})
 

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -46,7 +46,7 @@ func createGetCallsFunc() func(
 	object client.Object,
 	option ...client.GetOption,
 ) error {
-	return func(ctx context.Context, key client.ObjectKey, object client.Object, option ...client.GetOption) error {
+	return func(_ context.Context, _ client.ObjectKey, object client.Object, option ...client.GetOption) error {
 		Expect(option).To(BeEmpty())
 
 		switch typedObj := object.(type) {
@@ -414,7 +414,7 @@ var _ = Describe("Collector", Ordered, func() {
 				It("should error if the kubernetes client errored when getting the Pod", func() {
 					expectedErr := errors.New("there was an error getting the Pod")
 					k8sClientReader.GetCalls(
-						func(ctx context.Context, key client.ObjectKey, object client.Object, option ...client.GetOption) error {
+						func(_ context.Context, _ client.ObjectKey, object client.Object, option ...client.GetOption) error {
 							Expect(option).To(BeEmpty())
 
 							switch typedObj := object.(type) {
@@ -433,7 +433,7 @@ var _ = Describe("Collector", Ordered, func() {
 				It("should error if the Pod's owner reference is nil", func() {
 					expectedErr := errors.New("expected one owner reference of the NGF Pod, got 0")
 					k8sClientReader.GetCalls(
-						func(ctx context.Context, key client.ObjectKey, object client.Object, option ...client.GetOption) error {
+						func(_ context.Context, _ client.ObjectKey, object client.Object, option ...client.GetOption) error {
 							Expect(option).To(BeEmpty())
 
 							switch typedObj := object.(type) {
@@ -455,7 +455,7 @@ var _ = Describe("Collector", Ordered, func() {
 				It("should error if the Pod has multiple owner references", func() {
 					expectedErr := errors.New("expected one owner reference of the NGF Pod, got 2")
 					k8sClientReader.GetCalls(
-						func(ctx context.Context, key client.ObjectKey, object client.Object, option ...client.GetOption) error {
+						func(_ context.Context, _ client.ObjectKey, object client.Object, option ...client.GetOption) error {
 							Expect(option).To(BeEmpty())
 
 							switch typedObj := object.(type) {
@@ -486,7 +486,7 @@ var _ = Describe("Collector", Ordered, func() {
 				It("should error if the Pod's owner reference is not a ReplicaSet", func() {
 					expectedErr := errors.New("expected pod owner reference to be ReplicaSet, got Deployment")
 					k8sClientReader.GetCalls(
-						func(ctx context.Context, key client.ObjectKey, object client.Object, option ...client.GetOption) error {
+						func(_ context.Context, _ client.ObjectKey, object client.Object, option ...client.GetOption) error {
 							Expect(option).To(BeEmpty())
 
 							switch typedObj := object.(type) {
@@ -513,7 +513,7 @@ var _ = Describe("Collector", Ordered, func() {
 				It("should error if the replica set's replicas is nil", func() {
 					expectedErr := errors.New("replica set replicas was nil")
 					k8sClientReader.GetCalls(
-						func(ctx context.Context, key client.ObjectKey, object client.Object, option ...client.GetOption) error {
+						func(_ context.Context, _ client.ObjectKey, object client.Object, option ...client.GetOption) error {
 							Expect(option).To(BeEmpty())
 
 							switch typedObj := object.(type) {
@@ -544,7 +544,7 @@ var _ = Describe("Collector", Ordered, func() {
 				It("should error if the kubernetes client errored when getting the ReplicaSet", func() {
 					expectedErr := errors.New("there was an error getting the ReplicaSet")
 					k8sClientReader.GetCalls(
-						func(ctx context.Context, key client.ObjectKey, object client.Object, option ...client.GetOption) error {
+						func(_ context.Context, _ client.ObjectKey, object client.Object, option ...client.GetOption) error {
 							Expect(option).To(BeEmpty())
 
 							switch typedObj := object.(type) {


### PR DESCRIPTION
Problem: Want to collect deployment replica count as a telemetry datapoint. 

Solution: Collect deployment replica count.

Testing: E2E testing and additional unit tests.

When at 1 replica:
```
{"level":"debug","ts":"2024-02-08T00:28:47Z","logger":"telemetryJob","msg":"Gathering telemetry data"}
{"level":"debug","ts":"2024-02-08T00:28:47Z","logger":"telemetryJob","msg":"Exporting telemetry data"}
{"level":"debug","ts":"2024-02-08T00:28:47Z","logger":"telemetryExporter","msg":"Exporting telemetry","data":{"ProjectMetadata":{"Name":"NGF","Version":"edge"},"NodeCount":1,"NGFResourceCounts":{"Gateways":0,"GatewayClasses":1,"HTTPRoutes":0,"Secrets":0,"Services":0,"Endpoints":0},"NGFReplicaCount":1}}
```

When scaled to 3 replicas:
```
{"level":"debug","ts":"2024-02-08T00:31:48Z","logger":"telemetryJob","msg":"Gathering telemetry data"}
{"level":"debug","ts":"2024-02-08T00:31:48Z","logger":"telemetryJob","msg":"Exporting telemetry data"}
{"level":"debug","ts":"2024-02-08T00:31:48Z","logger":"telemetryExporter","msg":"Exporting telemetry","data":{"ProjectMetadata":{"Name":"NGF","Version":"edge"},"NodeCount":1,"NGFResourceCounts":{"Gateways":0,"GatewayClasses":1,"HTTPRoutes":0,"Secrets":0,"Services":0,"Endpoints":0},"NGFReplicaCount":3}}
```

Closes #1307

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
