### PR TITLE
POC - Refactor Status Updater to be resource agnostic

### DIFF
--- a/internal/framework/status2/updater.go
+++ b/internal/framework/status2/updater.go
@@ -1,0 +1,239 @@
+package status2
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller"
+)
+
+// K8sUpdater updates a resource from the k8s API.
+// It allows us to mock the client.Reader.Status.Update method.
+type K8sUpdater interface {
+	// Update is from client.StatusClient.SubResourceWriter.
+	Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error
+}
+
+type UpdateRequest struct {
+	NsName       types.NamespacedName
+	ResourceType client.Object
+	Setter       Setter
+}
+
+type Setter func(client.Object) bool
+
+type Updater struct {
+	client client.Client
+	logger logr.Logger
+}
+
+func NewUpdater(client client.Client, logger logr.Logger) *Updater {
+	return &Updater{
+		client: client,
+		logger: logger,
+	}
+}
+
+func (u *Updater) Update(ctx context.Context, reqs ...UpdateRequest) {
+	for _, r := range reqs {
+		u.writeStatuses(ctx, r.NsName, r.ResourceType, r.Setter)
+	}
+}
+
+func (u *Updater) writeStatuses(
+	ctx context.Context,
+	nsname types.NamespacedName,
+	obj client.Object,
+	statusSetter Setter,
+) {
+	err := wait.ExponentialBackoffWithContext(
+		ctx,
+		wait.Backoff{
+			Duration: time.Millisecond * 200,
+			Factor:   2,
+			Jitter:   0.5,
+			Steps:    4,
+			Cap:      time.Millisecond * 3000,
+		},
+		// Function returns true if the condition is satisfied, or an error if the loop should be aborted.
+		NewRetryUpdateFunc(u.client, u.client.Status(), nsname, obj, u.logger, statusSetter),
+	)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		u.logger.Error(
+			err,
+			"Failed to update status",
+			"namespace", nsname.Namespace,
+			"name", nsname.Name,
+			"kind", obj.GetObjectKind().GroupVersionKind().Kind)
+	}
+}
+
+// NewRetryUpdateFunc returns a function which will be used in wait.ExponentialBackoffWithContext.
+// The function will attempt to Update a kubernetes resource and will be retried in
+// wait.ExponentialBackoffWithContext if an error occurs. Exported for testing purposes.
+//
+// wait.ExponentialBackoffWithContext will retry if this function returns nil as its error,
+// which is what we want if we encounter an error from the functions we call. However,
+// the linter will complain if we return nil if an error was found.
+//
+//nolint:nilerr
+func NewRetryUpdateFunc(
+	getter controller.Getter,
+	updater K8sUpdater,
+	nsname types.NamespacedName,
+	obj client.Object,
+	logger logr.Logger,
+	statusSetter func(client.Object) bool,
+) func(ctx context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		// The function handles errors by reporting them in the logs.
+		// We need to get the latest version of the resource.
+		// Otherwise, the Update status API call can fail.
+		// Note: the default client uses a cache for reads, so we're not making an unnecessary API call here.
+		// the default is configurable in the Manager options.
+		if err := getter.Get(ctx, nsname, obj); err != nil {
+			// apierrors.IsNotFound(err) can happen when the resource is deleted,
+			// so no need to retry or return an error.
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+
+			logger.V(1).Info(
+				"Encountered error when getting resource to update status",
+				"error", err,
+				"namespace", nsname.Namespace,
+				"name", nsname.Name,
+				"kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			)
+
+			return false, nil
+		}
+
+		if !statusSetter(obj) {
+			logger.V(1).Info(
+				"Skipping status update because there's no change",
+				"namespace", nsname.Namespace,
+				"name", nsname.Name,
+				"kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			)
+
+			return true, nil
+		}
+
+		if err := updater.Update(ctx, obj); err != nil {
+			logger.V(1).Info(
+				"Encountered error updating status",
+				"error", err,
+				"namespace", nsname.Namespace,
+				"name", nsname.Name,
+				"kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			)
+
+			return false, nil
+		}
+
+		return true, nil
+	}
+}
+
+type GroupUpdateRequest struct {
+	Name    string
+	Request []UpdateRequest
+}
+
+type CachingGroupUpdater struct {
+	updater *Updater
+	lock    *sync.Mutex
+	groups  map[string]GroupUpdateRequest
+	enabled bool
+}
+
+func NewCachingGroupUpdater(updater *Updater) *CachingGroupUpdater {
+	return &CachingGroupUpdater{
+		updater: updater,
+		lock:    &sync.Mutex{},
+		groups:  make(map[string]GroupUpdateRequest),
+	}
+}
+
+func (u *CachingGroupUpdater) Update(ctx context.Context, update GroupUpdateRequest) {
+	u.lock.Lock()
+	defer u.lock.Unlock()
+
+	if len(update.Request) == 0 {
+		delete(u.groups, update.Name)
+	}
+
+	u.groups[update.Name] = update
+
+	if !u.enabled {
+		return
+	}
+
+	u.updater.Update(ctx, update.Request...)
+}
+
+func (u *CachingGroupUpdater) Enable(ctx context.Context) {
+	u.lock.Lock()
+	defer u.lock.Unlock()
+
+	u.enabled = true
+
+	for _, update := range u.groups {
+		u.updater.Update(ctx, update.Request...)
+	}
+}
+
+func ConditionsEqual(prev, cur []v1.Condition) bool {
+	return slices.EqualFunc(prev, cur, func(c1, c2 v1.Condition) bool {
+		if c1.ObservedGeneration != c2.ObservedGeneration {
+			return false
+		}
+
+		if c1.Type != c2.Type {
+			return false
+		}
+
+		if c1.Status != c2.Status {
+			return false
+		}
+
+		if c1.Message != c2.Message {
+			return false
+		}
+
+		return c1.Reason == c2.Reason
+	})
+}
+
+func ConvertConditions(
+	conds []conditions.Condition,
+	observedGeneration int64,
+	transitionTime v1.Time,
+) []v1.Condition {
+	apiConds := make([]v1.Condition, len(conds))
+
+	for i := range conds {
+		apiConds[i] = v1.Condition{
+			Type:               conds[i].Type,
+			Status:             conds[i].Status,
+			ObservedGeneration: observedGeneration,
+			LastTransitionTime: transitionTime,
+			Reason:             conds[i].Reason,
+			Message:            conds[i].Message,
+		}
+	}
+
+	return apiConds
+}

--- a/internal/mode/provisioner/manager.go
+++ b/internal/mode/provisioner/manager.go
@@ -20,7 +20,7 @@ import (
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller/predicate"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/events"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/gatewayclass"
-	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/status"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/status2"
 )
 
 // Config is configuration for the provisioner mode.
@@ -121,14 +121,9 @@ func StartManager(cfg Config) error {
 		},
 	)
 
-	statusUpdater := status.NewUpdater(
-		status.UpdaterConfig{
-			Client:                   mgr.GetClient(),
-			Clock:                    status.NewRealClock(),
-			Logger:                   cfg.Logger.WithName("statusUpdater"),
-			GatewayClassName:         cfg.GatewayClassName,
-			UpdateGatewayClassStatus: true,
-		},
+	statusUpdater := status2.NewUpdater(
+		mgr.GetClient(),
+		cfg.Logger.WithName("statusUpdater"),
 	)
 
 	handler := newEventHandler(

--- a/internal/mode/static/status_setters.go
+++ b/internal/mode/static/status_setters.go
@@ -1,0 +1,315 @@
+package static
+
+import (
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/status2"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/graph"
+)
+
+func newNginxGatewayStatusSetter(status ngfAPI.NginxGatewayStatus) func(client.Object) bool {
+	return func(object client.Object) bool {
+		ng := object.(*ngfAPI.NginxGateway)
+
+		if status2.ConditionsEqual(ng.Status.Conditions, status.Conditions) {
+			return false
+		}
+
+		ng.Status = status
+
+		return true
+	}
+}
+
+func newGatewayStatusSetter(gwStatus gatewayv1.GatewayStatus) func(client.Object) bool {
+	return func(object client.Object) bool {
+		gw := object.(*gatewayv1.Gateway)
+
+		if gwStatusEqual(gw.Status, gwStatus) {
+			return false
+		}
+
+		gw.Status = gwStatus
+
+		return true
+	}
+}
+
+func gwStatusEqual(prev, cur gatewayv1.GatewayStatus) bool {
+	addressesEqual := slices.EqualFunc(prev.Addresses, cur.Addresses, func(a1, a2 gatewayv1.GatewayStatusAddress) bool {
+		if !equalPointers[gatewayv1.AddressType](a1.Type, a2.Type) {
+			return false
+		}
+
+		return a1.Value == a2.Value
+	})
+
+	if !addressesEqual {
+		return false
+	}
+
+	if !status2.ConditionsEqual(prev.Conditions, cur.Conditions) {
+		return false
+	}
+
+	return slices.EqualFunc(prev.Listeners, cur.Listeners, func(s1, s2 gatewayv1.ListenerStatus) bool {
+		if s1.Name != s2.Name {
+			return false
+		}
+
+		if s1.AttachedRoutes != s2.AttachedRoutes {
+			return false
+		}
+
+		if !status2.ConditionsEqual(s1.Conditions, s2.Conditions) {
+			return false
+		}
+
+		return slices.EqualFunc(s1.SupportedKinds, s2.SupportedKinds, func(k1, k2 gatewayv1.RouteGroupKind) bool {
+			if k1.Kind != k2.Kind {
+				return false
+			}
+
+			return equalPointers(k1.Group, k2.Group)
+		})
+	})
+}
+
+func newHTTPRouteStatusSetter(hrStatus gatewayv1.HTTPRouteStatus, gatewayCtlrName string) func(client.Object) bool {
+	return func(object client.Object) bool {
+		hr := object.(*gatewayv1.HTTPRoute)
+
+		// keep all the parent statuses that belong to other controllers
+		for _, os := range hr.Status.Parents {
+			if string(os.ControllerName) != gatewayCtlrName {
+				hrStatus.Parents = append(hrStatus.Parents, os)
+			}
+		}
+
+		if hrStatusEqual(gatewayCtlrName, hr.Status, hrStatus) {
+			return false
+		}
+
+		hr.Status = hrStatus
+
+		return true
+	}
+}
+
+func hrStatusEqual(gatewayCtlrName string, prev, cur gatewayv1.HTTPRouteStatus) bool {
+	// Since other controllers may update HTTPRoute status we can't assume anything about the order of the statuses,
+	// and we have to ignore statuses written by other controllers when checking for equality.
+	// Therefore, we can't use slices.EqualFunc here because it cares about the order.
+
+	// First, we check if the prev status has any RouteParentStatuses that are no longer present in the cur status.
+	for _, prevParent := range prev.Parents {
+		if prevParent.ControllerName != gatewayv1.GatewayController(gatewayCtlrName) {
+			continue
+		}
+
+		exists := slices.ContainsFunc(cur.Parents, func(curParent gatewayv1.RouteParentStatus) bool {
+			return routeParentStatusEqual(prevParent, curParent)
+		})
+
+		if !exists {
+			return false
+		}
+	}
+
+	// Then, we check if the cur status has any RouteParentStatuses that are no longer present in the prev status.
+	for _, curParent := range cur.Parents {
+		exists := slices.ContainsFunc(prev.Parents, func(prevParent gatewayv1.RouteParentStatus) bool {
+			return routeParentStatusEqual(curParent, prevParent)
+		})
+
+		if !exists {
+			return false
+		}
+	}
+
+	return true
+}
+
+func routeParentStatusEqual(p1, p2 gatewayv1.RouteParentStatus) bool {
+	if p1.ControllerName != p2.ControllerName {
+		return false
+	}
+
+	if p1.ParentRef.Name != p2.ParentRef.Name {
+		return false
+	}
+
+	if !equalPointers(p1.ParentRef.Namespace, p2.ParentRef.Namespace) {
+		return false
+	}
+
+	if !equalPointers(p1.ParentRef.SectionName, p2.ParentRef.SectionName) {
+		return false
+	}
+
+	// we ignore the rest of the ParentRef fields because we do not set them
+
+	return status2.ConditionsEqual(p1.Conditions, p2.Conditions)
+}
+
+func newGatewayClassStatusSetter(generation int64, conds []conditions.Condition) func(client.Object) bool {
+	return func(object client.Object) bool {
+		gc := object.(*gatewayv1.GatewayClass)
+
+		apiConds := status2.ConvertConditions(conds, generation, metav1.Now())
+
+		if status2.ConditionsEqual(gc.Status.Conditions, apiConds) {
+			return false
+		}
+
+		gc.Status = gatewayv1.GatewayClassStatus{
+			Conditions: apiConds,
+		}
+
+		return true
+	}
+}
+
+func newBackendTLSPolicyStatusSetter(
+	gatewayCtlrName string,
+	policy *graph.BackendTLSPolicy,
+) func(client.Object) bool {
+	return func(object client.Object) bool {
+		btp := object.(*gatewayv1alpha2.BackendTLSPolicy)
+		status := prepareBackendTLSPolicyStatus(
+			btp.Status,
+			policy.Source.Generation,
+			policy.Conditions,
+			policy.Gateway,
+			gatewayCtlrName,
+			metav1.Now(),
+		)
+
+		if btpStatusEqual(gatewayCtlrName, btp.Status, status) {
+			return false
+		}
+
+		btp.Status = status
+
+		return true
+	}
+}
+
+// prepareBackendTLSPolicyStatus prepares the status for a BackendTLSPolicy resource.
+func prepareBackendTLSPolicyStatus(
+	oldStatus gatewayv1alpha2.PolicyStatus,
+	observedGeneration int64,
+	conds []conditions.Condition,
+	gatewayNsName types.NamespacedName,
+	gatewayCtlrName string,
+	transitionTime metav1.Time,
+) gatewayv1alpha2.PolicyStatus {
+	// maxAncestors is the max number of ancestor statuses which is the sum of all new ancestor statuses and all old
+	// ancestor statuses.
+	maxAncestors := 1 + len(oldStatus.Ancestors)
+	ancestors := make([]gatewayv1alpha2.PolicyAncestorStatus, 0, maxAncestors)
+
+	// keep all the ancestor statuses that belong to other controllers
+	for _, os := range oldStatus.Ancestors {
+		if string(os.ControllerName) != gatewayCtlrName {
+			ancestors = append(ancestors, os)
+		}
+	}
+
+	a := gatewayv1alpha2.PolicyAncestorStatus{
+		AncestorRef: gatewayv1.ParentReference{
+			Namespace: (*gatewayv1.Namespace)(&gatewayNsName.Namespace),
+			Name:      gatewayv1alpha2.ObjectName(gatewayNsName.Name),
+		},
+		ControllerName: gatewayv1alpha2.GatewayController(gatewayCtlrName),
+		Conditions:     status2.ConvertConditions(conds, observedGeneration, transitionTime),
+	}
+	ancestors = append(ancestors, a)
+
+	return gatewayv1alpha2.PolicyStatus{
+		Ancestors: ancestors,
+	}
+}
+
+func btpStatusEqual(gatewayCtlrName string, prev, cur gatewayv1alpha2.PolicyStatus) bool {
+	// Since other controllers may update BackendTLSPolicy status we can't assume anything about the order of the
+	// statuses, and we have to ignore statuses written by other controllers when checking for equality.
+	// Therefore, we can't use slices.EqualFunc here because it cares about the order.
+
+	// First, we check if the prev status has any PolicyAncestorStatuses that are no longer present in the cur status.
+	for _, prevAncestor := range prev.Ancestors {
+		if prevAncestor.ControllerName != gatewayv1.GatewayController(gatewayCtlrName) {
+			continue
+		}
+
+		exists := slices.ContainsFunc(cur.Ancestors, func(curAncestor gatewayv1alpha2.PolicyAncestorStatus) bool {
+			return btpAncestorStatusEqual(prevAncestor, curAncestor)
+		})
+
+		if !exists {
+			return false
+		}
+	}
+
+	// Then, we check if the cur status has any PolicyAncestorStatuses that are no longer present in the prev status.
+	for _, curParent := range cur.Ancestors {
+		exists := slices.ContainsFunc(prev.Ancestors, func(prevAncestor gatewayv1alpha2.PolicyAncestorStatus) bool {
+			return btpAncestorStatusEqual(curParent, prevAncestor)
+		})
+
+		if !exists {
+			return false
+		}
+	}
+
+	return true
+}
+
+func btpAncestorStatusEqual(p1, p2 gatewayv1alpha2.PolicyAncestorStatus) bool {
+	if p1.ControllerName != p2.ControllerName {
+		return false
+	}
+
+	if p1.AncestorRef.Name != p2.AncestorRef.Name {
+		return false
+	}
+
+	if !equalPointers(p1.AncestorRef.Namespace, p2.AncestorRef.Namespace) {
+		return false
+	}
+
+	// we ignore the rest of the AncestorRef fields because we do not set them
+
+	return status2.ConditionsEqual(p1.Conditions, p2.Conditions)
+}
+
+// equalPointers returns whether two pointers are equal.
+// Pointers are considered equal if one of the following is true:
+// - They are both nil.
+// - One is nil and the other is empty (e.g. nil string and "").
+// - They are both non-nil, and their values are the same.
+func equalPointers[T comparable](p1, p2 *T) bool {
+	if p1 == nil && p2 == nil {
+		return true
+	}
+
+	var p1Val, p2Val T
+
+	if p1 != nil {
+		p1Val = *p1
+	}
+
+	if p2 != nil {
+		p2Val = *p2
+	}
+
+	return p1Val == p2Val
+}


### PR DESCRIPTION
### Proposed changes

Problem:
Currently, the status updater is aware of what resource it is updating the status of. This makes it difficult to extend because for each new resource we add support for, we have to modify the status updater.

Solution:
Replace old status updater with two new ones

(1) Regular Updater, to update statuses of multiple resources via UpdateRequest type

(2) CachingGroupUpdater to update statuses of groups of resources and cache results until the updater is enabled (when pod becomes leader). It uses Regular Updater.

Using groups allow replacing statuses of subset of resources, without the need to recompute all cached statuses.

The new status2 package (which will replace status package) is resource agnostic. This is acomplished by representing status update as a function (Setter).

The manager packages were updated:
- provisioner mode, to use regular Updater
- static mode, to use CachingGroupUpdater

status Setters were updated and moved to the static package.

CLOSES -- https://github.com/nginxinc/nginx-gateway-fabric/issues/1071

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
