### PR TITLE
Update package for CVE-2024-25062 and remove fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,12 +148,14 @@ jobs:
           sbom: "sbom-${{ inputs.image }}.json"
           only-fixed: true
           add-cpes-if-none: true
+          fail-build: false
 
       - name: Upload scan result to GitHub Security tab
         uses: github/codeql-action/upload-sarif@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
         continue-on-error: true
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: build-${{ inputs.image }}
         if: always()
 
       - name: Upload Scan Results

--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -9,8 +9,8 @@ RUN apk add --no-cache libcap \
     && mkdir -p /var/lib/nginx /usr/lib/nginx/modules \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-    # Update packages for CVE-2023-52425
-    && apk --no-cache upgrade libexpat \
+    # Update packages for CVE-2023-52425 and CVE-2024-25062
+    && apk --no-cache upgrade libexpat libxml2 \
     && apk del libcap
 
 COPY ${NJS_DIR}/httpmatches.js /usr/lib/nginx/modules/njs/httpmatches.js


### PR DESCRIPTION
### Proposed changes

Problem: There's a new CVE and it's making fail all the PRs

Solution: Update the package affected by the CVE and stop failing on new CVE, just alert us.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
