### PR TITLE
Add functional test for product telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
           AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
           AZURE_BUCKET_NAME: ${{ secrets.AZURE_BUCKET_NAME }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMMUNITY }}
+          TELEMETRY_ENDPOINT: "" # disables sending telemetry
+          TELEMETRY_ENDPOINT_INSECURE: "false"
 
       - name: Cache Artifacts
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -84,6 +84,9 @@ jobs:
         with:
           version: latest
           args: build --snapshot --clean
+        env:
+          TELEMETRY_ENDPOINT: "" # disables sending telemetry
+          TELEMETRY_ENDPOINT_INSECURE: "false"
 
       - name: Build NGF Docker Image
         uses: docker/build-push-action@af5a7ed5ba88268d5278f7203fb52cd833f66d6e # v5.2.0

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -73,6 +73,9 @@ jobs:
         with:
           version: latest
           args: build --snapshot --clean
+        env:
+          TELEMETRY_ENDPOINT: otel-collector-opentelemetry-collector.collector.svc.cluster.local:4317
+          TELEMETRY_ENDPOINT_INSECURE: "false"
 
       - name: Build NGF Docker Image
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
@@ -116,9 +119,9 @@ jobs:
           make load-images${{ matrix.nginx-image == 'nginx-plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag}
         working-directory: ./tests
 
-      - name: Run functional tests
+      - name: Run functional telemetry tests
         run: |
           ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
-          make test${{ matrix.nginx-image == 'nginx-plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag}
+          make test${{ matrix.nginx-image == 'nginx-plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag} GINKGO_LABEL=telemetry
         working-directory: ./tests

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -75,7 +75,7 @@ jobs:
           args: build --snapshot --clean
         env:
           TELEMETRY_ENDPOINT: otel-collector-opentelemetry-collector.collector.svc.cluster.local:4317
-          TELEMETRY_ENDPOINT_INSECURE: "false"
+          TELEMETRY_ENDPOINT_INSECURE: "true"
 
       - name: Build NGF Docker Image
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,13 @@ builds:
     asmflags:
       - all=-trimpath={{.Env.GOPATH}}
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.telemetryReportPeriod=24h -X main.telemetryEndpointInsecure=false
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+      - -X main.telemetryReportPeriod=24h
+      - -X main.telemetryEndpoint={{.Env.TELEMETRY_ENDPOINT}}
+      - -X main.telemetryEndpointInsecure={{.Env.TELEMETRY_ENDPOINT_INSECURE}}
     main: ./cmd/gateway/
     binary: gateway
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,6 +13,8 @@ GINKGO_LABEL=
 GINKGO_FLAGS=
 NGF_VERSION=
 CI=false
+TELEMETRY_ENDPOINT=
+TELEMETRY_ENDPOINT_INSECURE=
 
 ifneq ($(GINKGO_LABEL),)
     override GINKGO_FLAGS += -ginkgo.label-filter "$(GINKGO_LABEL)"
@@ -38,11 +40,11 @@ delete-kind-cluster: ## Delete kind cluster
 
 .PHONY: build-images
 build-images: ## Build NGF and NGINX images
-	cd .. && make PREFIX=$(PREFIX) TAG=$(TAG) build-images
+	cd .. && make PREFIX=$(PREFIX) TAG=$(TAG) TELEMETRY_ENDPOINT=$(TELEMETRY_ENDPOINT) TELEMETRY_ENDPOINT_INSECURE=$(TELEMETRY_ENDPOINT_INSECURE) build-images
 
 .PHONY: build-images-with-plus
 build-images-with-plus: ## Build NGF and NGINX Plus images
-	cd .. && make PREFIX=$(PREFIX) TAG=$(TAG) build-images-with-plus
+	cd .. && make PREFIX=$(PREFIX) TAG=$(TAG) TELEMETRY_ENDPOINT=$(TELEMETRY_ENDPOINT) TELEMETRY_ENDPOINT_INSECURE=$(TELEMETRY_ENDPOINT_INSECURE) build-images-with-plus
 
 .PHONY: load-images
 load-images: ## Load NGF and NGINX images on configured kind cluster

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,20 +68,23 @@ test-with-plus                 Runs the functional tests for NGF with NGINX Plus
 
 **Note:** The following variables are configurable when running the below `make` commands:
 
-| Variable            | Default                         | Description                                                    |
-| ------------------- | ------------------------------- | -------------------------------------------------------------- |
-| TAG                 | edge                            | tag for the locally built NGF images                           |
-| PREFIX              | nginx-gateway-fabric            | prefix for the locally built NGF image                         |
-| NGINX_PREFIX        | nginx-gateway-fabric/nginx      | prefix for the locally built NGINX image                       |
-| NGINX_PLUS_PREFIX   | nginx-gateway-fabric/nginx-plus | prefix for the locally built NGINX Plus image                  |
-| PLUS_ENABLED        | false                           | Flag to indicate if NGINX Plus should be enabled               |
-| PULL_POLICY         | Never                           | NGF image pull policy                                          |
-| GW_API_VERSION      | 1.0.0                           | version of Gateway API resources to install                    |
-| K8S_VERSION         | latest                          | version of k8s that the tests are run on                       |
-| GW_SERVICE_TYPE     | NodePort                        | type of Service that should be created                         |
-| GW_SVC_GKE_INTERNAL | false                           | specifies if the LoadBalancer should be a GKE internal service |
-| GINKGO_LABEL        | ""                              | name of the ginkgo label that will filter the tests to run     |
-| GINKGO_FLAGS        | ""                              | other ginkgo flags to pass to the go test command              |
+| Variable                     | Default                         | Description                                                         |
+|------------------------------|---------------------------------|---------------------------------------------------------------------|
+| TAG                          | edge                            | tag for the locally built NGF images                                |
+| PREFIX                       | nginx-gateway-fabric            | prefix for the locally built NGF image                              |
+| NGINX_PREFIX                 | nginx-gateway-fabric/nginx      | prefix for the locally built NGINX image                            |
+| NGINX_PLUS_PREFIX            | nginx-gateway-fabric/nginx-plus | prefix for the locally built NGINX Plus image                       |
+| PLUS_ENABLED                 | false                           | Flag to indicate if NGINX Plus should be enabled                    |
+| PULL_POLICY                  | Never                           | NGF image pull policy                                               |
+| GW_API_VERSION               | 1.0.0                           | version of Gateway API resources to install                         |
+| K8S_VERSION                  | latest                          | version of k8s that the tests are run on                            |
+| GW_SERVICE_TYPE              | NodePort                        | type of Service that should be created                              |
+| GW_SVC_GKE_INTERNAL          | false                           | specifies if the LoadBalancer should be a GKE internal service      |
+| GINKGO_LABEL                 | ""                              | name of the ginkgo label that will filter the tests to run          |
+| GINKGO_FLAGS                 | ""                              | other ginkgo flags to pass to the go test command                   |
+| TELEMETRY_ENDPOINT           | Set in the main Makefile        | The endpoint to which telemetry reports are sent                    |
+| TELEMETRY_ENDPOINT_INSECURE= | Set in the main Makefile        | Controls whether TLS should be used when sending telemetry reports. |
+
 
 ## Step 1 - Create a Kubernetes cluster
 
@@ -137,6 +140,12 @@ Or, to build NGF with NGINX Plus enabled (NGINX Plus cert and key must exist in 
 make build-images-with-plus load-images-with-plus TAG=$(whoami)
 ```
 
+For the telemetry test, which requires a OTel collector, build an image with the following variables set:
+
+```makefile
+TELEMETRY_ENDPOINT=otel-collector-opentelemetry-collector.collector.svc.cluster.local:4317 TELEMETRY_ENDPOINT_INSECURE=true
+```
+
 ## Step 3 - Run the tests
 
 ### 3a - Run the functional tests locally
@@ -149,6 +158,15 @@ Or, to run the tests with NGINX Plus enabled:
 
 ```makefile
 make test TAG=$(whoami) PLUS_ENABLED=true
+```
+
+> The command above doesn't run the telemetry functional test, which requires a dedicated invocation because it uses a
+> specially built image (see above) and it needs to deploy NGF differently from the rest of functional tests.
+
+To run the telemetry test:
+
+```makefile
+make test TAG=$(whoami) GINKGO_LABEL=telemetry
 ```
 
 ### 3b - Run the tests on a GKE cluster from a GCP VM

--- a/tests/suite/manifests/telemetry/collector-values.yaml
+++ b/tests/suite/manifests/telemetry/collector-values.yaml
@@ -1,0 +1,31 @@
+mode: deployment
+replicaCount: 1
+config:
+  exporters:
+    debug:
+      verbosity: detailed
+    logging: {}
+  extensions:
+    health_check: {}
+    memory_ballast:
+      size_in_percentage: 40
+  processors:
+    batch: {}
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+  service:
+    extensions:
+    - health_check
+    pipelines:
+      traces:
+        exporters:
+        - debug
+        receivers:
+        - otlp

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -1,0 +1,166 @@
+package suite
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+	crClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	collectorNamespace        = "collector"
+	collectorChartReleaseName = "otel-collector"
+	// FIXME(pleshakov): Find a automated way to keep the version updated here similar to dependabot.
+	// https://github.com/nginxinc/nginx-gateway-fabric/issues/1665
+	collectorChartVersion = "0.73.1"
+)
+
+var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func() {
+	BeforeEach(func() {
+		// Because NGF reports telemetry on start, we need to install the collector first.
+
+		// Install collector
+		output, err := installCollector()
+		Expect(err).ToNot(HaveOccurred(), string(output))
+
+		// Install NGF
+		// Note: the suite doesn't install NGF for 'telemetry' label
+
+		setup(getDefaultSetupCfg())
+	})
+
+	AfterEach(func() {
+		output, err := uninstallCollector()
+		Expect(err).ToNot(HaveOccurred(), string(output))
+	})
+
+	It("sends telemetry", func() {
+		names, err := resourceManager.GetPodNames(
+			collectorNamespace,
+			crClient.MatchingLabels{
+				"app.kubernetes.io/name": "opentelemetry-collector",
+			},
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(names).To(HaveLen(1))
+
+		name := names[0]
+
+		// We assert that all data points were sent
+		// For some data points, as a sanity check, we assert on sent values.
+
+		info, err := resourceManager.GetClusterInfo()
+		Expect(err).ToNot(HaveOccurred())
+
+		ngfDeployment, err := resourceManager.GetNGFDeployment(ngfNamespace, releaseName)
+		Expect(err).ToNot(HaveOccurred())
+
+		matchFirstExpectedLine := func() bool {
+			logs, err := resourceManager.GetPodLogs(collectorNamespace, name, &core.PodLogOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			return strings.Contains(logs, "dataType: Str(ngf-product-telemetry)")
+		}
+
+		// Wait until the collector has received the telemetry data
+		Eventually(matchFirstExpectedLine, "30s", "5s").Should(BeTrue())
+
+		logs, err := resourceManager.GetPodLogs(collectorNamespace, name, &core.PodLogOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		assertConsecutiveLinesInLogs(
+			logs,
+			[]string{
+				"ImageSource:",
+				"ProjectName: Str(NGF)",
+				"ProjectVersion:",
+				"ProjectArchitecture:",
+				fmt.Sprintf("ClusterID: Str(%s)", info.ID),
+				"ClusterVersion:",
+				"ClusterPlatform:",
+				fmt.Sprintf("InstallationID: Str(%s)", ngfDeployment.UID),
+				fmt.Sprintf("ClusterNodeCount: Int(%d)", info.NodeCount),
+				"FlagNames: Slice",
+				"FlagValues: Slice",
+				"GatewayCount: Int(0)",
+				"GatewayClassCount: Int(1)",
+				"HTTPRouteCount: Int(0)",
+				"SecretCount: Int(0)",
+				"ServiceCount: Int(0)",
+				"EndpointCount: Int(0)",
+				"NGFReplicaCount: Int(1)",
+			},
+		)
+	})
+})
+
+func installCollector() ([]byte, error) {
+	repoAddArgs := []string{
+		"repo",
+		"add",
+		"open-telemetry",
+		"https://open-telemetry.github.io/opentelemetry-helm-charts",
+	}
+
+	if output, err := exec.Command("helm", repoAddArgs...).CombinedOutput(); err != nil {
+		return output, err
+	}
+
+	args := []string{
+		"install",
+		collectorChartReleaseName,
+		"open-telemetry/opentelemetry-collector",
+		"--create-namespace",
+		"--namespace", collectorNamespace,
+		"--version", collectorChartVersion,
+		"-f", "manifests/telemetry/collector-values.yaml",
+		"--wait",
+	}
+
+	return exec.Command("helm", args...).CombinedOutput()
+}
+
+func uninstallCollector() ([]byte, error) {
+	args := []string{
+		"uninstall", collectorChartReleaseName,
+		"--namespace", collectorNamespace,
+	}
+
+	return exec.Command("helm", args...).CombinedOutput()
+}
+
+func assertConsecutiveLinesInLogs(logs string, expectedLines []string) {
+	lines := strings.Split(logs, "\n")
+
+	// find first expected line in lines
+
+	i := 0
+
+	for ; i < len(lines); i++ {
+		if strings.Contains(lines[i], expectedLines[0]) {
+			i++
+			break
+		}
+	}
+
+	if i == len(lines) {
+		Fail(fmt.Sprintf("Expected first line not found: %s, \n%s", expectedLines[0], logs))
+	}
+
+	linesLeft := len(lines) - i
+	expectedLinesLeft := len(expectedLines) - 1
+
+	if linesLeft < expectedLinesLeft {
+		format := "Not enough lines remains in the logs, expected %d, got %d\n%s"
+		Fail(fmt.Sprintf(format, linesLeft, expectedLinesLeft, logs))
+	}
+
+	for j := 1; j < len(expectedLines); j++ {
+		Expect(lines[i]).To(ContainSubstring(expectedLines[j]))
+		i++
+	}
+}

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 		Expect(err).ToNot(HaveOccurred(), string(output))
 
 		// Install NGF
-		// Note: the suite doesn't install NGF for 'telemetry' label
+		// Note: the BeforeSuite call doesn't install NGF for 'telemetry' label
 
 		setup(getDefaultSetupCfg())
 	})


### PR DESCRIPTION
### Proposed changes

Problem:
Ensure product telemetry feature is tested with a functional test

Solution:
- Add a functional test.
- Because it requires a NGF with a custom built, it only runs when ginkgo runs with its label.

Testing:
Ran successfully:
- make test TAG=$(whoami) GINKGO_LABEL=telemetry PLUS_ENABLED=true
- make test TAG=$(whoami) GINKGO_LABEL=telemetry
- make test TAG=$(whoami) # here telemetry test was skipped, but all the rest ran successfully

ClOSES - https://github.com/nginxinc/nginx-gateway-fabric/issues/1640
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
