### PR TITLE
Force conformance tests to fail properly

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -103,6 +103,7 @@ run-conformance-tests: ## Run conformance tests
 		--restart=Never -- sh -c "go test -v . -tags conformance,experimental -args --gateway-class=$(GATEWAY_CLASS) \
 						        --supported-features=$(SUPPORTED_FEATURES) --version=$(VERSION) \
 								--report-output=output.txt; cat output.txt" | tee output.txt
+	bash scripts/check-pod-exit-code.sh
 	sed -e '1,/CONFORMANCE PROFILE/d' output.txt > conformance-profile.yaml
 	rm output.txt
 	[ $(shell cat conformance-profile.yaml | yq '.profiles[0].core.result') != "failure" ] \

--- a/conformance/scripts/check-pod-exit-code.sh
+++ b/conformance/scripts/check-pod-exit-code.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+CODE=$(kubectl get pod conformance -o jsonpath='{.status.containerStatuses[].state.terminated.exitCode}')
+if [ $CODE -ne 0 ]; then
+    exit 2
+fi


### PR DESCRIPTION
Problem: If the conformance test Pod runner failed, the `make` process would still pass. This is because the failure code would not propagate to outside of the Pod.

Solution: After the Pod runs, check the exit code and fail it it's non-zero. Used a bash script for this because running the `kubectl get pod` command in the Makefile would not return an Errored Pod for some reason. Only worked in bash.

Closes #1784 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
