### PR TITLE
Client Settings Policy Attachment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ generate: ## Run go generate
 
 .PHONY: generate-crds
 generate-crds: ## Generate CRDs and Go types using kubebuilder
-	go run sigs.k8s.io/controller-tools/cmd/controller-gen crd object paths=./apis/v1alpha1 output:crd:artifacts:config=config/crd/bases
+	go run sigs.k8s.io/controller-tools/cmd/controller-gen crd object paths=./apis/... output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate-manifests
 generate-manifests: ## Generate manifests using Helm.

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ generate: ## Run go generate
 
 .PHONY: generate-crds
 generate-crds: ## Generate CRDs and Go types using kubebuilder
-	go run sigs.k8s.io/controller-tools/cmd/controller-gen crd object paths=./apis/... output:crd:artifacts:config=config/crd/bases
+	go run sigs.k8s.io/controller-tools/cmd/controller-gen crd object paths=./apis/v1alpha1 output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate-manifests
 generate-manifests: ## Generate manifests using Helm.

--- a/apis/v1alpha1/clientsettingspolicy_types.go
+++ b/apis/v1alpha1/clientsettingspolicy_types.go
@@ -95,7 +95,11 @@ type ClientKeepAlive struct {
 
 	// Timeout defines the keep-alive timeouts for clients.
 	//
+	// +kubebuilder:validation:XValidation:message="header can only be specified if server is specified",rule="!(has(self.header) && !has(self.server))"
+	//
+	//
 	// +optional
+	//nolint:lll
 	Timeout *ClientKeepAliveTimeout `json:"timeout,omitempty"`
 }
 

--- a/apis/v1alpha1/policy_methods.go
+++ b/apis/v1alpha1/policy_methods.go
@@ -1,0 +1,20 @@
+package v1alpha1
+
+import (
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// FIXME(kate-osborn): Figure out a way to generate these methods for all our policies.
+// These methods implement the policies.Policy interface which extends client.Object to add the following methods.
+
+func (p *ClientSettingsPolicy) GetTargetRef() v1alpha2.PolicyTargetReference {
+	return p.Spec.TargetRef
+}
+
+func (p *ClientSettingsPolicy) GetPolicyStatus() v1alpha2.PolicyStatus {
+	return p.Status
+}
+
+func (p *ClientSettingsPolicy) SetPolicyStatus(status v1alpha2.PolicyStatus) {
+	p.Status = status
+}

--- a/charts/nginx-gateway-fabric/templates/deployment.yaml
+++ b/charts/nginx-gateway-fabric/templates/deployment.yaml
@@ -122,6 +122,8 @@ spec:
           mountPath: /etc/nginx/secrets
         - name: nginx-run
           mountPath: /var/run/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         {{- with .Values.nginxGateway.extraVolumeMounts -}}
         {{ toYaml . | nindent 8 }}
         {{- end }}
@@ -157,6 +159,8 @@ spec:
           mountPath: /var/cache/nginx
         - name: nginx-lib
           mountPath: /var/lib/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
         {{- with .Values.nginx.extraVolumeMounts -}}
         {{ toYaml . | nindent 8 }}
         {{- end }}
@@ -188,6 +192,8 @@ spec:
       - name: nginx-cache
         emptyDir: {}
       - name: nginx-lib
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
       {{- with .Values.extraVolumes -}}
       {{ toYaml . | nindent 6 }}

--- a/charts/nginx-gateway-fabric/templates/rbac.yaml
+++ b/charts/nginx-gateway-fabric/templates/rbac.yaml
@@ -111,6 +111,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - clientsettingspolicies
   verbs:
   - get
   - list
@@ -119,6 +120,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways/status
+  - clientsettingspolicies/status
   verbs:
   - update
 {{- if .Values.nginxGateway.leaderElection.enable }}

--- a/config/crd/bases/gateway.nginx.org_clientsettingspolicies.yaml
+++ b/config/crd/bases/gateway.nginx.org_clientsettingspolicies.yaml
@@ -108,6 +108,9 @@ spec:
                         pattern: ^\d{1,4}(ms|s)?$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: header can only be specified if server is specified
+                      rule: '!(has(self.header) && !has(self.server))'
                 type: object
               targetRef:
                 description: |-

--- a/conformance/provisioner/static-deployment.yaml
+++ b/conformance/provisioner/static-deployment.yaml
@@ -74,6 +74,8 @@ spec:
           mountPath: /etc/nginx/secrets
         - name: nginx-run
           mountPath: /var/run/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       - image: ghcr.io/nginxinc/nginx-gateway-fabric/nginx:edge
         imagePullPolicy: Always
         name: nginx
@@ -102,6 +104,8 @@ spec:
           mountPath: /var/cache/nginx
         - name: nginx-lib
           mountPath: /var/lib/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       terminationGracePeriodSeconds: 30
       serviceAccountName: nginx-gateway
       shareProcessNamespace: true
@@ -118,4 +122,6 @@ spec:
       - name: nginx-cache
         emptyDir: {}
       - name: nginx-lib
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}

--- a/deploy/manifests/nginx-gateway-experimental.yaml
+++ b/deploy/manifests/nginx-gateway-experimental.yaml
@@ -93,6 +93,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - clientsettingspolicies
   verbs:
   - get
   - list
@@ -101,6 +102,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways/status
+  - clientsettingspolicies/status
   verbs:
   - update
 - apiGroups:
@@ -217,6 +219,8 @@ spec:
           mountPath: /etc/nginx/secrets
         - name: nginx-run
           mountPath: /var/run/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       - image: ghcr.io/nginxinc/nginx-gateway-fabric/nginx:edge
         imagePullPolicy: Always
         name: nginx
@@ -245,6 +249,8 @@ spec:
           mountPath: /var/cache/nginx
         - name: nginx-lib
           mountPath: /var/lib/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       terminationGracePeriodSeconds: 30
       serviceAccountName: nginx-gateway
       shareProcessNamespace: true
