### PR TITLE
Do not send telemetry data if failure in collection

### DIFF
--- a/internal/framework/events/events_test.go
+++ b/internal/framework/events/events_test.go
@@ -31,5 +31,5 @@ func TestEventLoop_SwapBatches(t *testing.T) {
 	g.Expect(eventLoop.currentBatch).To(HaveLen(len(nextBatch)))
 	g.Expect(eventLoop.currentBatch).To(Equal(nextBatch))
 	g.Expect(eventLoop.nextBatch).To(BeEmpty())
-	g.Expect(cap(eventLoop.nextBatch)).To(Equal(3))
+	g.Expect(cap(eventLoop.nextBatch)).To(HaveCap(3))
 }

--- a/internal/framework/events/events_test.go
+++ b/internal/framework/events/events_test.go
@@ -31,5 +31,5 @@ func TestEventLoop_SwapBatches(t *testing.T) {
 	g.Expect(eventLoop.currentBatch).To(HaveLen(len(nextBatch)))
 	g.Expect(eventLoop.currentBatch).To(Equal(nextBatch))
 	g.Expect(eventLoop.nextBatch).To(BeEmpty())
-	g.Expect(cap(eventLoop.nextBatch)).To(HaveCap(3))
+	g.Expect(eventLoop.nextBatch).To(HaveCap(3))
 }

