### PR TITLE
Remove zone size for invalid backend ref

### DIFF
--- a/internal/mode/static/nginx/config/upstreams.go
+++ b/internal/mode/static/nginx/config/upstreams.go
@@ -22,7 +22,7 @@ const (
 	// plusZoneSize is the upstream zone size for nginx plus.
 	plusZoneSize = "1m"
 	// invalidBackendZoneSize is the upstream zone size for the invalid backend upstream.
-	invalidBackendZoneSize = "32k"
+	invalidBackendZoneSize = ""
 )
 
 func (g GeneratorImpl) executeUpstreams(conf dataplane.Configuration) []executeResult {

--- a/internal/mode/static/nginx/config/upstreams.go
+++ b/internal/mode/static/nginx/config/upstreams.go
@@ -21,8 +21,6 @@ const (
 	ossZoneSize = "512k"
 	// plusZoneSize is the upstream zone size for nginx plus.
 	plusZoneSize = "1m"
-	// invalidBackendZoneSize is the upstream zone size for the invalid backend upstream.
-	invalidBackendZoneSize = ""
 )
 
 func (g GeneratorImpl) executeUpstreams(conf dataplane.Configuration) []executeResult {
@@ -82,8 +80,7 @@ func (g GeneratorImpl) createUpstream(up dataplane.Upstream) http.Upstream {
 
 func createInvalidBackendRefUpstream() http.Upstream {
 	return http.Upstream{
-		Name:     invalidBackendRef,
-		ZoneSize: invalidBackendZoneSize,
+		Name: invalidBackendRef,
 		Servers: []http.UpstreamServer{
 			{
 				Address: nginx500Server,

--- a/internal/mode/static/nginx/config/upstreams.go
+++ b/internal/mode/static/nginx/config/upstreams.go
@@ -79,6 +79,7 @@ func (g GeneratorImpl) createUpstream(up dataplane.Upstream) http.Upstream {
 }
 
 func createInvalidBackendRefUpstream() http.Upstream {
+	// ZoneSize is omitted since we will only ever proxy to one destination/backend.
 	return http.Upstream{
 		Name: invalidBackendRef,
 		Servers: []http.UpstreamServer{

--- a/internal/mode/static/nginx/config/upstreams_template.go
+++ b/internal/mode/static/nginx/config/upstreams_template.go
@@ -7,7 +7,7 @@ package config
 const upstreamsTemplateText = `
 {{ range $u := . }}
 upstream {{ $u.Name }} {
-	random two least_conn;
+    random two least_conn;
     {{ if $u.ZoneSize -}}
     zone {{ $u.Name }} {{ $u.ZoneSize }};
     {{ end -}}

--- a/internal/mode/static/nginx/config/upstreams_template.go
+++ b/internal/mode/static/nginx/config/upstreams_template.go
@@ -7,11 +7,13 @@ package config
 const upstreamsTemplateText = `
 {{ range $u := . }}
 upstream {{ $u.Name }} {
-    random two least_conn;
-    zone {{ $u.Name }} {{ $u.ZoneSize }};
-    {{ range $server := $u.Servers }}
-    server {{ $server.Address }};
-    {{- end }}
+   random two least_conn;
+   {{ if $u.ZoneSize -}}
+   zone {{ $u.Name }} {{ $u.ZoneSize }};
+   {{ end -}}
+   {{ range $server := $u.Servers }}
+   server {{ $server.Address }};
+   {{- end }}
 }
 {{ end -}}
 `

--- a/internal/mode/static/nginx/config/upstreams_template.go
+++ b/internal/mode/static/nginx/config/upstreams_template.go
@@ -7,13 +7,13 @@ package config
 const upstreamsTemplateText = `
 {{ range $u := . }}
 upstream {{ $u.Name }} {
-   random two least_conn;
-   {{ if $u.ZoneSize -}}
-   zone {{ $u.Name }} {{ $u.ZoneSize }};
-   {{ end -}}
-   {{ range $server := $u.Servers }}
-   server {{ $server.Address }};
-   {{- end }}
+	random two least_conn;
+    {{ if $u.ZoneSize -}}
+    zone {{ $u.Name }} {{ $u.ZoneSize }};
+    {{ end -}}
+    {{ range $server := $u.Servers }}
+    server {{ $server.Address }};
+    {{- end }}
 }
 {{ end -}}
 `

--- a/internal/mode/static/nginx/config/upstreams_test.go
+++ b/internal/mode/static/nginx/config/upstreams_test.go
@@ -128,8 +128,7 @@ func TestCreateUpstreams(t *testing.T) {
 			},
 		},
 		{
-			Name:     invalidBackendRef,
-			ZoneSize: invalidBackendZoneSize,
+			Name: invalidBackendRef,
 			Servers: []http.UpstreamServer{
 				{
 					Address: nginx500Server,


### PR DESCRIPTION
### Proposed changes

Remove zone size for invalid backend ref.

Problem: The invalid-backend-ref size of 32k is too small for some environments causing an inability of the gateway to program.

Solution: Do not specify zone size for `invalid-backend-ref` so that NGINX does not share upstream state across backends. This is ok for this specific upstream because we will only ever proxy to one backend.

Testing: Adjusted unit test to match. Deployed NGF with HTTPRoutes and verified it correctly still generates zone sizes for normal upstreams, an upstream missing its endpoint (service is present but no deployment/pod), and `invalid-backend-ref`:

```
upstream default_coffee_80 {
   random two least_conn;
   zone default_coffee_80 512k;

   server 10.244.0.25:8080;
}

upstream default_tea_80 {
   random two least_conn;
   zone default_tea_80 512k;

   server unix:/var/lib/nginx/nginx-502-server.sock;
}

upstream invalid-backend-ref {
   random two least_conn;

   server unix:/var/lib/nginx/nginx-500-server.sock;
}
```

**Note: This PR does not test if the fix would work in the bug-submitter's environment. Recreating the exact test environment is probably not worth the effort.**

Closes #1794

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Remove zone size for invalid-backend-ref
```