@@ -261,6 +267,8 @@ spec:
       - name: nginx-cache
         emptyDir: {}
       - name: nginx-lib
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
 ---
 # Source: nginx-gateway-fabric/templates/gatewayclass.yaml

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -90,6 +90,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - clientsettingspolicies
   verbs:
   - get
   - list
@@ -98,6 +99,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways/status
+  - clientsettingspolicies/status
   verbs:
   - update
 - apiGroups:
@@ -213,6 +215,8 @@ spec:
           mountPath: /etc/nginx/secrets
         - name: nginx-run
           mountPath: /var/run/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       - image: ghcr.io/nginxinc/nginx-gateway-fabric/nginx:edge
         imagePullPolicy: Always
         name: nginx
@@ -241,6 +245,8 @@ spec:
           mountPath: /var/cache/nginx
         - name: nginx-lib
           mountPath: /var/lib/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       terminationGracePeriodSeconds: 30
       serviceAccountName: nginx-gateway
       shareProcessNamespace: true
@@ -257,6 +263,8 @@ spec:
       - name: nginx-cache
         emptyDir: {}
       - name: nginx-lib
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
 ---
 # Source: nginx-gateway-fabric/templates/gatewayclass.yaml

--- a/deploy/manifests/nginx-plus-gateway-experimental.yaml
+++ b/deploy/manifests/nginx-plus-gateway-experimental.yaml
@@ -99,6 +99,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - clientsettingspolicies
   verbs:
   - get
   - list
@@ -107,6 +108,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways/status
+  - clientsettingspolicies/status
   verbs:
   - update
 - apiGroups:
@@ -224,6 +226,8 @@ spec:
           mountPath: /etc/nginx/secrets
         - name: nginx-run
           mountPath: /var/run/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       - image: nginx-gateway-fabric/nginx-plus:edge
         imagePullPolicy: Always
         name: nginx
@@ -252,6 +256,8 @@ spec:
           mountPath: /var/cache/nginx
         - name: nginx-lib
           mountPath: /var/lib/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       terminationGracePeriodSeconds: 30
       serviceAccountName: nginx-gateway
       shareProcessNamespace: true
@@ -268,6 +274,8 @@ spec:
       - name: nginx-cache
         emptyDir: {}
       - name: nginx-lib
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
 ---
 # Source: nginx-gateway-fabric/templates/gatewayclass.yaml

--- a/deploy/manifests/nginx-plus-gateway.yaml
+++ b/deploy/manifests/nginx-plus-gateway.yaml
@@ -96,6 +96,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways
+  - clientsettingspolicies
   verbs:
   - get
   - list
@@ -104,6 +105,7 @@ rules:
   - gateway.nginx.org
   resources:
   - nginxgateways/status
+  - clientsettingspolicies/status
   verbs:
   - update
 - apiGroups:
@@ -220,6 +222,8 @@ spec:
           mountPath: /etc/nginx/secrets
         - name: nginx-run
           mountPath: /var/run/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       - image: nginx-gateway-fabric/nginx-plus:edge
         imagePullPolicy: Always
         name: nginx
@@ -248,6 +252,8 @@ spec:
           mountPath: /var/cache/nginx
         - name: nginx-lib
           mountPath: /var/lib/nginx
+        - name: nginx-includes
+          mountPath: /etc/nginx/includes
       terminationGracePeriodSeconds: 30
       serviceAccountName: nginx-gateway
       shareProcessNamespace: true
@@ -264,6 +270,8 @@ spec:
       - name: nginx-cache
         emptyDir: {}
       - name: nginx-lib
+        emptyDir: {}
+      - name: nginx-includes
         emptyDir: {}
 ---
 # Source: nginx-gateway-fabric/templates/gatewayclass.yaml

--- a/examples/client-settings-policy/README.md
+++ b/examples/client-settings-policy/README.md
@@ -1,0 +1,5 @@
+TODO(kate-osborn): remove before merging to main
+
+# Client Settings Policy
+
+This contains examples for testing Client Settings Policy.

--- a/examples/client-settings-policy/cafe-routes.yaml
+++ b/examples/client-settings-policy/cafe-routes.yaml
@@ -1,0 +1,43 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: coffee
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  - name: gateway
+    sectionName: http2
+  hostnames:
+  - "cafe.example.com"
+  - "cafe.example.org"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /coffee
+    backendRefs:
+    - name: coffee
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tea
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  - name: gateway
+    sectionName: http2
+  hostnames:
+  - "cafe.example.com"
+  - "cafe.example.org"
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /tea
+    backendRefs:
+    - name: tea
+      port: 80

--- a/examples/client-settings-policy/cafe.yaml
+++ b/examples/client-settings-policy/cafe.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coffee
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coffee
+  template:
+    metadata:
+      labels:
+        app: coffee
+    spec:
+      containers:
+      - name: coffee
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coffee
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: coffee
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tea
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tea
+  template:
+    metadata:
+      labels:
+        app: tea
+    spec:
+      containers:
+      - name: tea
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tea
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: tea

--- a/examples/client-settings-policy/conflict.yaml
+++ b/examples/client-settings-policy/conflict.yaml
@@ -1,0 +1,83 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: keepalive-requests
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  keepAlive:
+    requests: 100
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: body-max-size
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  body:
+    maxSize: 10m
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: body-timeout
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  body:
+    timeout: 30s
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: keepalive-rest
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  keepAlive:
+    time: 5s
+    timeout:
+      server: 2s
+      header: 1s
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: zzzzzz-conflict
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  keepAlive:
+    time: 5s
+    timeout:
+      server: 2s
+      header: 1s
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: zzzzzz-conflict-2
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  body:
+    maxSize: 50m

--- a/examples/client-settings-policy/gateway.yaml
+++ b/examples/client-settings-policy/gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  gatewayClassName: nginx
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    hostname: "*.example.com"
+  - name: http2
+    port: 8080
+    protocol: HTTP
+    hostname: "*.example.org"