--- a/internal/mode/static/telemetry/job_worker.go
+++ b/internal/mode/static/telemetry/job_worker.go
@@ -27,6 +27,7 @@ func CreateTelemetryJobWorker(
 		data, err := dataCollector.Collect(ctx)
 		if err != nil {
 			logger.Error(err, "Failed to collect telemetry data")
+			return
 		}
 
 		// Export telemetry

--- a/internal/mode/static/usage/job_worker.go
+++ b/internal/mode/static/usage/job_worker.go
@@ -23,16 +23,19 @@ func CreateUsageJobWorker(
 		nodeCount, err := CollectNodeCount(ctx, k8sClient)
 		if err != nil {
 			logger.Error(err, "Failed to collect node count")
+			return
 		}
 
 		podCount, err := GetTotalNGFPodCount(ctx, k8sClient)
 		if err != nil {
 			logger.Error(err, "Failed to collect replica count")
+			return
 		}
 
 		clusterUID, err := telemetry.CollectClusterID(ctx, k8sClient)
 		if err != nil {
 			logger.Error(err, "Failed to collect cluster UID")
+			return
 		}
 
 		clusterDetails := ClusterDetails{

--- a/internal/mode/static/usage/job_worker_test.go
+++ b/internal/mode/static/usage/job_worker_test.go
@@ -37,11 +37,11 @@ func TestCreateUsageJobWorker(t *testing.T) {
 	}
 
 	tests := []struct {
+		name      string
 		listCalls func(_ context.Context, object client.ObjectList, _ ...client.ListOption) error
 		getCalls  func(_ context.Context, _ types.NamespacedName, object client.Object, _ ...client.GetOption) error
-		expErr    error
-		name      string
 		expData   usage.ClusterDetails
+		expErr    bool
 	}{
 		{
 			name: "succeeds",
@@ -77,7 +77,7 @@ func TestCreateUsageJobWorker(t *testing.T) {
 					},
 				},
 			},
-			expErr: nil,
+			expErr: false,
 		},
 		{
 			name: "collect node count fails",
@@ -92,7 +92,7 @@ func TestCreateUsageJobWorker(t *testing.T) {
 				return nil
 			},
 			expData: usage.ClusterDetails{},
-			expErr:  errors.New("failed to collect node list"),
+			expErr:  true,
 		},
 		{
 			name: "collect replica count fails",
@@ -110,7 +110,7 @@ func TestCreateUsageJobWorker(t *testing.T) {
 				return nil
 			},
 			expData: usage.ClusterDetails{},
-			expErr:  errors.New("failed to collect replica set list"),
+			expErr:  true,
 		},
 		{
 			name: "collect cluster UID fails",
@@ -133,7 +133,7 @@ func TestCreateUsageJobWorker(t *testing.T) {
 				return nil
 			},
 			expData: usage.ClusterDetails{},
-			expErr:  errors.New("failed to collect namespace"),
+			expErr:  true,
 		},
 	}
 
@@ -167,7 +167,7 @@ func TestCreateUsageJobWorker(t *testing.T) {
 			defer cancel()
 
 			worker(ctx)
-			if test.expErr != nil {
+			if test.expErr {
 				g.Expect(reporter.ReportCallCount()).To(Equal(0))
 			} else {
 				_, data := reporter.ReportArgsForCall(0)

--- a/internal/mode/static/usage/job_worker_test.go
+++ b/internal/mode/static/usage/job_worker_test.go
@@ -2,6 +2,7 @@ package usage_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -9,17 +10,18 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/events/eventsfakes"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/config"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/usage"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/usage/usagefakes"
 )
 
 func TestCreateUsageJobWorker(t *testing.T) {
-	g := NewWithT(t)
-
 	replicas := int32(1)
 	ngfReplicaSet := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -34,64 +36,145 @@ func TestCreateUsageJobWorker(t *testing.T) {
 		},
 	}
 
-	ngfPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "nginx-gateway",
-			Name:      "ngf-pod",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind: "ReplicaSet",
-					Name: "ngf-replicaset",
+	tests := []struct {
+		listCalls func(_ context.Context, object client.ObjectList, _ ...client.ListOption) error
+		getCalls  func(_ context.Context, _ types.NamespacedName, object client.Object, _ ...client.GetOption) error
+		expErr    error
+		name      string
+		expData   usage.ClusterDetails
+	}{
+		{
+			name: "succeeds",
+			listCalls: func(_ context.Context, object client.ObjectList, _ ...client.ListOption) error {
+				switch typedList := object.(type) {
+				case *v1.NodeList:
+					typedList.Items = append(typedList.Items, v1.Node{})
+					return nil
+				case *appsv1.ReplicaSetList:
+					typedList.Items = append(typedList.Items, *ngfReplicaSet)
+					return nil
+				}
+				return nil
+			},
+			getCalls: func(_ context.Context, _ types.NamespacedName, object client.Object, _ ...client.GetOption) error {
+				switch typedObject := object.(type) {
+				case *v1.Namespace:
+					typedObject.Name = metav1.NamespaceSystem
+					typedObject.UID = "1234abcd"
+					return nil
+				}
+				return nil
+			},
+			expData: usage.ClusterDetails{
+				Metadata: usage.Metadata{
+					UID:         "1234abcd",
+					DisplayName: "my-cluster",
+				},
+				NodeCount: 1,
+				PodDetails: usage.PodDetails{
+					CurrentPodCounts: usage.CurrentPodsCount{
+						PodCount: 1,
+					},
 				},
 			},
+			expErr: nil,
+		},
+		{
+			name: "collect node count fails",
+			listCalls: func(_ context.Context, object client.ObjectList, _ ...client.ListOption) error {
+				switch object.(type) {
+				case *v1.NodeList:
+					return errors.New("failed to collect node list")
+				}
+				return nil
+			},
+			getCalls: func(_ context.Context, _ types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return nil
+			},
+			expData: usage.ClusterDetails{},
+			expErr:  errors.New("failed to collect node list"),
+		},
+		{
+			name: "collect replica count fails",
+			listCalls: func(_ context.Context, object client.ObjectList, _ ...client.ListOption) error {
+				switch typedList := object.(type) {
+				case *v1.NodeList:
+					typedList.Items = append(typedList.Items, v1.Node{})
+					return nil
+				case *appsv1.ReplicaSetList:
+					return errors.New("failed to collect replica set list")
+				}
+				return nil
+			},
+			getCalls: func(_ context.Context, _ types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return nil
+			},
+			expData: usage.ClusterDetails{},
+			expErr:  errors.New("failed to collect replica set list"),
+		},
+		{
+			name: "collect cluster UID fails",
+			listCalls: func(_ context.Context, object client.ObjectList, _ ...client.ListOption) error {
+				switch typedList := object.(type) {
+				case *v1.NodeList:
+					typedList.Items = append(typedList.Items, v1.Node{})
+					return nil
+				case *appsv1.ReplicaSetList:
+					typedList.Items = append(typedList.Items, *ngfReplicaSet)
+					return nil
+				}
+				return nil
+			},
+			getCalls: func(_ context.Context, _ types.NamespacedName, object client.Object, _ ...client.GetOption) error {
+				switch object.(type) {
+				case *v1.Namespace:
+					return errors.New("failed to collect namespace")
+				}
+				return nil
+			},
+			expData: usage.ClusterDetails{},
+			expErr:  errors.New("failed to collect namespace"),
 		},
 	}
 
-	kubeSystem := &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: metav1.NamespaceSystem,
-			UID:  "1234abcd",
-		},
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			k8sClientReader := &eventsfakes.FakeReader{}
+			k8sClientReader.ListCalls(test.listCalls)
+			k8sClientReader.GetCalls(test.getCalls)
+
+			reporter := &usagefakes.FakeReporter{}
+
+			worker := usage.CreateUsageJobWorker(
+				zap.New(),
+				k8sClientReader,
+				reporter,
+				config.Config{
+					GatewayPodConfig: config.GatewayPodConfig{
+						Namespace: "nginx-gateway",
+						Name:      "ngf-pod",
+					},
+					UsageReportConfig: &config.UsageReportConfig{
+						ClusterDisplayName: "my-cluster",
+					},
+				},
+			)
+
+			timeout := 10 * time.Second
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			worker(ctx)
+			if test.expErr != nil {
+				g.Expect(reporter.ReportCallCount()).To(Equal(0))
+			} else {
+				_, data := reporter.ReportArgsForCall(0)
+				g.Expect(data).To(Equal(test.expData))
+			}
+		})
 	}
