### PR TITLE
Fix reload errors for NGINX when large num of match conditions are used

### DIFF
--- a/internal/mode/static/nginx/config/http/config.go
+++ b/internal/mode/static/nginx/config/http/config.go
@@ -16,7 +16,7 @@ type Location struct {
 	ProxySSLVerify  *ProxySSLVerify
 	Path            string
 	ProxyPass       string
-	HTTPMatchVar    string
+	HTTPMatchVar    []string
 	Rewrites        []string
 	ProxySetHeaders []Header
 }

--- a/internal/mode/static/nginx/config/servers_template.go
+++ b/internal/mode/static/nginx/config/servers_template.go
@@ -41,10 +41,10 @@ server {
         return {{ $l.Return.Code }} "{{ $l.Return.Body }}";
         {{- end }}
 
-        {{- if $l.HTTPMatchVar }}
-        set $http_matches {{ $l.HTTPMatchVar | printf "%q" }};
-        js_content httpmatches.redirect;
+        {{ range $i, $h := $l.HTTPMatchVar }}
+        set $http_matches_{{ $i }} {{ $h | printf "%q" }};
         {{- end }}
+        js_content httpmatches.redirect;
 
         {{- if $l.ProxyPass -}}
             {{ range $h := $l.ProxySetHeaders }}

--- a/internal/mode/static/nginx/config/servers_test.go
+++ b/internal/mode/static/nginx/config/servers_test.go
@@ -508,11 +508,12 @@ func TestCreateServers(t *testing.T) {
 		},
 	}
 
-	expectedMatchString := func(m []httpMatch) string {
+	expectedMatchString := func(m []httpMatch) []string {
 		g := NewWithT(t)
 		b, err := json.Marshal(m)
 		g.Expect(err).ToNot(HaveOccurred())
-		return string(b)
+		str := string(b)
+		return []string{str}
 	}
 
 	slashMatches := []httpMatch{

--- a/internal/mode/static/nginx/modules/src/httpmatches.js
+++ b/internal/mode/static/nginx/modules/src/httpmatches.js
@@ -50,21 +50,25 @@ function redirect(r) {
 }
 
 function extractMatchesFromRequest(r) {
-  if (!r.variables[MATCHES_VARIABLE]) {
-    throw Error(
-      `cannot redirect the request; the variable ${MATCHES_VARIABLE} is not defined on the request object`,
-    );
-  }
-
+  let index = 0;
   let matches;
 
-  try {
-    matches = JSON.parse(r.variables[MATCHES_VARIABLE]);
-  } catch (e) {
-    throw Error(
-      `cannot redirect the request; error parsing ${r.variables[MATCHES_VARIABLE]} into a JSON object: ${e}`,
-    );
+  while (true) {
+    const MATCHES_VARIABLE = `http_matches_${index}`;
+    if (!r.variables[MATCHES_VARIABLE]) {
+      break;
+    }
+
+    try {
+      matches = JSON.parse(r.variables[MATCHES_VARIABLE]);
+    } catch (e) {
+      throw Error(
+        `cannot redirect the request; error parsing ${r.variables[MATCHES_VARIABLE]} into a JSON object: ${e}`,
+      );
+    }
   }
+
+  console.log('matches in js', matches);
 
   if (!Array.isArray(matches)) {
     throw Error(`cannot redirect the request; expected a list of matches, got ${matches}`);


### PR DESCRIPTION
### Proposed changes

Problem: A large number of match conditions for a single hostname/path cause reload errors with NGINX about being parameter being too long

Solution: The solution is to divide the `http_matches` into different sets and then parse them through NGINX using NJS to map the correct match condition

Testing: TODO



Closes #1107 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