--- a/examples/client-settings-policy/inherited.yaml
+++ b/examples/client-settings-policy/inherited.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: gw
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  body:
+    maxSize: 10m
+    timeout: 30s
+  keepAlive:
+    requests: 100
+    time: 5s
+    timeout:
+      server: 2s
+      header: 1s
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: tea-route
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: tea
+  body:
+    maxSize: 800m
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: coffee-route
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: coffee
+  keepAlive:
+    requests: 60
+    time: 7s

--- a/examples/client-settings-policy/merge.yaml
+++ b/examples/client-settings-policy/merge.yaml
@@ -1,0 +1,54 @@
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: keepalive-requests
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  keepAlive:
+    requests: 100
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: body-max-size
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  body:
+    maxSize: 10m
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: body-timeout
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  body:
+    timeout: 30s
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: ClientSettingsPolicy
+metadata:
+  name: keepalive-rest
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  keepAlive:
+    time: 5s
+    timeout:
+      server: 2s
+      header: 1s

--- a/internal/mode/static/nginx/config/http/config.go
+++ b/internal/mode/static/nginx/config/http/config.go
@@ -8,6 +8,7 @@ type Server struct {
 	IsDefaultHTTP bool
 	IsDefaultSSL  bool
 	Port          int32
+	Includes      []Include
 }
 
 // Location holds all configuration for an HTTP location.
@@ -19,9 +20,10 @@ type Location struct {
 	HTTPMatchVar    string
 	Rewrites        []string
 	ProxySetHeaders []Header
+	Includes        []Include
 }
 