-
-	k8sClient := fake.NewFakeClient(&v1.Node{}, ngfReplicaSet, ngfPod, kubeSystem)
-	reporter := &usagefakes.FakeReporter{}
-
-	worker := usage.CreateUsageJobWorker(
-		zap.New(),
-		k8sClient,
-		reporter,
-		config.Config{
-			GatewayPodConfig: config.GatewayPodConfig{
-				Namespace: "nginx-gateway",
-				Name:      "ngf-pod",
-			},
-			UsageReportConfig: &config.UsageReportConfig{
-				ClusterDisplayName: "my-cluster",
-			},
-		},
-	)
-
-	expData := usage.ClusterDetails{
-		Metadata: usage.Metadata{
-			UID:         "1234abcd",
-			DisplayName: "my-cluster",
-		},
-		NodeCount: 1,
-		PodDetails: usage.PodDetails{
-			CurrentPodCounts: usage.CurrentPodsCount{
-				PodCount: 1,
-			},
-		},
-	}
-
-	timeout := 10 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	worker(ctx)
-	_, data := reporter.ReportArgsForCall(0)
-	g.Expect(data).To(Equal(expData))
 }
 
 func TestGetTotalNGFPodCount(t *testing.T) {


### PR DESCRIPTION
Fix error handling in telemetry and usage reporting

Problem: We send empty telemetry data if there is any failure in collection of data. We also do the same for NIM usage reporting.

Solution: Don't send telemetry data in case of failure of collection. Also does not send data for NIM usage reporting if there was any failure. Refactored some tests to comply with code coverage. 

Testing: Manually verified bug described in #1729 no longer occurs.

Closes #1729 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
