### PR TITLE
Support NginxProxy CRD and global tracing settings

### DIFF
--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -1,11 +1,18 @@
 # syntax=docker/dockerfile:1.6
+FROM scratch as nginx-files
+
+# the following links can be replaced with local files if needed, i.e. ADD --chown=101:1001 <local_file> <container_file>
+ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.pub nginx_signing.rsa.pub
+
 FROM nginx:1.25.5-alpine
 
 ARG NJS_DIR
 ARG NGINX_CONF_DIR
 ARG BUILD_AGENT
 
-RUN apk add --no-cache libcap \
+RUN --mount=type=bind,from=nginx-files,src=nginx_signing.rsa.pub,target=/etc/apk/keys/nginx_signing.rsa.pub \
+    printf "%s\n" "http://nginx.org/packages/mainline/alpine/v$(egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
+    && apk add --no-cache libcap nginx-module-otel \
     && mkdir -p /var/lib/nginx /usr/lib/nginx/modules \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx \

--- a/build/Dockerfile.nginxplus
+++ b/build/Dockerfile.nginxplus
@@ -18,7 +18,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
     addgroup -g 1001 -S nginx \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
     && printf "%s\n" "https://pkgs.nginx.com/plus/${NGINX_PLUS_VERSION}/alpine/v$(grep -E -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
-    && apk add --no-cache nginx-plus nginx-plus-module-njs libcap \
+    && apk add --no-cache nginx-plus nginx-plus-module-njs nginx-plus-module-otel libcap \
     && mkdir -p /var/lib/nginx /usr/lib/nginx/modules \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx \

--- a/conformance/provisioner/static-deployment.yaml
+++ b/conformance/provisioner/static-deployment.yaml
@@ -70,6 +70,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -94,6 +96,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -110,6 +114,8 @@ spec:
         runAsNonRoot: true
       volumes:
       - name: nginx-conf
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
       - name: nginx-secrets
         emptyDir: {}

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -249,7 +249,7 @@ To uninstall/delete the release `ngf`:
 ```shell
 helm uninstall ngf -n nginx-gateway
 kubectl delete ns nginx-gateway
-kubectl delete crd nginxgateways.gateway.nginx.org
+for crd in `kubectl get crds -oname | grep gateway.nginx.org | awk -F / '{ print $2 }'`; do kubectl delete crd $crd; done
 ```
 
 These commands remove all the Kubernetes components associated with the release and deletes the release.

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -149,6 +151,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -180,6 +184,8 @@ spec:
       {{- end }}
       volumes:
       - name: nginx-conf
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
       - name: nginx-secrets
         emptyDir: {}

--- a/deploy/helm-chart/templates/rbac.yaml
+++ b/deploy/helm-chart/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if or .Values.serviceAccount.imagePullSecret .Values.serviceAccount.imagePullSecrets }}
   imagePullSecrets:
     {{- if .Values.serviceAccount.imagePullSecret }}
-    - name: {{ .Values.serviceAccount.imagePullSecret}}
+    - name: {{ .Values.serviceAccount.imagePullSecret }}
     {{- end }}
     {{- if .Values.serviceAccount.imagePullSecrets }}
     {{- range .Values.serviceAccount.imagePullSecrets }}
@@ -111,6 +111,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - nginxproxies
   verbs:
   - get
   - list

--- a/deploy/manifests/nginx-gateway-experimental.yaml
+++ b/deploy/manifests/nginx-gateway-experimental.yaml
@@ -93,6 +93,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - nginxproxies
   verbs:
   - get
   - list
@@ -213,6 +214,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -237,6 +240,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -253,6 +258,8 @@ spec:
         runAsNonRoot: true
       volumes:
       - name: nginx-conf
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
       - name: nginx-secrets
         emptyDir: {}

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -90,6 +90,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - nginxproxies
   verbs:
   - get
   - list
@@ -209,6 +210,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -233,6 +236,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -249,6 +254,8 @@ spec:
         runAsNonRoot: true
       volumes:
       - name: nginx-conf
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
       - name: nginx-secrets
         emptyDir: {}

--- a/deploy/manifests/nginx-plus-gateway-experimental.yaml
+++ b/deploy/manifests/nginx-plus-gateway-experimental.yaml
@@ -99,6 +99,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - nginxproxies
   verbs:
   - get
   - list
