### PR TITLE
Move version in event handler

### DIFF
--- a/internal/mode/static/handler.go
+++ b/internal/mode/static/handler.go
@@ -77,8 +77,6 @@ type eventHandlerConfig struct {
 	nginxConfiguredOnStartChecker *nginxConfiguredOnStartChecker
 	// controlConfigNSName is the NamespacedName of the NginxGateway config for this controller.
 	controlConfigNSName types.NamespacedName
-	// version is the current version number of the nginx config.
-	version int
 }
 
 // filterKey is the `kind_namespace_name" of an object being filtered.
@@ -107,6 +105,9 @@ type eventHandlerImpl struct {
 
 	cfg  eventHandlerConfig
 	lock sync.Mutex
+
+	// version is the current version number of the nginx config.
+	version int
 }
 
 // newEventHandlerImpl creates a new eventHandlerImpl.
@@ -177,8 +178,8 @@ func (h *eventHandlerImpl) HandleEventBatch(ctx context.Context, logger logr.Log
 		}
 		return
 	case state.EndpointsOnlyChange:
-		h.cfg.version++
-		cfg := dataplane.BuildConfiguration(ctx, graph, h.cfg.serviceResolver, h.cfg.version)
+		h.version++
+		cfg := dataplane.BuildConfiguration(ctx, graph, h.cfg.serviceResolver, h.version)
 
 		h.setLatestConfiguration(&cfg)
 
@@ -188,8 +189,8 @@ func (h *eventHandlerImpl) HandleEventBatch(ctx context.Context, logger logr.Log
 			cfg,
 		)
 	case state.ClusterStateChange:
-		h.cfg.version++
-		cfg := dataplane.BuildConfiguration(ctx, graph, h.cfg.serviceResolver, h.cfg.version)
+		h.version++
+		cfg := dataplane.BuildConfiguration(ctx, graph, h.cfg.serviceResolver, h.version)
 
 		h.setLatestConfiguration(&cfg)
 


### PR DESCRIPTION
### Proposed changes

Problem: The version variable is used by handler to track generated config versions. It is part of the handler config, which means we expect it to be configurable when creating the handler. However, it is not configurable, so should not be part of the config.

Solution: Refactor the handler so that version is part of the handler, not its config

Testing: Ensured all tests still pass successfully and manual verification of the config version file

Closes #1416 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
