### PR TITLE
Only write images to cache from the Build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=edge
+            type=schedule
             type=ref,event=pr
             type=ref,event=branch,suffix=-rc,enable=${{ startsWith(github.ref, 'refs/heads/release') }}
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
+  schedule:
+    - cron: "0 4 * * *" # run every day at 4am UTC
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 on:
   push:
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       go_path: ${{ steps.vars.outputs.go_path }}
+      min_k8s_version: ${{ steps.vars.outputs.min_k8s_version }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -37,7 +38,9 @@ jobs:
 
       - name: Output Variables
         id: vars
-        run: echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
+        run: |
+          echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
+          echo "min_k8s_version=1.23.17" >> $GITHUB_OUTPUT
 
       - name: Check if go.mod and go.sum are up to date
         run: go mod tidy && git diff --exit-code -- go.mod go.sum
@@ -160,10 +163,61 @@ jobs:
           path: ${{ github.workspace }}/dist
           key: nginx-gateway-fabric-${{ github.run_id }}-${{ github.run_number }}
 
+  build:
+    name: Build Image
+    needs: [vars, binary]
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ngf, nginx, plus]
+        platforms: ["linux/arm64, linux/amd64"]
+    uses: ./.github/workflows/build.yml
+    with:
+      image: ${{ matrix.image }}
+      platforms: ${{ matrix.platforms }}
+    permissions:
+      contents: read # for docker/build-push-action to read repo content
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      packages: write # for docker/build-push-action to push to GHCR
+      id-token: write # for docker/login to login to NGINX registry
+    secrets: inherit
+
+  functional-tests:
+    name: Functional tests
+    needs: [vars, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [nginx, plus]
+        k8s-version: ["${{ needs.vars.outputs.min_k8s_version }}", "latest"]
+    uses: ./.github/workflows/functional.yml
+    with:
+      image: ${{ matrix.image }}
+      k8s-version: ${{ matrix.k8s-version }}
+    permissions:
+      contents: read
+
+  conformance-tests:
+    name: Conformance tests
+    needs: [vars, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [nginx, plus]
+        k8s-version: ["${{ needs.vars.outputs.min_k8s_version }}", "latest"]
+        enable-experimental: [true, false]
+    uses: ./.github/workflows/conformance.yml
+    with:
+      image: ${{ matrix.image }}
+      k8s-version: ${{ matrix.k8s-version }}
+      enable-experimental: ${{ matrix.enable-experimental }}
+    permissions:
+      contents: write
+
   helm-tests:
     name: Helm Tests
     runs-on: ubuntu-22.04
-    needs: [vars, binary]
+    needs: [vars, build]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -210,7 +264,6 @@ jobs:
           target: goreleaser
           load: true
           cache-from: type=gha,scope=ngf
-          cache-to: type=gha,scope=ngf,mode=max
           pull: true
 
       - name: Build NGINX Docker Image
@@ -221,7 +274,6 @@ jobs:
           context: "."
           load: true
           cache-from: type=gha,scope=nginx
-          cache-to: type=gha,scope=nginx,mode=max
           pull: true
           build-args: |
             NJS_DIR=internal/mode/static/nginx/modules/src
@@ -253,25 +305,6 @@ jobs:
           --set service.type=NodePort
           -n nginx-gateway
         working-directory: ${{ github.workspace }}/deploy/helm-chart
-
-  build:
-    name: Build Image
-    needs: [vars, binary]
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [ngf, nginx, plus]
-        platforms: ["linux/arm64, linux/amd64"]
-    uses: ./.github/workflows/build.yml
-    with:
-      image: ${{ matrix.image }}
-      platforms: ${{ matrix.platforms }}
-    permissions:
-      contents: read # for docker/build-push-action to read repo content
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      packages: write # for docker/build-push-action to push to GHCR
-      id-token: write # for docker/login to login to NGINX registry
-    secrets: inherit
 
   publish-helm:
     name: Package and Publish Helm Chart

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,10 +17,6 @@ defaults:
   run:
     shell: bash
 
-concurrency:
-  group: ${{ github.ref_name }}-conformance
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,49 +1,40 @@
 name: Conformance Testing
 
 on:
-  push:
-    branches:
-      - main
-      - release-*
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
-  pull_request:
-  schedule:
-    - cron: "0 4 * * *" # run every day at 4am UTC
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+      k8s-version:
+        required: true
+        type: string
+      enable-experimental:
+        required: true
+        type: boolean
 
 defaults:
   run:
     shell: bash
-
-concurrency:
-  group: ${{ github.ref_name }}-conformance
-  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   conformance-tests:
-    name: Gateway Conformance Tests
+    name: Run Tests
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        k8s-version: ["1.23.17", "latest"]
-        nginx-image: [nginx, nginx-plus]
-        enable-experimental: [true, false]
     permissions:
       contents: write # needed for uploading release artifacts
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-      - name: Setup Golang Environment
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - name: Fetch Cached Artifacts
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
-          go-version: stable
-
-      - name: Set GOPATH
-        run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          path: ${{ github.workspace }}/dist
+          key: nginx-gateway-fabric-${{ github.run_id }}-${{ github.run_number }}
 
       - name: Docker Buildx
         uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
@@ -65,7 +56,7 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
-            name=ghcr.io/nginxinc/nginx-gateway-fabric/${{ matrix.nginx-image }}
+            name=ghcr.io/nginxinc/nginx-gateway-fabric/${{ inputs.image == 'plus' && 'nginx-plus' || inputs.image }}
           tags: |
             type=semver,pattern={{version}}
             type=edge
@@ -76,17 +67,8 @@ jobs:
         run: |
           ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
-          make update-ngf-manifest${{ matrix.nginx-image == 'nginx-plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag}
+          make update-ngf-manifest${{ inputs.image == 'plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag}
         working-directory: ./conformance
-
-      - name: Build binary
-        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
-        with:
-          version: latest
-          args: build --snapshot --clean
-        env:
-          TELEMETRY_ENDPOINT: "" # disables sending telemetry
-          TELEMETRY_ENDPOINT_INSECURE: "false"
 
       - name: Build NGF Docker Image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
@@ -97,18 +79,16 @@ jobs:
           target: goreleaser
           load: true
           cache-from: type=gha,scope=ngf
-          cache-to: type=gha,scope=ngf,mode=max
           pull: true
 
       - name: Build NGINX Docker Image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
-          file: build/Dockerfile${{ matrix.nginx-image == 'nginx' && '.nginx' || '' }}${{ matrix.nginx-image == 'nginx-plus' && '.nginxplus' || ''}}
+          file: build/Dockerfile${{ inputs.image == 'nginx' && '.nginx' || '' }}${{ inputs.image == 'plus' && '.nginxplus' || ''}}
           tags: ${{ steps.nginx-meta.outputs.tags }}
           context: "."
           load: true
-          cache-from: type=gha,scope=${{ matrix.nginx-image }}
-          cache-to: type=gha,scope=${{ matrix.nginx-image }},mode=max
+          cache-from: type=gha,scope=${{ inputs.image }}
           pull: true
           build-args: |
             NJS_DIR=internal/mode/static/nginx/modules/src
@@ -134,8 +114,8 @@ jobs:
       - name: Deploy Kubernetes
         id: k8s
         run: |
-          k8s_version=${{ matrix.k8s-version }}
-          make create-kind-cluster KIND_KUBE_CONFIG=${{ github.workspace }}/kube-${{ github.run_id }} ${{ ! contains(matrix.k8s-version, 'latest') && 'KIND_IMAGE=kindest/node:v${k8s_version}' || '' }}
+          k8s_version=${{ inputs.k8s-version }}
+          make create-kind-cluster KIND_KUBE_CONFIG=${{ github.workspace }}/kube-${{ github.run_id }} ${{ ! contains(inputs.k8s-version, 'latest') && 'KIND_IMAGE=kindest/node:v${k8s_version}' || '' }}
           echo "KUBECONFIG=${{ github.workspace }}/kube-${{ github.run_id }}" >> "$GITHUB_ENV"
         working-directory: ./conformance
 
@@ -151,9 +131,9 @@ jobs:
           ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
           if [ ${{ github.event_name }} == "schedule" ]; then export GW_API_VERSION=main; fi
-          if [ ${{ startsWith(matrix.k8s-version, '1.23') ||  startsWith(matrix.k8s-version, '1.24') }} == "true" ]; then export INSTALL_WEBHOOK=true; fi
-          if [ ${{ matrix.enable-experimental }} == "true" ]; then export ENABLE_EXPERIMENTAL=true; fi
-          make install-ngf-local-no-build${{ matrix.nginx-image == 'nginx-plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag}
+          if [ ${{ startsWith(inputs.k8s-version, '1.23') ||  startsWith(inputs.k8s-version, '1.24') }} == "true" ]; then export INSTALL_WEBHOOK=true; fi
+          if [ ${{ inputs.enable-experimental }} == "true" ]; then export ENABLE_EXPERIMENTAL=true; fi
+          make install-ngf-local-no-build${{ inputs.image == 'plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag}
         working-directory: ./conformance
 
       - name: Run conformance tests
@@ -165,7 +145,7 @@ jobs:
         working-directory: ./conformance
 
       - name: Upload profile to release
-        if: ${{ matrix.k8s-version == 'latest' && startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ inputs.k8s-version == 'latest' && startsWith(github.ref, 'refs/tags/') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} conformance-profile.yaml

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -125,13 +125,6 @@ jobs:
           echo "KUBECONFIG=${{ github.workspace }}/kube-${{ github.run_id }}" >> "$GITHUB_ENV"
         working-directory: ./conformance
 
-      - name: Wait for release to exist
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          REF=${{ github.ref_name }}
-          until docker pull ghcr.io/nginxinc/nginx-gateway-fabric:${REF#v}; do sleep 5; done
-          until docker pull ghcr.io/nginxinc/nginx-gateway-fabric/nginx:${REF#v}; do sleep 5; done
-
       - name: Setup conformance tests
         run: |
           ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,6 +17,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.ref_name }}-conformance
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -48,6 +52,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=edge
+            type=schedule
             type=ref,event=pr
             type=ref,event=branch,suffix=-rc,enable=${{ startsWith(github.ref, 'refs/heads/release') }}
 
@@ -60,6 +65,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=edge
+            type=schedule
             type=ref,event=pr
             type=ref,event=branch,suffix=-rc,enable=${{ startsWith(github.ref, 'refs/heads/release') }}
 

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -14,10 +14,6 @@ defaults:
   run:
     shell: bash
 
-concurrency:
-  group: ${{ github.ref_name }}-functional
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -14,6 +14,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.ref_name }}-functional
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -44,6 +48,7 @@ jobs:
             name=ghcr.io/nginxinc/nginx-gateway-fabric
           tags: |
             type=semver,pattern={{version}}
+            type=schedule
             type=edge
             type=ref,event=pr
             type=ref,event=branch,suffix=-rc,enable=${{ startsWith(github.ref, 'refs/heads/release') }}
@@ -57,6 +62,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=edge
+            type=schedule
             type=ref,event=pr
             type=ref,event=branch,suffix=-rc,enable=${{ startsWith(github.ref, 'refs/heads/release') }}
 

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,33 +1,26 @@
 name: Functional Testing
 
 on:
-  push:
-    branches:
-      - main
-      - release-*
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
-  pull_request:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+      k8s-version:
+        required: true
+        type: string
 
 defaults:
   run:
     shell: bash
-
-concurrency:
-  group: ${{ github.ref_name }}-functional
-  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   functional-tests:
-    name: Gateway Functional Tests
+    name: Run Tests
     runs-on: ubuntu-22.04
-    strategy:
-        matrix:
-          k8s-version: ["1.23.17", "latest"]
-          nginx-image: [nginx, nginx-plus]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -42,7 +35,6 @@ jobs:
 
       - name: Docker Buildx
         uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
-
 
       - name: NGF Docker meta
         id: ngf-meta
@@ -61,7 +53,7 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
-            name=ghcr.io/nginxinc/nginx-gateway-fabric/${{ matrix.nginx-image }}
+            name=ghcr.io/nginxinc/nginx-gateway-fabric/${{ inputs.image == 'plus' && 'nginx-plus' || inputs.image }}
           tags: |
             type=semver,pattern={{version}}
             type=edge
@@ -85,19 +77,17 @@ jobs:
           context: "."
           load: true
           cache-from: type=gha,scope=ngf
-          cache-to: type=gha,scope=ngf,mode=max
           pull: true
           target: goreleaser
 
       - name: Build NGINX Docker Image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
-          file: build/Dockerfile${{ matrix.nginx-image == 'nginx' && '.nginx' || '' }}${{ matrix.nginx-image == 'nginx-plus' && '.nginxplus' || ''}}
+          file: build/Dockerfile${{ inputs.image == 'nginx' && '.nginx' || '' }}${{ inputs.image == 'plus' && '.nginxplus' || ''}}
           tags: ${{ steps.nginx-meta.outputs.tags }}
           context: "."
           load: true
-          cache-from: type=gha,scope=${{ matrix.nginx-image }}
-          cache-to: type=gha,scope=${{ matrix.nginx-image }},mode=max
+          cache-from: type=gha,scope=${{ inputs.image }}
           pull: true
           build-args: |
             NJS_DIR=internal/mode/static/nginx/modules/src
@@ -107,8 +97,8 @@ jobs:
       - name: Deploy Kubernetes
         id: k8s
         run: |
-          k8s_version=${{ matrix.k8s-version }}
-          make create-kind-cluster KIND_KUBE_CONFIG=${{ github.workspace }}/kube-${{ github.run_id }} ${{ ! contains(matrix.k8s-version, 'latest') && 'KIND_IMAGE=kindest/node:v${k8s_version}' || '' }}
+          k8s_version=${{ inputs.k8s-version }}
+          make create-kind-cluster KIND_KUBE_CONFIG=${{ github.workspace }}/kube-${{ github.run_id }} ${{ ! contains(inputs.k8s-version, 'latest') && 'KIND_IMAGE=kindest/node:v${k8s_version}' || '' }}
           echo "KUBECONFIG=${{ github.workspace }}/kube-${{ github.run_id }}" >> "$GITHUB_ENV"
 
       - name: Setup functional tests
@@ -116,12 +106,12 @@ jobs:
         run: |
           ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
-          make load-images${{ matrix.nginx-image == 'nginx-plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag}
+          make load-images${{ inputs.image == 'plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag}
         working-directory: ./tests
 
       - name: Run functional telemetry tests
         run: |
           ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
-          make test${{ matrix.nginx-image == 'nginx-plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag} GINKGO_LABEL=telemetry
+          make test${{ inputs.image == 'plus' && '-with-plus' || ''}} PREFIX=${ngf_prefix} TAG=${ngf_tag} GINKGO_LABEL=telemetry
         working-directory: ./tests


### PR DESCRIPTION
### Proposed changes

Problem: There are multiple workflows and jobs all writing to the same
cache causing it to be invalidated

Solution: Write to cache only in the Build job and read the cache from
all the other jobs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
