### PR TITLE
Fix httproute counts

### DIFF
--- a/internal/mode/static/telemetry/collector.go
+++ b/internal/mode/static/telemetry/collector.go
@@ -174,7 +174,7 @@ func collectGraphResourceCount(
 		ngfResourceCounts.GatewayCount++
 	}
 
-	ngfResourceCounts.HTTPRouteCount = int64(len(g.Routes))
+	ngfResourceCounts.HTTPRouteCount = computeRouteCount(g.Routes)
 	ngfResourceCounts.SecretCount = int64(len(g.ReferencedSecrets))
 	ngfResourceCounts.ServiceCount = int64(len(g.ReferencedServices))
 
@@ -185,6 +185,15 @@ func collectGraphResourceCount(
 	}
 
 	return ngfResourceCounts, nil
+}
+
+func computeRouteCount(routes map[graph.RouteKey]*graph.L7Route) (httpRouteCount int64) {
+	for _, r := range routes {
+		if r.RouteType == graph.RouteTypeHTTP {
+			httpRouteCount = httpRouteCount + 1
+		}
+	}
+	return httpRouteCount
 }
 
 func getPodReplicaSet(

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -279,9 +279,10 @@ var _ = Describe("Collector", Ordered, func() {
 						{Name: "ignoredGw2"}: {},
 					},
 					Routes: map[graph.RouteKey]*graph.L7Route{
-						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-1"}, RouteType: graph.RouteTypeHTTP}: {},
-						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-2"}, RouteType: graph.RouteTypeHTTP}: {},
-						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-3"}, RouteType: graph.RouteTypeHTTP}: {},
+						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-1"}}: {RouteType: graph.RouteTypeHTTP},
+						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-2"}}: {RouteType: graph.RouteTypeHTTP},
+						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-3"}}: {RouteType: graph.RouteTypeHTTP},
+						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "gr-1"}}: {RouteType: graph.RouteTypeGRPC},
 					},
 					ReferencedSecrets: map[types.NamespacedName]*graph.Secret{
 						client.ObjectKeyFromObject(secret1): {
@@ -476,7 +477,7 @@ var _ = Describe("Collector", Ordered, func() {
 				GatewayClass: &graph.GatewayClass{},
 				Gateway:      &graph.Gateway{},
 				Routes: map[graph.RouteKey]*graph.L7Route{
-					{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-1"}, RouteType: graph.RouteTypeHTTP}: {},
+					{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-1"}}: {RouteType: graph.RouteTypeHTTP},
 				},
 				ReferencedSecrets: map[types.NamespacedName]*graph.Secret{
 					client.ObjectKeyFromObject(secret): {


### PR DESCRIPTION
### Proposed changes

Problem: Our telemetry uses the total graph Route count to report the HTTPRoutes counts. However, after GRPCRoute support was added, this count now includes both GRPC and HTTP routes.

Solution: Add a new function to check the route type of a route and only count it if it is HTTP. Added a GRPCRoute to the unit-tests to cover the case where a non-HTTP route is reported as part of the graph to validate it is not reported in the count.

Testing: Unit testing

Please focus on (optional): Note that GRPCRoute counts support will be added in a later PR.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
