### PR TITLE
Add installed architecture to telemetry data

### DIFF
--- a/internal/mode/static/telemetry/collector.go
+++ b/internal/mode/static/telemetry/collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -52,6 +53,7 @@ type Data struct {
 	ProjectMetadata   ProjectMetadata
 	ClusterID         string
 	ImageSource       string
+	Arch              string
 	NGFResourceCounts NGFResourceCounts
 	NodeCount         int
 	NGFReplicaCount   int
@@ -119,6 +121,7 @@ func (c DataCollectorImpl) Collect(ctx context.Context) (Data, error) {
 		NGFReplicaCount: ngfReplicaCount,
 		ClusterID:       clusterID,
 		ImageSource:     c.cfg.ImageSource,
+		Arch:            runtime.GOARCH,
 	}
 
 	return data, nil

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -124,6 +125,7 @@ var _ = Describe("Collector", Ordered, func() {
 			NGFReplicaCount:   1,
 			ClusterID:         string(kubeNamespace.GetUID()),
 			ImageSource:       "local",
+			Arch:              runtime.GOARCH,
 		}
 
 		k8sClientReader = &eventsfakes.FakeReader{}


### PR DESCRIPTION
Problem: As a maintainer of NGF/NIC
I want to record the architecture used (ARM, x86, etc) from all participating NGF installations So that I can ensure used architectures are tested.

Solution: Use the golang runtime library to extract the architecture


Testing: Verified value in logs:

```
{"level":"debug","ts":"2024-02-21T18:03:03Z","logger":"telemetryExporter","msg":"Exporting telemetry","data":{"ProjectMetadata":{"Name":"NGF","Version":"edge"},"ClusterID":"3b13d5bb-3ccb-4a25-9caf-99d3f9ba89ad","Arch":"arm64","NodeCount":1,"NGFResourceCounts":{"Gateways":1,"GatewayClasses":1,"HTTPRoutes":2,"Secrets":0,"Services":2,"Endpoints":2},"NGFReplicaCount":1}}
```

Closes #1316

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
NONE
```