### PR TITLE
Add workaround for golangci-lint errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,8 @@ jobs:
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
           args: --timeout 10m0s
+          # Disable caching as a workaround for https://github.com/golangci/golangci-lint-action/issues/135.
+          skip-pkg-cache: true
 
   njs-lint:
     name: NJS Lint


### PR DESCRIPTION
### Proposed changes

Problem: golangci-lint is throwing hundreds of errors on setup, making it hard to see the actual run and slowing down the UI

Solution: The community found a workaround in https://github.com/golangci/golangci-lint-action/issues/135, disabling pkg cache, which seems to be working without affecting performance.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