@@ -220,6 +221,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -244,6 +247,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -260,6 +265,8 @@ spec:
         runAsNonRoot: true
       volumes:
       - name: nginx-conf
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
       - name: nginx-secrets
         emptyDir: {}

--- a/deploy/manifests/nginx-plus-gateway.yaml
+++ b/deploy/manifests/nginx-plus-gateway.yaml
@@ -96,6 +96,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - nginxproxies
   verbs:
   - get
   - list
@@ -216,6 +217,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -240,6 +243,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         - name: nginx-secrets
           mountPath: /etc/nginx/secrets
         - name: nginx-run
@@ -256,6 +261,8 @@ spec:
         runAsNonRoot: true
       volumes:
       - name: nginx-conf
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
       - name: nginx-secrets
         emptyDir: {}

--- a/docs/proposals/gateway-settings.md
+++ b/docs/proposals/gateway-settings.md
@@ -1,7 +1,7 @@
 # Enhancement Proposal-1775: Gateway Settings
 
 - Issue: https://github.com/nginxinc/nginx-gateway-fabric/issues/1775
-- Status: Implementable
+- Status: Completed
 
 ## Summary
 
@@ -93,7 +93,7 @@ type Telemetry struct {
     // SpanAttributes are custom key/value attributes that are added to each span.
     //
     // +optional
-    SpanAttributes map[string]string `json:"spanAttributes,omitempty"`
+    SpanAttributes []SpanAttribute `json:"spanAttributes,omitempty"`
 }
 
 // TelemetryExporter specifies OpenTelemetry export parameters.
