### PR TITLE
Update ClientSettingsPolicy future work section

### DIFF
--- a/docs/proposals/client-settings.md
+++ b/docs/proposals/client-settings.md
@@ -411,6 +411,8 @@ All fields in the `ClientSettingsPolicy` will be validated with Open API Schema.
 
 - Add support for more client-related directives, such as `client_body_buffer_size`, `client_header_buffer_size`, or `keepalive_disable`.
 - Extend implementation to support multiple Gateways.
+- Allow attaching to GRPCRoutes. [GRPCRoute implementation](https://github.com/nginxinc/nginx-gateway-fabric/issues/1139) is scheduled for the 1.3 release. All the directives included in this policy are applicable to gRPC servers (HTTP/2 server). For streams, the `client_max_body_size` directive applies to the entire stream, not individual messages. Therefore, for streaming methods it is recommended that this be set to a large value or 0 to disable checking.
+- Extend with HTTP/2 and HTTP/3 directives. For example, `http2_preread_size`, `http2_chunk_size`, `http2_max_concurrent_streams`, etc. See the [HTTP/2](https://nginx.org/en/docs/http/ngx_http_v2_module.html) and [HTTP/3](https://nginx.org/en/docs/http/ngx_http_v3_module.html) modules for more directives.
 - Add more attachment points. For example, allowing attachment to GatewayClasses or Gateway Listeners.
 - Improve on status and discoverability.
 


### PR DESCRIPTION
### Proposed changes

Update the ClientSettingsPolicy future work section to include supporting attaching to GRPCRoutes and adding HTTP/2 and HTTP/3 directives. 

Problem: The ClientSettingsPolicy didn't address GRPCRoute attachment or HTTP/2 and HTTP/3 directives. 

Solution: Add GRPCRoute attachment and HTTP/2 and HTTP/3 directives to the future work section of the ClientSettingsPolicy.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
