### PR TITLE
Update package for CVE-2023-52425

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           images: |
             name=ghcr.io/nginxinc/nginx-gateway-fabric,enable=${{ inputs.image == 'ngf' && github.event_name != 'pull_request' }}
             name=ghcr.io/nginxinc/nginx-gateway-fabric/nginx,enable=${{ inputs.image == 'nginx' && github.event_name != 'pull_request' }}
-            name=docker-mgmt.nginx.com/nginx-gateway-fabric/nginx-plus,enable=${{ inputs.image == 'nginx-plus' && github.event_name != 'pull_request' }}
+            name=docker-mgmt.nginx.com/nginx-gateway-fabric/nginx-plus,enable=${{ inputs.image == 'plus' && github.event_name != 'pull_request' }}
             name=localhost:5000/nginx-gateway-fabric/${{ inputs.image }}
           flavor: |
             latest=${{ (inputs.tag != '' && 'true') || 'auto' }}
@@ -114,7 +114,7 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
-          file: build/Dockerfile${{ inputs.image == 'nginx' && '.nginx' || '' }}${{ inputs.image == 'nginx-plus' && '.nginxplus' || '' }}
+          file: build/Dockerfile${{ inputs.image == 'nginx' && '.nginx' || '' }}${{ inputs.image == 'plus' && '.nginxplus' || '' }}
           context: "."
           target: ${{ inputs.image == 'ngf' && 'goreleaser' || '' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -154,6 +154,7 @@ jobs:
         continue-on-error: true
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
+        if: always()
 
       - name: Upload Scan Results
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
@@ -162,5 +163,6 @@ jobs:
           name: scan-results-${{ inputs.image }}
           path: |
             ${{ steps.scan.outputs.sarif }}
-            !sbom-nginx-plus.json
+            *.json
+            !sbom-plus.json
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ngf, nginx, nginx-plus]
+        image: [ngf, nginx, plus]
         platforms: ["linux/arm64, linux/amd64"]
     uses: ./.github/workflows/build.yml
     with:

--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -5,10 +5,12 @@ ARG NJS_DIR
 ARG NGINX_CONF_DIR
 ARG BUILD_AGENT
 
-RUN apk update && apk upgrade && apk add --no-cache libcap \
+RUN apk add --no-cache libcap \
     && mkdir -p /var/lib/nginx /usr/lib/nginx/modules \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+    # Update packages for CVE-2023-52425
+    && apk --no-cache upgrade libexpat \
     && apk del libcap
 
 COPY ${NJS_DIR}/httpmatches.js /usr/lib/nginx/modules/njs/httpmatches.js


### PR DESCRIPTION
### Proposed changes

Problem: There's a new CVE in the base image, but since Docker is caching the layer, `apk update && apk upgrade` doesn't have any effect.

Solution: Only upgrade the affected package. This will invalidate the cache and only upgrade the package with a CVE. This also makes the build somewhat reproducible since we're not updating all the packages at build time.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