@@ -122,6 +122,15 @@ type TelemetryExporter struct {
 // The format is a subset of the syntax parsed by Golang time.ParseDuration.
 // Examples: 1h, 12m, 30s, 150ms.
 type Duration string
+
+// SpanAttribute is a key value pair to be added to a tracing span.
+type SpanAttribute struct {
+	// Key is the key for a span attribute.
+	Key string `json:"key"`
+
+	// Value is the value for a span attribute.
+	Value string `json:"value"`
+}
 ```
 
 ### Status

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -414,6 +414,12 @@ func registerControllers(
 				),
 			},
 		},
+		{
+			objectType: &ngfAPI.NginxProxy{},
+			options: []controller.Option{
+				controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
+			},
+		},
 	}
 
 	if cfg.ExperimentalFeatures {
@@ -592,6 +598,7 @@ func prepareFirstEventBatchPreparerArgs(
 		&discoveryV1.EndpointSliceList{},
 		&gatewayv1.HTTPRouteList{},
 		&gatewayv1beta1.ReferenceGrantList{},
+		&ngfAPI.NginxProxyList{},
 		partialObjectMetadataList,
 	}
 

--- a/internal/mode/static/manager_test.go
+++ b/internal/mode/static/manager_test.go
@@ -16,6 +16,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/config"
 )
 
@@ -52,6 +53,7 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				&gatewayv1.HTTPRouteList{},
 				&gatewayv1.GatewayList{},
 				&gatewayv1beta1.ReferenceGrantList{},
+				&ngfAPI.NginxProxyList{},
 				partialObjectMetadataList,
 			},
 		},
@@ -72,6 +74,7 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				&discoveryV1.EndpointSliceList{},
 				&gatewayv1.HTTPRouteList{},
 				&gatewayv1beta1.ReferenceGrantList{},
+				&ngfAPI.NginxProxyList{},
 				partialObjectMetadataList,
 			},
 		},
@@ -93,6 +96,7 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				&discoveryV1.EndpointSliceList{},
 				&gatewayv1.HTTPRouteList{},
 				&gatewayv1beta1.ReferenceGrantList{},
+				&ngfAPI.NginxProxyList{},
 				partialObjectMetadataList,
 				&gatewayv1alpha2.BackendTLSPolicyList{},
 			},

--- a/internal/mode/static/nginx/conf/nginx-plus.conf
+++ b/internal/mode/static/nginx/conf/nginx-plus.conf
@@ -1,4 +1,5 @@
 load_module /usr/lib/nginx/modules/ngx_http_js_module.so;
+include /etc/nginx/includes/*.conf;
 
 worker_processes auto;
 

--- a/internal/mode/static/nginx/conf/nginx.conf
+++ b/internal/mode/static/nginx/conf/nginx.conf
@@ -1,4 +1,5 @@
 load_module /usr/lib/nginx/modules/ngx_http_js_module.so;
+include /etc/nginx/includes/*.conf;
 
 worker_processes auto;
 

--- a/internal/mode/static/nginx/config/generator.go
+++ b/internal/mode/static/nginx/config/generator.go
@@ -15,6 +15,7 @@ const (
 
 	// httpFolder is the folder where NGINX HTTP configuration files are stored.
 	httpFolder = configFolder + "/conf.d"
+
 	// secretsFolder is the folder where secrets (like TLS certs/keys) are stored.
 	secretsFolder = configFolder + "/secrets"
 
@@ -23,6 +24,9 @@ const (
 
 	// configVersionFile is the path to the config version configuration file.
 	configVersionFile = httpFolder + "/config-version.conf"
+
+	// loadModulesFile is the path to the file containing any load_module directives.
+	loadModulesFile = configFolder + "/includes/load_modules.conf"
 )
 
 // ConfigFolders is a list of folders where NGINX configuration files are stored.
@@ -73,6 +77,8 @@ func (g GeneratorImpl) Generate(conf dataplane.Configuration) []file.File {
 	for id, bundle := range conf.CertBundles {
 		files = append(files, generateCertBundle(id, bundle))
 	}
+
+	files = append(files, generateLoadModulesConf(conf))
 
 	return files
 }
@@ -125,6 +131,7 @@ func (g GeneratorImpl) getExecuteFuncs() []executeFunc {
 		executeSplitClients,
 		executeServers,
 		executeMaps,
+		executeTelemetry,
 	}
 }
 
@@ -135,6 +142,19 @@ func generateConfigVersion(configVersion int) file.File {
 	return file.File{
 		Content: c,
 		Path:    configVersionFile,
+		Type:    file.TypeRegular,
+	}
+}
+
+func generateLoadModulesConf(conf dataplane.Configuration) file.File {
+	var c []byte
+	if conf.Telemetry.Endpoint != "" {
+		c = []byte("load_module modules/ngx_otel_module.so;")
+	}
+
+	return file.File{
+		Content: c,
+		Path:    loadModulesFile,
 		Type:    file.TypeRegular,
 	}
 }

--- a/internal/mode/static/nginx/config/maps_template.go
+++ b/internal/mode/static/nginx/config/maps_template.go
@@ -1,6 +1,6 @@
 package config
 
-var mapsTemplateText = `
+const mapsTemplateText = `
 {{ range $m := . }}
 map {{ $m.Source }} {{ $m.Variable }} {
     {{ range $p := $m.Parameters }}

--- a/internal/mode/static/nginx/config/servers_template.go
+++ b/internal/mode/static/nginx/config/servers_template.go
@@ -1,6 +1,6 @@
 package config
 
-var serversTemplateText = `
+const serversTemplateText = `
 {{- range $s := . -}}
     {{ if $s.IsDefaultSSL -}}
 server {

--- a/internal/mode/static/nginx/config/split_clients_template.go
+++ b/internal/mode/static/nginx/config/split_clients_template.go
@@ -1,6 +1,6 @@
 package config
 
-var splitClientsTemplateText = `
+const splitClientsTemplateText = `
 {{ range $sc := . }}
 split_clients $request_id ${{ $sc.VariableName }} {
     {{- range $d := $sc.Distributions }}

--- a/internal/mode/static/nginx/config/telemetry.go
+++ b/internal/mode/static/nginx/config/telemetry.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	gotemplate "text/template"
+
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
+)
+
+var otelTemplate = gotemplate.Must(gotemplate.New("otel").Parse(otelTemplateText))
+
+func executeTelemetry(conf dataplane.Configuration) []byte {
+	if conf.Telemetry.Endpoint != "" {
+		return execute(otelTemplate, conf.Telemetry)
+	}
+
+	return nil
+}

--- a/internal/mode/static/nginx/config/telemetry_template.go
+++ b/internal/mode/static/nginx/config/telemetry_template.go
@@ -1,0 +1,22 @@
+package config
+
+const otelTemplateText = `
+otel_exporter {
+	endpoint {{ .Endpoint }};
+	{{- if .Interval }}
+	interval {{ .Interval }};
+	{{- end }}
+	{{- if .BatchSize }}
+	batch_size {{ .BatchSize }};
+	{{- end }}
+	{{- if .BatchCount }}
+	batch_count {{ .BatchCount }};
+	{{- end }}
+}
+
+otel_service_name {{ .ServiceName }};
+
+{{- range $attr := .SpanAttributes }}
+otel_span_attr {{ $attr.Key }} {{ $attr.Value }};
+{{- end }}
+`

--- a/internal/mode/static/nginx/config/telemetry_test.go
+++ b/internal/mode/static/nginx/config/telemetry_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
+)
+
+func TestExecuteTelemetry(t *testing.T) {
+	conf := dataplane.Configuration{
+		Telemetry: dataplane.Telemetry{
+			Endpoint:    "1.2.3.4:123",
+			ServiceName: "ngf:gw-ns:gw-name:my-name",
+			Interval:    "5s",
+			BatchSize:   512,
+			BatchCount:  4,
+			SpanAttributes: []ngfAPI.SpanAttribute{
+				{
+					Key:   "key1",
+					Value: "val1",
+				},
+				{
+					Key:   "key2",
+					Value: "val2",
+				},
+			},
+		},
+	}
+
+	g := NewWithT(t)
+	expSubStrings := map[string]int{
+		"endpoint 1.2.3.4:123;":                        1,
+		"otel_service_name ngf:gw-ns:gw-name:my-name;": 1,
+		"interval 5s;":                                 1,
+		"batch_size 512;":                              1,
+		"batch_count 4;":                               1,
+		"otel_span_attr":                               2,
+	}
+
+	for expSubStr, expCount := range expSubStrings {
+		g.Expect(expCount).To(Equal(strings.Count(string(executeTelemetry(conf)), expSubStr)))
+	}
+}
+
+func TestExecuteTelemetryNil(t *testing.T) {
+	conf := dataplane.Configuration{
+		Telemetry: dataplane.Telemetry{},
+	}
+
+	g := NewWithT(t)
+
+	g.Expect(string(executeTelemetry(conf))).To(BeEmpty())
+}

--- a/internal/mode/static/nginx/config/upstreams_template.go
+++ b/internal/mode/static/nginx/config/upstreams_template.go
@@ -4,7 +4,7 @@ package config
 // 512k will support up to 648 upstream servers for OSS.
 // NGINX Plus needs 1m to support roughly the same amount of servers (556 upstream servers).
 // https://github.com/nginxinc/nginx-gateway-fabric/issues/483
-var upstreamsTemplateText = `
+const upstreamsTemplateText = `
 {{ range $u := . }}
 upstream {{ $u.Name }} {
     random two least_conn;

--- a/internal/mode/static/nginx/config/version_template.go
+++ b/internal/mode/static/nginx/config/version_template.go
@@ -1,6 +1,6 @@
 package config
 
-var versionTemplateText = `
+const versionTemplateText = `
 server {
     listen unix:/var/run/nginx/nginx-config-version.sock;
     access_log off;

--- a/internal/mode/static/state/change_processor.go
+++ b/internal/mode/static/state/change_processor.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/gatewayclass"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/graph"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/validation"
@@ -105,6 +106,7 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 		CRDMetadata:        make(map[types.NamespacedName]*metav1.PartialObjectMetadata),
 		BackendTLSPolicies: make(map[types.NamespacedName]*v1alpha2.BackendTLSPolicy),
 		ConfigMaps:         make(map[types.NamespacedName]*apiv1.ConfigMap),
+		NginxProxies:       make(map[types.NamespacedName]*ngfAPI.NginxProxy),
 	}
 
 	extractGVK := func(obj client.Object) schema.GroupVersionKind {
@@ -181,6 +183,11 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 				gvk:       extractGVK(&apiext.CustomResourceDefinition{}),
 				store:     newObjectStoreMapAdapter(clusterStore.CRDMetadata),
 				predicate: annotationChangedPredicate{annotation: gatewayclass.BundleVersionAnnotation},
+			},
+			{
+				gvk:       extractGVK(&ngfAPI.NginxProxy{}),
+				store:     newObjectStoreMapAdapter(clusterStore.NginxProxies),
+				predicate: nil,
 			},
 		},
 	)

--- a/internal/mode/static/state/dataplane/configuration.go
+++ b/internal/mode/static/state/dataplane/configuration.go
@@ -40,6 +40,7 @@ func BuildConfiguration(
 	backendGroups := buildBackendGroups(append(httpServers, sslServers...))
 	keyPairs := buildSSLKeyPairs(g.ReferencedSecrets, g.Gateway.Listeners)
 	certBundles := buildCertBundles(g.ReferencedCaCertConfigMaps, backendGroups)
+	telemetry := buildTelemetry(g)
 
 	config := Configuration{
 		HTTPServers:   httpServers,
@@ -49,6 +50,7 @@ func BuildConfiguration(
 		SSLKeyPairs:   keyPairs,
 		Version:       configVersion,
 		CertBundles:   certBundles,
+		Telemetry:     telemetry,
 	}
 
 	return config
@@ -558,4 +560,35 @@ func generateSSLKeyPairID(secret types.NamespacedName) SSLKeyPairID {
 // The ID is safe to use as a file name.
 func generateCertBundleID(configMap types.NamespacedName) CertBundleID {
 	return CertBundleID(fmt.Sprintf("cert_bundle_%s_%s", configMap.Namespace, configMap.Name))
+}
+
+// buildTelemetry generates the Otel configuration.
+func buildTelemetry(g *graph.Graph) Telemetry {
+	if g.NginxProxy != nil && g.NginxProxy.Spec.Telemetry != nil && g.NginxProxy.Spec.Telemetry.Exporter != nil {
+		serviceName := fmt.Sprintf("ngf:%s:%s", g.Gateway.Source.Namespace, g.Gateway.Source.Name)
+		telemetry := g.NginxProxy.Spec.Telemetry
+		if telemetry.ServiceName != nil {
+			serviceName = serviceName + ":" + *telemetry.ServiceName
+		}
+
+		tel := Telemetry{
+			Endpoint:       telemetry.Exporter.Endpoint,
+			ServiceName:    serviceName,
+			SpanAttributes: telemetry.SpanAttributes,
+		}
+
+		if telemetry.Exporter.BatchCount != nil {
+			tel.BatchCount = *telemetry.Exporter.BatchCount
+		}
+		if telemetry.Exporter.BatchSize != nil {
+			tel.BatchSize = *telemetry.Exporter.BatchSize
+		}
+		if telemetry.Exporter.Interval != nil {
+			tel.Interval = string(*telemetry.Exporter.Interval)
+		}
+
+		return tel
+	}
+
+	return Telemetry{}
 }

--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -14,6 +14,7 @@ import (
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/graph"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/resolver"
@@ -536,6 +537,20 @@ func TestBuildConfiguration(t *testing.T) {
 				},
 			},
 			CACert: []byte("cert-2"),
+		},
+	}
+
+	nginxProxy := &ngfAPI.NginxProxy{
+		Spec: ngfAPI.NginxProxySpec{
+			Telemetry: &ngfAPI.Telemetry{
+				Exporter: &ngfAPI.TelemetryExporter{
+					Endpoint:   "my-otel.svc:4563",
+					BatchSize:  helpers.GetPointer(int32(512)),
+					BatchCount: helpers.GetPointer(int32(4)),
+					Interval:   helpers.GetPointer(ngfAPI.Duration("5s")),
+				},
+				ServiceName: helpers.GetPointer("my-svc"),
+			},
 		},
 	}
 
@@ -1858,6 +1873,51 @@ func TestBuildConfiguration(t *testing.T) {
 			},
 			msg: "https listener with httproute with backend that has a backend TLS policy with binaryData attached",
 		},
+		{
+			graph: &graph.Graph{
+				GatewayClass: &graph.GatewayClass{
+					Source: &v1.GatewayClass{},
+					Valid:  true,
+				},
+				Gateway: &graph.Gateway{
+					Source: &v1.Gateway{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gw",
+							Namespace: "ns",
+						},
+					},
+					Listeners: []*graph.Listener{
+						{
+							Name:   "listener-80-1",
+							Source: listener80,
+							Valid:  true,
+							Routes: map[types.NamespacedName]*graph.Route{},
+						},
+					},
+				},
+				Routes:     map[types.NamespacedName]*graph.Route{},
+				NginxProxy: nginxProxy,
+			},
+			expConf: Configuration{
+				HTTPServers: []VirtualServer{
+					{
+						IsDefault: true,
+						Port:      80,
+					},
+				},
+				SSLServers:  []VirtualServer{},
+				SSLKeyPairs: map[SSLKeyPairID]SSLKeyPair{},
+				CertBundles: map[CertBundleID]CertBundle{},
+				Telemetry: Telemetry{
+					Endpoint:    "my-otel.svc:4563",
+					Interval:    "5s",
+					BatchSize:   512,
+					BatchCount:  4,
+					ServiceName: "ngf:ns:gw:my-svc",
+				},
+			},
+			msg: "NginxProxy with tracing config",
+		},
 	}
 
 	for _, test := range tests {
@@ -1873,6 +1933,7 @@ func TestBuildConfiguration(t *testing.T) {
 			g.Expect(result.SSLKeyPairs).To(Equal(test.expConf.SSLKeyPairs))
 			g.Expect(result.Version).To(Equal(1))
 			g.Expect(result.CertBundles).To(Equal(test.expConf.CertBundles))
+			g.Expect(result.Telemetry).To(Equal(test.expConf.Telemetry))
 		})
 	}
 }
@@ -2508,6 +2569,66 @@ func TestConvertBackendTLS(t *testing.T) {
 			g := NewWithT(t)
 
 			g.Expect(convertBackendTLS(tc.btp)).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestBuildTelemetry(t *testing.T) {
+	telemetryConfigured := &ngfAPI.NginxProxy{
+		Spec: ngfAPI.NginxProxySpec{
+			Telemetry: &ngfAPI.Telemetry{
+				Exporter: &ngfAPI.TelemetryExporter{
+					Endpoint:   "my-otel.svc:4563",
+					BatchSize:  helpers.GetPointer(int32(512)),
+					BatchCount: helpers.GetPointer(int32(4)),
+					Interval:   helpers.GetPointer(ngfAPI.Duration("5s")),
+				},
+				ServiceName: helpers.GetPointer("my-svc"),
+			},
+		},
+	}
+
+	expTelemetryConfigured := Telemetry{
+		Endpoint:    "my-otel.svc:4563",
+		ServiceName: "ngf:ns:gw:my-svc",
+		Interval:    "5s",
+		BatchSize:   512,
+		BatchCount:  4,
+	}
+
+	tests := []struct {
+		g            *graph.Graph
+		msg          string
+		expTelemetry Telemetry
+	}{
+		{
+			g: &graph.Graph{
+				NginxProxy: &ngfAPI.NginxProxy{},
+			},
+			expTelemetry: Telemetry{},
+			msg:          "No telemetry configured",
+		},
+		{
+			g: &graph.Graph{
+				Gateway: &graph.Gateway{
+					Source: &v1.Gateway{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gw",
+							Namespace: "ns",
+						},
+					},
+				},
+				NginxProxy: telemetryConfigured,
+			},
+			expTelemetry: expTelemetryConfigured,
+			msg:          "Telemetry configured",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.msg, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(buildTelemetry(tc.g)).To(Equal(tc.expTelemetry))
 		})
 	}
 }

--- a/internal/mode/static/state/dataplane/types.go
+++ b/internal/mode/static/state/dataplane/types.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/resolver"
 )
 
@@ -33,6 +34,8 @@ type Configuration struct {
 	Upstreams []Upstream
 	// BackendGroups holds all unique BackendGroups.
 	BackendGroups []BackendGroup
+	// Telemetry holds the Otel configuration.
+	Telemetry Telemetry
 	// Version represents the version of the generated configuration.
 	Version int
 }
@@ -248,4 +251,20 @@ type VerifyTLS struct {
 	CertBundleID CertBundleID
 	Hostname     string
 	RootCAPath   string
+}
+
+// Telemetry represents Otel configuration for the dataplane.
+type Telemetry struct {
+	// Endpoint specifies the address of OTLP/gRPC endpoint that will accept telemetry data.
+	Endpoint string
+	// ServiceName is the “service.name” attribute of the OTel resource.
+	ServiceName string
+	// Interval specifies the export interval.
+	Interval string
+	// SpanAttributes are custom key/value attributes that are added to each span.
+	SpanAttributes []ngfAPI.SpanAttribute
+	// BatchSize specifies the maximum number of spans to be sent in one batch per worker.
+	BatchSize int32
+	// BatchCount specifies the number of pending batches per worker, spans exceeding the limit are dropped.
+	BatchCount int32
 }

--- a/internal/mode/static/state/graph/graph.go
+++ b/internal/mode/static/state/graph/graph.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/controller/index"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/validation"
 )
@@ -26,6 +27,7 @@ type ClusterState struct {
 	CRDMetadata        map[types.NamespacedName]*metav1.PartialObjectMetadata
 	BackendTLSPolicies map[types.NamespacedName]*v1alpha2.BackendTLSPolicy
 	ConfigMaps         map[types.NamespacedName]*v1.ConfigMap
+	NginxProxies       map[types.NamespacedName]*ngfAPI.NginxProxy
 }
 
 // Graph is a Graph-like representation of Gateway API resources.
@@ -58,6 +60,8 @@ type Graph struct {
 	ReferencedCaCertConfigMaps map[types.NamespacedName]*CaCertConfigMap
 	// BackendTLSPolicies holds BackendTLSPolicy resources.
 	BackendTLSPolicies map[types.NamespacedName]*BackendTLSPolicy
+	// NginxProxy holds the NginxProxy config for the GatewayClass.
+	NginxProxy *ngfAPI.NginxProxy
 }
 
 // ProtectedPorts are the ports that may not be configured by a listener with a descriptive name of each port.
@@ -118,7 +122,8 @@ func BuildGraph(
 		return &Graph{}
 	}
 
-	gc := buildGatewayClass(processedGwClasses.Winner, state.CRDMetadata)
+	npCfg := getNginxProxy(state.NginxProxies, processedGwClasses.Winner)
+	gc := buildGatewayClass(processedGwClasses.Winner, npCfg, state.CRDMetadata)
 
 	secretResolver := newSecretResolver(state.Secrets)
 	configMapResolver := newConfigMapResolver(state.ConfigMaps)
@@ -154,6 +159,7 @@ func BuildGraph(
 		ReferencedServices:         referencedServices,
 		ReferencedCaCertConfigMaps: configMapResolver.getResolvedConfigMaps(),
 		BackendTLSPolicies:         processedBackendTLSPolicies,
+		NginxProxy:                 npCfg,
 	}
 
 	return g

--- a/internal/mode/static/state/graph/nginxproxy.go
+++ b/internal/mode/static/state/graph/nginxproxy.go
@@ -1,0 +1,23 @@
+package graph
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
+)
+
+// getNginxProxy returns the NginxProxy associated with the GatewayClass (if it exists).
+func getNginxProxy(
+	nps map[types.NamespacedName]*ngfAPI.NginxProxy,
+	gc *v1.GatewayClass,
+) *ngfAPI.NginxProxy {
+	if gc != nil {
+		ref := gc.Spec.ParametersRef
+		if ref != nil && ref.Group == ngfAPI.GroupName && ref.Kind == v1.Kind("NginxProxy") {
+			return nps[types.NamespacedName{Name: ref.Name}]
+		}
+	}
+
+	return nil
+}

--- a/internal/mode/static/state/graph/nginxproxy_test.go
+++ b/internal/mode/static/state/graph/nginxproxy_test.go
@@ -1,0 +1,129 @@
+package graph
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
+)
+
+func TestGetNginxProxy(t *testing.T) {
+	tests := []struct {
+		nps   map[types.NamespacedName]*ngfAPI.NginxProxy
+		gc    *v1.GatewayClass
+		expNP *ngfAPI.NginxProxy
+		name  string
+	}{
+		{
+			nps: map[types.NamespacedName]*ngfAPI.NginxProxy{
+				{Name: "np1"}: {},
+			},
+			gc:    nil,
+			expNP: nil,
+			name:  "nil gatewayclass",
+		},
+		{
+			nps: map[types.NamespacedName]*ngfAPI.NginxProxy{
+				{Name: "np1"}: {},
+			},
+			gc:    &v1.GatewayClass{},
+			expNP: nil,
+			name:  "nil paramsRef",
+		},
+		{
+			nps: map[types.NamespacedName]*ngfAPI.NginxProxy{},
+			gc: &v1.GatewayClass{
+				Spec: v1.GatewayClassSpec{
+					ParametersRef: &v1.ParametersReference{
+						Group: ngfAPI.GroupName,
+						Kind:  v1.Kind("NginxProxy"),
+						Name:  "np1",
+					},
+				},
+			},
+			expNP: nil,
+			name:  "no nginxproxy resources",
+		},
+		{
+			nps: map[types.NamespacedName]*ngfAPI.NginxProxy{
+				{Name: "np1"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "np1",
+					},
+				},
+			},
+			gc: &v1.GatewayClass{
+				Spec: v1.GatewayClassSpec{
+					ParametersRef: &v1.ParametersReference{
+						Group: v1.Group("wrong-group"),
+						Kind:  v1.Kind("NginxProxy"),
+						Name:  "wrong-group",
+					},
+				},
+			},
+			expNP: nil,
+			name:  "wrong group",
+		},
+		{
+			nps: map[types.NamespacedName]*ngfAPI.NginxProxy{
+				{Name: "np1"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "np1",
+					},
+				},
+			},
+			gc: &v1.GatewayClass{
+				Spec: v1.GatewayClassSpec{
+					ParametersRef: &v1.ParametersReference{
+						Group: ngfAPI.GroupName,
+						Kind:  v1.Kind("WrongKind"),
+						Name:  "wrong-kind",
+					},
+				},
+			},
+			expNP: nil,
+			name:  "wrong kind",
+		},
+		{
+			nps: map[types.NamespacedName]*ngfAPI.NginxProxy{
+				{Name: "np1"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "np1",
+					},
+				},
+				{Name: "np2"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "np2",
+					},
+				},
+			},
+			gc: &v1.GatewayClass{
+				Spec: v1.GatewayClassSpec{
+					ParametersRef: &v1.ParametersReference{
+						Group: ngfAPI.GroupName,
+						Kind:  v1.Kind("NginxProxy"),
+						Name:  "np2",
+					},
+				},
+			},
+			expNP: &ngfAPI.NginxProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "np2",
+				},
+			},
+			name: "returns correct resource",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(getNginxProxy(test.nps, test.gc)).To(Equal(test.expNP))
+		})
+	}
+}

--- a/site/content/overview/gateway-api-compatibility.md
+++ b/site/content/overview/gateway-api-compatibility.md
@@ -58,7 +58,7 @@ NGINX Gateway Fabric supports a single GatewayClass resource configured with the
 
 - `spec`
   - `controllerName` - supported.
-  - `parametersRef` - not supported.
+  - `parametersRef` - NginxProxy resource supported.
   - `description` - supported.
 - `status`
   - `conditions` - supported (Condition/Status/Reason):


### PR DESCRIPTION
Problem: As a user of NGF
I want to set the collection point for my traces for my installation of NGF So that I can ensure all my traces are sent to the same collection platform.

Solution: Implement the NginxProxy CRD which contains the fields required to configure the collection point for tracing. This resource is attached to the GatewayClass. If the resource is not found, a condition will be set on the GatewayClass to indicate this. The GatewayClass will continue to be Accepted even if the parametersRef is invalid.

This configuration sets the `http` context-level otel directives. The otel module is loaded conditionally based on the existence of this configuration.

Note: tracing is not enabled by this configuration, this only sets high level options. https://github.com/nginxinc/nginx-gateway-fabric/issues/1828 is required to actually enable tracing on a per-route basis.

Testing: Manually verified that the otel configuration is populated in the nginx.conf when appropriate. Conditions are also properly set on the GatewayClass.

Closes #1827
Closes #1775 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NginxProxy CRD added to configure global settings (such as tracing endpoint) at the GatewayClass level.
```
