### PR TITLE
Avoid unnecessary build of NGF

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,6 +9,8 @@ RUN go mod download
 COPY . /go/src/github.com/nginxinc/nginx-gateway-fabric
 RUN make build
 
+FROM golang:1.22 as ca-certs-provider
+
 FROM alpine:3.19 as capabilizer
 RUN apk add --no-cache libcap
 
@@ -28,7 +30,7 @@ RUN setcap 'cap_kill=+ep' /usr/bin/gateway
 FROM scratch as common
 # CA certs are needed for telemetry report and NGINX Plus usage report features, so that
 # NGF can verify the server's certificate.
-COPY --from=builder --link /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=ca-certs-provider --link /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 USER 102:1001
 ARG BUILD_AGENT
 ENV BUILD_AGENT=${BUILD_AGENT}


### PR DESCRIPTION
### Proposed changes

Problem:
When building an NGF image, building NGF binary will always happen, even if it's not needed (Docker build target is not local)

Solution:
Fix it by adding a stage for a container that holds CA certs.

Introduced in 799ea76

Closes https://github.com/nginxinc/nginx-gateway-fabric/issues/1680

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
