### PR TITLE
Fix crdPath in automated tests when applying the crd directory

### DIFF
--- a/tests/framework/ngf.go
+++ b/tests/framework/ngf.go
@@ -78,7 +78,7 @@ func InstallNGF(cfg InstallationConfig, extraArgs ...string) ([]byte, error) {
 
 // UpgradeNGF upgrades NGF. CRD upgrades assume the chart is local.
 func UpgradeNGF(cfg InstallationConfig, extraArgs ...string) ([]byte, error) {
-	crdPath := filepath.Join(cfg.ChartPath, "crds")
+	crdPath := filepath.Join(cfg.ChartPath, "crds") + "/"
 	if output, err := exec.Command("kubectl", "apply", "-f", crdPath).CombinedOutput(); err != nil {
 		return output, err
 	}


### PR DESCRIPTION
Problem: After modifying the crds path, the automated upgrade test would error when trying to apply the crds:

```
error: error parsing /home/username/nginx-gateway-fabric/charts/nginx-gateway-fabric/crds: read /home/username/nginx-gateway-fabric/charts/nginx-gateway-fabric/crds: is a directory

```

Solution: Add a trailing slash to the crdPath.

Testing: Automated upgrade test no longer errors on this section.

Closes 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
