### PR TITLE
Fix rbac ServiceAccount imagePullSecrets template

### DIFF
--- a/charts/nginx-gateway-fabric/templates/rbac.yaml
+++ b/charts/nginx-gateway-fabric/templates/rbac.yaml
@@ -8,15 +8,15 @@ metadata:
   annotations:
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- if or .Values.serviceAccount.imagePullSecret .Values.serviceAccount.imagePullSecrets }}
-  imagePullSecrets:
-    {{- if .Values.serviceAccount.imagePullSecret }}
-    - name: {{ .Values.serviceAccount.imagePullSecret }}
-    {{- end }}
-    {{- if .Values.serviceAccount.imagePullSecrets }}
-    {{- range .Values.serviceAccount.imagePullSecrets }}
-    - name: {{ . }}
-    {{- end }}
-    {{- end }}
+imagePullSecrets:
+  {{- if .Values.serviceAccount.imagePullSecret }}
+  - name: {{ .Values.serviceAccount.imagePullSecret }}
+  {{- end }}
+  {{- if .Values.serviceAccount.imagePullSecrets }}
+  {{- range .Values.serviceAccount.imagePullSecrets }}
+  - name: {{ . }}
+  {{- end }}
+  {{- end }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/nginx-gateway-fabric/templates/rbac.yaml
+++ b/charts/nginx-gateway-fabric/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "nginx-gateway.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
-  {{- if or .Values.serviceAccount.imagePullSecret .Values.serviceAccount.imagePullSecrets }}
+{{- if or .Values.serviceAccount.imagePullSecret .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
   {{- if .Values.serviceAccount.imagePullSecret }}
   - name: {{ .Values.serviceAccount.imagePullSecret }}
@@ -17,7 +17,7 @@ imagePullSecrets:
   - name: {{ . }}
   {{- end }}
   {{- end }}
-  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Fix rbac ServiceAccount imagePullSecrets template.

Problem: NGF fails to deploy with NGINX+ because of the rbac ServiceAccount imagePullSecrets template error.

Solution: Fix the spacing which moves imagePullSecrets from being in the ServiceAccount's `metadata` to its own field.

Testing: Created Kubernetes secret and Docker Config Secret, then deployed NGF with NGINX+ and saw that the error was no longer there.

Closes #1952

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix rbac ServiceAccount imagePullSecrets template which caused errors when running NGF with NGINX+
```