-// Header defines a HTTP header to be passed to the proxied server.
+// Header defines an HTTP header to be passed to the proxied server.
 type Header struct {
 	Name  string
 	Value string
@@ -92,4 +94,10 @@ type MapParameter struct {
 type ProxySSLVerify struct {
 	TrustedCertificate string
 	Name               string
+}
+
+// Include holds all the files to include using the include directive.
+type Include struct {
+	Filename string
+	Content  []byte
 }

--- a/internal/mode/static/nginx/config/maps.go
+++ b/internal/mode/static/nginx/config/maps.go
@@ -10,9 +10,14 @@ import (
 
 var mapsTemplate = gotemplate.Must(gotemplate.New("maps").Parse(mapsTemplateText))
 
-func executeMaps(conf dataplane.Configuration) []byte {
+func executeMaps(conf dataplane.Configuration) []executeResult {
 	maps := buildAddHeaderMaps(append(conf.HTTPServers, conf.SSLServers...))
-	return execute(mapsTemplate, maps)
+	result := executeResult{
+		dest: mapsConfigFile,
+		data: execute(mapsTemplate, maps),
+	}
+
+	return []executeResult{result}
 }
 
 func buildAddHeaderMaps(servers []dataplane.VirtualServer) []http.Map {

--- a/internal/mode/static/nginx/config/servers_template.go
+++ b/internal/mode/static/nginx/config/servers_template.go
@@ -31,9 +31,17 @@ server {
 
     server_name {{ $s.ServerName }};
 
+    {{ range $i := $s.Includes }}
+    include {{ $i.Filename }};
+    {{- end -}}
+
         {{ range $l := $s.Locations }}
     location {{ $l.Path }} {
-        {{- range $r := $l.Rewrites }}
+        {{- range $i := $l.Includes }}
+        include {{ $i.Filename }};
+        {{- end -}}
+
+        {{ range $r := $l.Rewrites }}
         rewrite {{ $r }};
         {{- end }}
 

--- a/internal/mode/static/nginx/config/split_clients.go
+++ b/internal/mode/static/nginx/config/split_clients.go
@@ -11,10 +11,13 @@ import (
 
 var splitClientsTemplate = gotemplate.Must(gotemplate.New("split_clients").Parse(splitClientsTemplateText))
 
-func executeSplitClients(conf dataplane.Configuration) []byte {
+func executeSplitClients(conf dataplane.Configuration) []executeResult {
 	splitClients := createSplitClients(conf.BackendGroups)
-
-	return execute(splitClientsTemplate, splitClients)
+	result := executeResult{
+		dest: splitClientsConfigFile,
+		data: execute(splitClientsTemplate, splitClients),
+	}
+	return []executeResult{result}
 }
 
 func createSplitClients(backendGroups []dataplane.BackendGroup) []http.SplitClient {

--- a/internal/mode/static/nginx/config/upstreams.go
+++ b/internal/mode/static/nginx/config/upstreams.go
@@ -25,10 +25,14 @@ const (
 	invalidBackendZoneSize = "32k"
 )
 
-func (g GeneratorImpl) executeUpstreams(conf dataplane.Configuration) []byte {
+func (g GeneratorImpl) executeUpstreams(conf dataplane.Configuration) []executeResult {
 	upstreams := g.createUpstreams(conf.Upstreams)
 
-	return execute(upstreamsTemplate, upstreams)
+	result := executeResult{
+		dest: upstreamsConfigFile,
+		data: execute(upstreamsTemplate, upstreams),
+	}
+	return []executeResult{result}
 }
 
 func (g GeneratorImpl) createUpstreams(upstreams []dataplane.Upstream) []http.Upstream {

--- a/internal/mode/static/policies/clientsettings/generator.go
+++ b/internal/mode/static/policies/clientsettings/generator.go
@@ -1,0 +1,55 @@
+package clientsettings
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/policies"
+)
+
+// NewClientSettingsGeneratorFunc returns a function that generates configuration as []byte for a ClientSettingsPolicy.
+func NewClientSettingsGeneratorFunc() func(policy policies.Policy) []byte {
+	return func(policy policies.Policy) []byte {
+		csp, ok := policy.(*ngfAPI.ClientSettingsPolicy)
+		if !ok {
+			panic(fmt.Sprintf("expected ClientSettingsPolicy, got: %T", policy))
+		}
+
+		tmpl := template.Must(template.New("client settings policy").Parse(clientSettingsTemplate))
+
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, csp.Spec); err != nil {
+			panic(fmt.Errorf("failed to execute template for client settings policy: %w", err))
+		}
+
+		return buf.Bytes()
+	}
+}
+
+var clientSettingsTemplate = `
+{{- if .Body }}
+	{{- if .Body.MaxSize }}
+client_max_body_size {{ .Body.MaxSize }};
+	{{- end }}
+	{{- if .Body.Timeout }}
+client_body_timeout {{ .Body.Timeout }};
+	{{- end }}
+{{- end }}
+{{- if .KeepAlive }}
+	{{- if .KeepAlive.Requests }}
+keepalive_requests {{ .KeepAlive.Requests }};
+	{{- end }}
+	{{- if .KeepAlive.Time }}
+keepalive_time {{ .KeepAlive.Time }};
+	{{- end }}
+    {{- if .KeepAlive.Timeout }}
+        {{- if and .KeepAlive.Timeout.Server .KeepAlive.Timeout.Header }}
+keepalive_timeout {{ .KeepAlive.Timeout.Server }} {{ .KeepAlive.Timeout.Header }};
+        {{- else if .KeepAlive.Timeout.Server }}
+keepalive_timeout {{ .KeepAlive.Timeout.Server }};
+        {{- end }}
+    {{- end }}
+{{- end }}
+`

--- a/internal/mode/static/policies/clientsettings/validator.go
+++ b/internal/mode/static/policies/clientsettings/validator.go
@@ -1,0 +1,180 @@
+package clientsettings
+
+import (
+	"fmt"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/policies"
+)
+
+// Validator validates a ClientSettingsPolicy.
+// Implements policies.Validator interface.
+type Validator struct{}
+
+// Validate validates the spec of a ClientSettingsPolicy.
+func (c Validator) Validate(policy policies.Policy) error {
+	csp, ok := policy.(*ngfAPI.ClientSettingsPolicy)
+	if !ok {
+		panic(fmt.Sprintf("expected ClientSettingsPolicy, got: %T", policy))
+	}
+
+	if err := validateTargetRef(csp.Spec.TargetRef, csp.Namespace); err != nil {
+		return err
+	}
+
+	return validateSettings(csp.Spec)
+}
+
+// Conflicts returns true if the two ClientSettingsPolicies conflict.
+func (c Validator) Conflicts(polA, polB policies.Policy) bool {
+	a, okA := polA.(*ngfAPI.ClientSettingsPolicy)
+	b, okB := polB.(*ngfAPI.ClientSettingsPolicy)
+
+	if !okA || !okB {
+		panic(fmt.Sprintf("expected ClientSettingsPolicy, got: %T", polA))
+	}
+
+	return conflicts(a.Spec, b.Spec)
+}
+
+func conflicts(a, b ngfAPI.ClientSettingsPolicySpec) bool {
+	if a.Body != nil && b.Body != nil {
+		if a.Body.Timeout != nil && b.Body.Timeout != nil {
+			return true
+		}
+
+		if a.Body.MaxSize != nil && b.Body.MaxSize != nil {
+			return true
+		}
+	}
+
+	if a.KeepAlive != nil && b.KeepAlive != nil {
+		if a.KeepAlive.Requests != nil && b.KeepAlive.Requests != nil {
+			return true
+		}
+
+		if a.KeepAlive.Time != nil && b.KeepAlive.Time != nil {
+			return true
+		}
+
+		if a.KeepAlive.Timeout != nil && b.KeepAlive.Timeout != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func validateTargetRef(ref v1alpha2.PolicyTargetReference, policyNs string) error {
+	basePath := field.NewPath("spec").Child("targetRef")
+
+	if ref.Namespace != nil && string(*ref.Namespace) != policyNs {
+		path := basePath.Child("namespace")
+
+		return field.Invalid(path, *ref.Namespace, "targetRef must be in the same namespace as the policy")
+	}
+
+	if ref.Group != gatewayv1.GroupName {
+		path := basePath.Child("group")
+
+		return field.Invalid(
+			path,
+			ref.Group,
+			fmt.Sprintf("unsupported targetRef Group %q; must be %s", ref.Group, gatewayv1.GroupName),
+		)
+	}
+
+	kinds := []gatewayv1.Kind{"HTTPRoute", "Gateway"}
+
+	if !slices.Contains(kinds, ref.Kind) {
+		path := basePath.Child("kind")
+
+		return field.Invalid(
+			path,
+			ref.Kind,
+			fmt.Sprintf("unsupported targetRef Kind %q; Kind must be one of: %v", ref.Kind, kinds),
+		)
+	}
+
+	return nil
+}
+
+func validateSettings(spec ngfAPI.ClientSettingsPolicySpec) error {
+	var allErrs field.ErrorList
+	fieldPath := field.NewPath("spec")
+
+	if spec.Body != nil {
+		if err := policies.ValidateDuration(spec.Body.Timeout); err != nil {
+			path := fieldPath.Child("body").Child("timeout")
+
+			allErrs = append(allErrs, field.Invalid(path, *spec.Body.Timeout, err.Error()))
+		}
+
+		if err := policies.ValidateSize(spec.Body.MaxSize); err != nil {
+			path := fieldPath.Child("body").Child("size")
+
+			allErrs = append(allErrs, field.Invalid(path, *spec.Body.MaxSize, err.Error()))
+		}
+	}
+
+	if spec.KeepAlive != nil {
+		if spec.KeepAlive.Requests != nil {
+			requests := *spec.KeepAlive.Requests
+			if requests < 0 {
+				path := fieldPath.Child("keepAlive").Child("requests")
+
+				allErrs = append(
+					allErrs,
+					field.Invalid(path, *spec.KeepAlive.Requests, "requests is invalid: must be positive"),
+				)
+			}
+		}
+
+		if err := policies.ValidateDuration(spec.KeepAlive.Time); err != nil {
+			path := fieldPath.Child("body").Child("keepAlive").Child("time")
+
+			allErrs = append(allErrs, field.Invalid(path, *spec.KeepAlive.Time, err.Error()))
+		}
+
+		if spec.KeepAlive.Timeout != nil {
+			timeout := spec.KeepAlive.Timeout
+
+			if err := policies.ValidateDuration(timeout.Server); err != nil {
+				path := fieldPath.Child("keepAlive").Child("timeout").Child("server")
+
+				allErrs = append(
+					allErrs,
+					field.Invalid(path, *spec.KeepAlive.Timeout.Server, err.Error()),
+				)
+			}
+
+			if err := policies.ValidateDuration(timeout.Header); err != nil {
+				path := fieldPath.Child("keepAlive").Child("timeout").Child("header")
+
+				allErrs = append(
+					allErrs,
+					field.Invalid(path, *spec.KeepAlive.Timeout.Header, err.Error()),
+				)
+			}
+
+			if spec.KeepAlive.Timeout.Header != nil && spec.KeepAlive.Timeout.Server == nil {
+				path := fieldPath.Child("keepAlive").Child("timeout")
+
+				allErrs = append(
+					allErrs,
+					field.Invalid(
+						path,
+						nil,
+						"server timeout must be set if header timeout is set",
+					),
+				)
+			}
+		}
+	}
+	return allErrs.ToAggregate()
+}

--- a/internal/mode/static/policies/common_validation.go
+++ b/internal/mode/static/policies/common_validation.go
@@ -1,0 +1,27 @@
+package policies
+
+import (
+	"regexp"
+
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
+)
+
+func ValidateSize(s *ngfAPI.Size) error {
+	if s == nil {
+		return nil
+	}
+
+	_, err := regexp.MatchString(`^\d{1,4}(m|g|k)+$`, string(*s))
+
+	return err
+}
+
+func ValidateDuration(d *ngfAPI.Duration) error {
+	if d == nil {
+		return nil
+	}
+
+	_, err := regexp.MatchString(`^\d{1,4}(ms|s)?$`, string(*d))
+
+	return err
+}

--- a/internal/mode/static/policies/manager.go
+++ b/internal/mode/static/policies/manager.go
@@ -1,0 +1,92 @@
+package policies
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GenerateFunc generates config as []byte for an NGF Policy.
+type GenerateFunc func(policy Policy) []byte
+
+// Validator validates an NGF Policy.
+type Validator interface {
+	// Validate validates an NGF Policy.
+	Validate(policy Policy) error
+	// Conflicts returns true if the two Policies conflict.
+	Conflicts(a, b Policy) bool
+}
+
+// Manager manages the validators and generators for NGF Policies.
+type Manager struct {
+	validators     map[schema.GroupVersionKind]Validator
+	generators     map[schema.GroupVersionKind]GenerateFunc
+	mustExtractGVK func(client.Object) schema.GroupVersionKind
+}
+
+// ManagerConfig contains the config to register a Policy with the Manager.
+type ManagerConfig struct {
+	// GVK is the GroupVersionKind of the Policy.
+	GVK schema.GroupVersionKind
+	// Validator is the Validator for the Policy.
+	Validator Validator
+	// Generator is the GenerateFunc for the Policy.
+	Generator GenerateFunc
+}
+
+// NewManager returns a new Manager.
+// Implements dataplane.PolicyConfigGenerator and validation.PolicyValidator.
+func NewManager(
+	mustExtractGVK func(client.Object) schema.GroupVersionKind,
+	configs ...ManagerConfig,
+) *Manager {
+	v := &Manager{
+		validators:     make(map[schema.GroupVersionKind]Validator),
+		generators:     make(map[schema.GroupVersionKind]GenerateFunc),
+		mustExtractGVK: mustExtractGVK,
+	}
+
+	for _, cfg := range configs {
+		v.validators[cfg.GVK] = cfg.Validator
+		v.generators[cfg.GVK] = cfg.Generator
+	}
+
+	return v
+}
+
+// Generate generates config for the policy as a byte array.
+func (m *Manager) Generate(policy Policy) []byte {
+	gvk := m.mustExtractGVK(policy)
+
+	generate, ok := m.generators[gvk]
+	if !ok {
+		panic(fmt.Sprintf("no generate function registered for policy %T", policy))
+	}
+
+	return generate(policy)
+}
+
+// Validate validates the policy.
+func (m *Manager) Validate(policy Policy) error {
+	gvk := m.mustExtractGVK(policy)
+
+	validator, ok := m.validators[gvk]
+	if !ok {
+		panic(fmt.Sprintf("no validator registered for policy %T", policy))
+	}
+
+	return validator.Validate(policy)
+}
+
+// Conflicts returns true if the policies conflict.
+func (m *Manager) Conflicts(polA, polB Policy) bool {
+	gvk := m.mustExtractGVK(polA)
+
+	validator, ok := m.validators[gvk]
+	if !ok {
+		panic(fmt.Sprintf("no validator registered for policy %T", polA))
+	}
+
+	return validator.Conflicts(polA, polB)
+}

--- a/internal/mode/static/policies/policy.go
+++ b/internal/mode/static/policies/policy.go
@@ -1,0 +1,14 @@
+package policies
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// Policy is an extension of client.Object. It adds methods that are common among all NGF Policies.
+type Policy interface {
+	GetTargetRef() v1alpha2.PolicyTargetReference
+	GetPolicyStatus() v1alpha2.PolicyStatus
+	SetPolicyStatus(status v1alpha2.PolicyStatus)
+	client.Object
+}

--- a/internal/mode/static/sort/sort.go
+++ b/internal/mode/static/sort/sort.go
@@ -1,6 +1,9 @@
 package sort
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // LessObjectMeta compares two ObjectMetas according to the Gateway API conflict resolution guidelines.
 // See https://gateway-api.sigs.k8s.io/concepts/guidelines/?h=conflict#conflicts
@@ -13,4 +16,21 @@ func LessObjectMeta(meta1 *metav1.ObjectMeta, meta2 *metav1.ObjectMeta) bool {
 	}
 
 	return meta1.CreationTimestamp.Before(&meta2.CreationTimestamp)
+}
+
+// ClientObject compares two client.Objects and returns true if the first object was created first.
+// If the objects were created at the same time,
+// it returns true if the first object's name appears first in alphabetical order.
+func ClientObject(obj1 client.Object, obj2 client.Object) bool {
+	create1 := obj1.GetCreationTimestamp()
+	create2 := obj2.GetCreationTimestamp()
+
+	if create1.Time.Equal(create2.Time) {
+		if obj1.GetNamespace() == obj2.GetNamespace() {
+			return obj1.GetName() < obj2.GetName()
+		}
+		return obj1.GetNamespace() < obj2.GetNamespace()
+	}
+
+	return create1.Time.Before(create2.Time)
 }

--- a/internal/mode/static/state/conditions/conditions.go
+++ b/internal/mode/static/state/conditions/conditions.go
@@ -575,3 +575,46 @@ func NewBackendTLSPolicyInvalid(msg string) conditions.Condition {
 		Message: msg,
 	}
 }
+
+// NewPolicyAccepted returns a Condition that indicates that the Policy is accepted.
+func NewPolicyAccepted() conditions.Condition {
+	return conditions.Condition{
+		Type:    string(v1alpha2.PolicyConditionAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(v1alpha2.PolicyReasonAccepted),
+		Message: "Policy is accepted",
+	}
+}
+
+// NewPolicyInvalid returns a Condition that indicates that the Policy is not accepted because it is semantically or
+// syntactically invalid.
+func NewPolicyInvalid(msg string) conditions.Condition {
+	return conditions.Condition{
+		Type:    string(v1alpha2.PolicyConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(v1alpha2.PolicyReasonInvalid),
+		Message: msg,
+	}
+}
+
+// NewPolicyConflicted returns a Condition that indicates that the Policy is not accepted because it conflicts with
+// another Policy and a merge is not possible.
+func NewPolicyConflicted(msg string) conditions.Condition {
+	return conditions.Condition{
+		Type:    string(v1alpha2.PolicyConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(v1alpha2.PolicyReasonConflicted),
+		Message: msg,
+	}
+}
+
+// NewPolicyTargetNotFound returns a Condition that indicates that the Policy is not accepted because the target
+// resource does not exist or can not be attached to.
+func NewPolicyTargetNotFound(msg string) conditions.Condition {
+	return conditions.Condition{
+		Type:    string(v1alpha2.PolicyConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(v1alpha2.PolicyReasonTargetNotFound),
+		Message: msg,
+	}
+}

--- a/internal/mode/static/state/dataplane/types.go
+++ b/internal/mode/static/state/dataplane/types.go
@@ -68,6 +68,16 @@ type VirtualServer struct {
 	IsDefault bool
 	// Port is the port of the server.
 	Port int32
+	// Customizations contain custom configuration for the VirtualServer.
+	Customizations []*Customization
+}
+
+// Customization holds custom configuration.
+type Customization struct {
+	// Bytes contains the customization as a byte array.
+	Bytes []byte
+	// Identifier is a unique ID for the customization.
+	Identifier string
 }
 
 // Upstream is a pool of endpoints to be load balanced.
@@ -198,6 +208,8 @@ type MatchRule struct {
 	Match Match
 	// BackendGroup is the group of Backends that the rule routes to.
 	BackendGroup BackendGroup
+	// Customizations contain custom configuration for the MatchRule.
+	Customizations []*Customization
 }
 
 // Match represents a match for a routing rule which consist of matches against various HTTP request attributes.

--- a/internal/mode/static/state/graph/gateway.go
+++ b/internal/mode/static/state/graph/gateway.go
@@ -23,6 +23,8 @@ type Gateway struct {
 	Conditions []conditions.Condition
 	// Valid indicates whether the Gateway Spec is valid.
 	Valid bool
+	// Policies hold the valid Policies attached to the Gateway.
+	Policies []*Policy
 }
 
 // processedGateways holds the resources that belong to NGF.

--- a/internal/mode/static/state/graph/httproute.go
+++ b/internal/mode/static/state/graph/httproute.go
@@ -37,6 +37,8 @@ type ParentRef struct {
 	Attachment *ParentRefAttachmentStatus
 	// Gateway is the NamespacedName of the referenced Gateway
 	Gateway types.NamespacedName
+	// SectionName is the SectionName of the referenced Gateway
+	SectionName string
 	// Idx is the index of the corresponding ParentReference in the HTTPRoute.
 	Idx int
 }
@@ -70,6 +72,8 @@ type Route struct {
 	// Attachable tells if the Route can be attached to any of the Gateways.
 	// Route can be invalid but still attachable.
 	Attachable bool
+	// Policies hold the valid Policies attached to the Route.
+	Policies []*Policy
 }
 
 // buildRoutesForGateways builds routes from HTTPRoutes that reference any of the specified Gateways.
@@ -129,8 +133,9 @@ func buildSectionNameRefs(
 		uniqueSectionsPerGateway[k] = struct{}{}
 
 		sectionNameRefs = append(sectionNameRefs, ParentRef{
-			Idx:     i,
-			Gateway: gw,
+			Idx:         i,
+			Gateway:     gw,
+			SectionName: sectionName,
 		})
 	}
 

--- a/internal/mode/static/state/graph/policies.go
+++ b/internal/mode/static/state/graph/policies.go
@@ -1,0 +1,313 @@
+package graph
+
+import (
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/policies"
+	ngfsort "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/sort"
+	staticConds "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/conditions"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/validation"
+)
+
+// Policy represents an NGF Policy.
+type Policy struct {
+	// Source is the NGF Policy object.
+	Source policies.Policy
+	// TargetRef is the TargetRef of the Policy.
+	TargetRef PolicyTargetRef
+	// Valid indicates whether the Policy is semantically and syntactically valid.
+	Valid bool
+	// Conditions contains the conditions of the Policy. Conditions will be nil if the Policy is valid.
+	Conditions []conditions.Condition
+	// Ancestors is a list of the ancestors of the Policies.
+	Ancestors []PolicyAncestor
+}
+
+// PolicyAncestor represents an ancestor of a Policy.
+type PolicyAncestor struct {
+	// Ancestor is the ancestor object.
+	Ancestor PolicyAncestorRef
+	// Conditions contains the list of conditions of the Policy in relation to the ancestor.
+	Conditions []conditions.Condition
+}
+
+// PolicyAncestorRef contains the identifying information of the ancestor.
+type PolicyAncestorRef struct {
+	// Kind is the Kind of the object.
+	Kind v1.Kind
+	// Group is the Group of the object.
+	Group v1.Group
+	// Nsname is the NamespacedName of the object.
+	Nsname types.NamespacedName
+	// SectionName is the SectionName of the object. For example, a listener name. This may be empty.
+	SectionName string
+}
+
+// PolicyTargetRef represents the object that the Policy is targeting.
+type PolicyTargetRef struct {
+	// Kind is the Kind of the object.
+	Kind v1.Kind
+	// Group is the Group of the object.
+	Group v1.Group
+	// Nsname is the NamespacedName of the object.
+	Nsname types.NamespacedName
+}
+
+// PolicyKey is a unique identifier for an NGF Policy.
+type PolicyKey struct {
+	// Nsname is the NamespacedName of the Policy.
+	NsName types.NamespacedName
+	// GVK is the GroupVersionKind of the Policy.
+	GVK schema.GroupVersionKind
+}
+
+const (
+	gatewayGroupKind = v1.GroupName + "/" + "Gateway"
+	hrGroupKind      = v1.GroupName + "/" + "HTTPRoute"
+)
+
+// attachPolicies attaches the graph's processed policies to the resources they target. It modifies the graph in place.
+func (g *Graph) attachPolicies() {
+	if g.Gateway == nil {
+		return
+	}
+
+	for _, policy := range g.NGFPolicies {
+		ref := policy.TargetRef
+
+		switch ref.Kind {
+		case "Gateway":
+			ancestor, attached := attachPolicyToGateway(policy, g.Gateway, g.IgnoredGateways)
+			if attached {
+				if g.Gateway.Policies == nil {
+					g.Gateway.Policies = make([]*Policy, 0, len(g.NGFPolicies))
+				}
+
+				g.Gateway.Policies = append(g.Gateway.Policies, policy)
+			}
+
+			policy.Ancestors = []PolicyAncestor{ancestor}
+		case "HTTPRoute":
+			route, exists := g.Routes[ref.Nsname]
+			if !exists {
+				return
+			}
+
+			ancestors, attached := attachPolicyToRoute(policy, route)
+
+			if attached {
+				if route.Policies == nil {
+					route.Policies = make([]*Policy, 0, len(g.NGFPolicies))
+				}
+
+				route.Policies = append(route.Policies, policy)
+			}
+
+			policy.Ancestors = ancestors
+		}
+	}
+}
+
+func attachPolicyToRoute(policy *Policy, route *Route) (ancestors []PolicyAncestor, attached bool) {
+	ancestors = make([]PolicyAncestor, 0, len(route.ParentRefs))
+
+	if len(route.ParentRefs) == 0 {
+		// this is an edge case that only happens when there are duplicate section names in the route
+		routeNsName := types.NamespacedName{Namespace: route.Source.Namespace, Name: route.Source.Name}
+		ancestors = append(ancestors, PolicyAncestor{
+			Ancestor: PolicyAncestorRef{
+				Kind:   "HTTPRoute",
+				Group:  v1.GroupName,
+				Nsname: routeNsName,
+			},
+			Conditions: []conditions.Condition{staticConds.NewPolicyTargetNotFound("TargetRef is invalid")},
+		})
+
+		return ancestors, false
+	}
+
+	for _, pr := range route.ParentRefs {
+		ancestor := PolicyAncestor{
+			Ancestor: PolicyAncestorRef{
+				Kind:        "Gateway",
+				Group:       v1.GroupName,
+				Nsname:      pr.Gateway,
+				SectionName: pr.SectionName,
+			},
+			Conditions: make([]conditions.Condition, 0, 1),
+		}
+
+		if !parentRefAttached(route, pr) {
+			ancestor.Conditions = append(
+				ancestor.Conditions,
+				staticConds.NewPolicyTargetNotFound("TargetRef is invalid"),
+			)
+		} else if policy.Valid {
+			ancestor.Conditions = append(ancestor.Conditions, staticConds.NewPolicyAccepted())
+			attached = true
+		}
+
+		ancestors = append(ancestors, ancestor)
+	}
+
+	return ancestors, attached
+}
+
+func parentRefAttached(route *Route, parent ParentRef) bool {
+	return route.Valid && parent.Attachment != nil && parent.Attachment.Attached
+}
+
+func attachPolicyToGateway(
+	policy *Policy,
+	gw *Gateway,
+	ignoredGateways map[types.NamespacedName]*v1.Gateway,
+) (ancestor PolicyAncestor, attached bool) {
+	ref := policy.TargetRef
+
+	_, ignored := ignoredGateways[ref.Nsname]
+
+	if !ignored && ref.Nsname != client.ObjectKeyFromObject(gw.Source) {
+		return PolicyAncestor{}, false
+	}
+
+	ancestor = PolicyAncestor{
+		Ancestor: PolicyAncestorRef{
+			Kind:   "Gateway",
+			Group:  v1.GroupName,
+			Nsname: ref.Nsname,
+		},
+		Conditions: make([]conditions.Condition, 0),
+	}
+
+	if ignored {
+		ancestor.Conditions = append(ancestor.Conditions, staticConds.NewPolicyTargetNotFound("TargetRef is ignored"))
+
+		return ancestor, false
+	}
+
+	if !gw.Valid {
+		ancestor.Conditions = append(ancestor.Conditions, staticConds.NewPolicyTargetNotFound("TargetRef is invalid"))
+
+		return ancestor, false
+	}
+
+	if !policy.Valid {
+		return ancestor, false
+	}
+
+	ancestor.Conditions = append(ancestor.Conditions, staticConds.NewPolicyAccepted())
+
+	return ancestor, true
+}
+
+func processPolicies(
+	policies map[PolicyKey]policies.Policy,
+	validator validation.PolicyValidator,
+	gateways processedGateways,
+	routes map[types.NamespacedName]*Route,
+) map[PolicyKey]*Policy {
+	if len(policies) == 0 || gateways.Winner == nil {
+		return nil
+	}
+
+	processedPolicies := make(map[PolicyKey]*Policy)
+
+	for key, policy := range policies {
+		ref := policy.GetTargetRef()
+		refNsName := targetRefNsName(ref, policy.GetNamespace())
+
+		refGroupKind := fmt.Sprintf("%s/%s", ref.Group, ref.Kind)
+
+		switch refGroupKind {
+		case gatewayGroupKind:
+			if !gatewayExists(refNsName, gateways.Winner, gateways.Ignored) {
+				continue
+			}
+		case hrGroupKind:
+			if _, exists := routes[refNsName]; !exists {
+				continue
+			}
+		}
+
+		conds := make([]conditions.Condition, 0, 2)
+
+		if err := validator.Validate(policy); err != nil {
+			conds = append(conds, staticConds.NewPolicyInvalid(err.Error()))
+		}
+
+		processedPolicies[key] = &Policy{
+			Source:     policy,
+			Valid:      len(conds) == 0,
+			Conditions: conds,
+			TargetRef: PolicyTargetRef{
+				Kind:   ref.Kind,
+				Group:  ref.Group,
+				Nsname: refNsName,
+			},
+		}
+	}
+
+	markConflictedPolicies(processedPolicies, validator)
+
+	return processedPolicies
+}
+
+// markConflictedPolicies marks policies that conflict with a policy of greater precedence as invalid.
+// Policies are sorted by timestamp and then alphabetically.
+func markConflictedPolicies(policies map[PolicyKey]*Policy, validator validation.PolicyValidator) {
+	type key struct {
+		policyGVK schema.GroupVersionKind
+		PolicyTargetRef
+	}
+
+	possibles := make(map[key][]*Policy)
+
+	for pk, p := range policies {
+		if p.Valid {
+			ak := key{
+				PolicyTargetRef: p.TargetRef,
+				policyGVK:       pk.GVK,
+			}
+			if possibles[ak] == nil {
+				possibles[ak] = make([]*Policy, 0)
+			}
+			possibles[ak] = append(possibles[ak], p)
+		}
+	}
+
+	for _, policyList := range possibles {
+		if len(policyList) > 1 {
+			sort.SliceStable(
+				policyList, func(i, j int) bool {
+					return ngfsort.ClientObject(policyList[i].Source, policyList[j].Source)
+				},
+			)
+
+			for i := range policyList {
+				if !policyList[i].Valid {
+					continue
+				}
+
+				for j := i + 1; j < len(policyList); j++ {
+					if validator.Conflicts(policyList[i].Source, policyList[j].Source) {
+						conflicted := policyList[j]
+						conflicted.Valid = false
+						conflicted.Conditions = append(conflicted.Conditions, staticConds.NewPolicyConflicted(
+							fmt.Sprintf(
+								"Conflicts with another %s",
+								conflicted.Source.GetObjectKind().GroupVersionKind().Kind,
+							),
+						))
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/mode/static/state/validation/validator.go
+++ b/internal/mode/static/state/validation/validator.go
@@ -1,11 +1,16 @@
 package validation
 
+import (
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/policies"
+)
+
 // Validators include validators for Gateway API resources from the perspective of a data-plane.
 // It is used for fields that propagate into the data plane configuration. For example, the path in a routing rule.
 // However, not all such fields are validated: NGF will not validate a field using Validators if it is confident that
 // the field is valid.
 type Validators struct {
 	HTTPFieldsValidator HTTPFieldsValidator
+	PolicyValidator     PolicyValidator
 }
 
 // HTTPFieldsValidator validates the HTTP-related fields of Gateway API resources from the perspective of
@@ -26,4 +31,12 @@ type HTTPFieldsValidator interface {
 	ValidateRewritePath(path string) error
 	ValidateRequestHeaderName(name string) error
 	ValidateRequestHeaderValue(value string) error
+}
+
+// PolicyValidator validates an NGF Policy.
+type PolicyValidator interface {
+	// Validate validates an NGF Policy.
+	Validate(policy policies.Policy) error
+	// Conflicts returns true if the two Policies conflict.
+	Conflicts(a, b policies.Policy) bool
 }


### PR DESCRIPTION
**Please review the approach only. Unit tests and lint fixes will be added after the approach is approved.**




### Proposed changes
Implement Client Settings Policy

Problems: 
- Users cannot attach Client Settings Policies to HTTPRoutes and Gateways (unimplemented). 
- Adding new policies to the code base is challenging because it requires changes to all code components. 

Solution: 
- Implement Client Settings Policy attachment to HTTPRoutes and Gateways following the inheritance guidelines. 
- Introduce a new Policy interface that the Client Settings Policy and all future NGF Policies will implement. This interface extends the client.Object interface by giving us access to the TargetRef and the Status of the policies. This allows us to store and act on policies generically (to an extent).
- Introduce PolicyValidator interface. The Graph uses the PolicyValidator to validate policies. 
- Introduce PolicyConfigGenerator interfaces. The dataplane package uses the PolicyConfigGenerator to generate the config for a policy. The generated config is a byte array.
- Introduce the policy Manager object. This manager implements the PolicyValidator and PolicyConfigGenerator. Each policy must implement its own validator and generator and register it with the policy Manager.
- Policy configuration is added to the nginx config using the include directive. Valid policies are written as nginx config to a file. The nginx config references the file at the appropriate attachment place using the include directive.

Steps to add a new NGF policy:
- Update RBAC
- Implement Policy Interface (eventually we should be able to generate these methods)
- Register policy with the controller runtime manager
- Implement validator and generator and register with the policy Manager
- Add entry to changeTrackingUpserter using common policy store and policy stateChanged predicate. 
- If policy supports attaching to resources other than Gateways and HTTPRoutes, update stateChanged predicate and graph logic. 
- If policy attaches to contexts other than locations and servers, update nginx config generation to support new location.

Testing: Manual testing covering the following:
- new CRD validation
- Inherited policy behavior
- Merge policy behavior
- Conflict policy behavior
- Policy Status


Closes #1792 #1760 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
