### PR TITLE
Collect backendTLSPolicy and GRPCRoute Count

### DIFF
--- a/internal/mode/static/telemetry/collector.go
+++ b/internal/mode/static/telemetry/collector.go
@@ -188,7 +188,7 @@ func collectGraphResourceCount(
 		}
 	}
 
-	ngfResourceCounts.BackendTLSPolicyCount = computeBackendTLSPolicyCount(g.BackendTLSPolicies)
+	ngfResourceCounts.BackendTLSPolicyCount = int64(len(g.BackendTLSPolicies))
 
 	return ngfResourceCounts, nil
 }
@@ -323,15 +323,4 @@ func collectClusterInformation(ctx context.Context, k8sClient client.Reader) (cl
 	clusterInfo.ClusterID = clusterID
 
 	return clusterInfo, nil
-}
-
-func computeBackendTLSPolicyCount(policies map[types.NamespacedName]*graph.BackendTLSPolicy) (
-	backendTLSPolicyCount int64,
-) {
-	for _, policy := range policies {
-		if policy.Valid {
-			backendTLSPolicyCount = backendTLSPolicyCount + 1
-		}
-	}
-	return backendTLSPolicyCount
 }

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -300,8 +300,8 @@ var _ = Describe("Collector", Ordered, func() {
 						client.ObjectKeyFromObject(nilsvc): {},
 					},
 					BackendTLSPolicies: map[types.NamespacedName]*graph.BackendTLSPolicy{
-						{Namespace: "test", Name: "bgPolicy-1"}: {Valid: true},
-						{Namespace: "test", Name: "bgPolicy-2"}: {Valid: true},
+						{Namespace: "test", Name: "bgPolicy-1"}: {},
+						{Namespace: "test", Name: "bgPolicy-2"}: {},
 						{Namespace: "test", Name: "bgPolicy-3"}: {},
 					},
 				}
@@ -349,7 +349,7 @@ var _ = Describe("Collector", Ordered, func() {
 					ServiceCount:          3,
 					EndpointCount:         4,
 					GRPCRouteCount:        2,
-					BackendTLSPolicyCount: 2,
+					BackendTLSPolicyCount: 3,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -300,9 +300,9 @@ var _ = Describe("Collector", Ordered, func() {
 						client.ObjectKeyFromObject(nilsvc): {},
 					},
 					BackendTLSPolicies: map[types.NamespacedName]*graph.BackendTLSPolicy{
-						{Namespace: "test", Name: "bgPolicy-1"}: {},
-						{Namespace: "test", Name: "bgPolicy-2"}: {},
-						{Namespace: "test", Name: "bgPolicy-3"}: {},
+						{Namespace: "test", Name: "backendTLSPolicy-1"}: {},
+						{Namespace: "test", Name: "backendTLSPolicy-2"}: {},
+						{Namespace: "test", Name: "backendTLSPolicy-3"}: {},
 					},
 				}
 

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -283,6 +283,7 @@ var _ = Describe("Collector", Ordered, func() {
 						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-2"}}: {RouteType: graph.RouteTypeHTTP},
 						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "hr-3"}}: {RouteType: graph.RouteTypeHTTP},
 						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "gr-1"}}: {RouteType: graph.RouteTypeGRPC},
+						{NamespacedName: types.NamespacedName{Namespace: "test", Name: "gr-2"}}: {RouteType: graph.RouteTypeGRPC},
 					},
 					ReferencedSecrets: map[types.NamespacedName]*graph.Secret{
 						client.ObjectKeyFromObject(secret1): {
@@ -297,6 +298,11 @@ var _ = Describe("Collector", Ordered, func() {
 						client.ObjectKeyFromObject(svc1):   {},
 						client.ObjectKeyFromObject(svc2):   {},
 						client.ObjectKeyFromObject(nilsvc): {},
+					},
+					BackendTLSPolicies: map[types.NamespacedName]*graph.BackendTLSPolicy{
+						{Namespace: "test", Name: "bgPolicy-1"}: {Valid: true},
+						{Namespace: "test", Name: "bgPolicy-2"}: {Valid: true},
+						{Namespace: "test", Name: "bgPolicy-3"}: {},
 					},
 				}
 
@@ -336,12 +342,14 @@ var _ = Describe("Collector", Ordered, func() {
 
 				expData.ClusterNodeCount = 3
 				expData.NGFResourceCounts = telemetry.NGFResourceCounts{
-					GatewayCount:      3,
-					GatewayClassCount: 3,
-					HTTPRouteCount:    3,
-					SecretCount:       3,
-					ServiceCount:      3,
-					EndpointCount:     4,
+					GatewayCount:          3,
+					GatewayClassCount:     3,
+					HTTPRouteCount:        3,
+					SecretCount:           3,
+					ServiceCount:          3,
+					EndpointCount:         4,
+					GRPCRouteCount:        2,
+					BackendTLSPolicyCount: 2,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"
@@ -567,12 +575,14 @@ var _ = Describe("Collector", Ordered, func() {
 				fakeGraphGetter.GetLatestGraphReturns(&graph.Graph{})
 				fakeConfigurationGetter.GetLatestConfigurationReturns(invalidUpstreamsConfig)
 				expData.NGFResourceCounts = telemetry.NGFResourceCounts{
-					GatewayCount:      0,
-					GatewayClassCount: 0,
-					HTTPRouteCount:    0,
-					SecretCount:       0,
-					ServiceCount:      0,
-					EndpointCount:     0,
+					GatewayCount:          0,
+					GatewayClassCount:     0,
+					HTTPRouteCount:        0,
+					SecretCount:           0,
+					ServiceCount:          0,
+					EndpointCount:         0,
+					GRPCRouteCount:        0,
+					BackendTLSPolicyCount: 0,
 				}
 
 				data, err := dataCollector.Collect(ctx)

--- a/internal/mode/static/telemetry/data.avdl
+++ b/internal/mode/static/telemetry/data.avdl
@@ -1,4 +1,5 @@
 @namespace("gateway.nginx.org") protocol NGFProductTelemetry {
+	/** Data is the product telemetry data of NGINX Gateway Fabric. */
 	@df_datatype("ngf-product-telemetry") record Data {
 		/** The field that identifies what type of data this is. */
 		string dataType;

--- a/internal/mode/static/telemetry/data.avdl
+++ b/internal/mode/static/telemetry/data.avdl
@@ -1,5 +1,4 @@
 @namespace("gateway.nginx.org") protocol NGFProductTelemetry {
-	/** Data is the product telemetry data of NGINX Gateway Fabric. */
 	@df_datatype("ngf-product-telemetry") record Data {
 		/** The field that identifies what type of data this is. */
 		string dataType;

--- a/internal/mode/static/telemetry/data.avdl
+++ b/internal/mode/static/telemetry/data.avdl
@@ -62,6 +62,12 @@ Each value is either 'true' or 'false' for boolean flags and 'default' or 'user-
 		/** EndpointCount include the total count of Endpoints(IP:port) across all referenced services. */
 		long? EndpointCount = null;
 		
+		/** GRPCRouteCount is the number of relevant GRPCRoutes. */
+		long? GRPCRouteCount = null;
+		
+		/** BackendTLSPolicyCount is the number of relevant BackendTLSPolicies. */
+		long? BackendTLSPolicyCount = null;
+		
 		/** NGFReplicaCount is the number of replicas of the NGF Pod. */
 		long? NGFReplicaCount = null;
 		

--- a/internal/mode/static/telemetry/data_test.go
+++ b/internal/mode/static/telemetry/data_test.go
@@ -24,12 +24,14 @@ func TestDataAttributes(t *testing.T) {
 		FlagNames:  []string{"test-flag"},
 		FlagValues: []string{"test-value"},
 		NGFResourceCounts: NGFResourceCounts{
-			GatewayCount:      1,
-			GatewayClassCount: 2,
-			HTTPRouteCount:    3,
-			SecretCount:       4,
-			ServiceCount:      5,
-			EndpointCount:     6,
+			GatewayCount:          1,
+			GatewayClassCount:     2,
+			HTTPRouteCount:        3,
+			SecretCount:           4,
+			ServiceCount:          5,
+			EndpointCount:         6,
+			GRPCRouteCount:        7,
+			BackendTLSPolicyCount: 8,
 		},
 		NGFReplicaCount: 3,
 	}
@@ -53,13 +55,14 @@ func TestDataAttributes(t *testing.T) {
 		attribute.Int64("SecretCount", 4),
 		attribute.Int64("ServiceCount", 5),
 		attribute.Int64("EndpointCount", 6),
+		attribute.Int64("GRPCRouteCount", 7),
+		attribute.Int64("BackendTLSPolicyCount", 8),
 		attribute.Int64("NGFReplicaCount", 3),
 	}
 
 	result := data.Attributes()
 
 	g := NewWithT(t)
-
 	g.Expect(result).To(Equal(expected))
 }
 
@@ -85,6 +88,8 @@ func TestDataAttributesWithEmptyData(t *testing.T) {
 		attribute.Int64("SecretCount", 0),
 		attribute.Int64("ServiceCount", 0),
 		attribute.Int64("EndpointCount", 0),
+		attribute.Int64("GRPCRouteCount", 0),
+		attribute.Int64("BackendTLSPolicyCount", 0),
 		attribute.Int64("NGFReplicaCount", 0),
 	}
 

--- a/internal/mode/static/telemetry/ngfresourcecounts_attributes_generated.go
+++ b/internal/mode/static/telemetry/ngfresourcecounts_attributes_generated.go
@@ -21,6 +21,8 @@ func (d *NGFResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("SecretCount", d.SecretCount))
 	attrs = append(attrs, attribute.Int64("ServiceCount", d.ServiceCount))
 	attrs = append(attrs, attribute.Int64("EndpointCount", d.EndpointCount))
+	attrs = append(attrs, attribute.Int64("GRPCRouteCount", d.GRPCRouteCount))
+	attrs = append(attrs, attribute.Int64("BackendTLSPolicyCount", d.BackendTLSPolicyCount))
 	
 
 	return attrs

--- a/site/content/overview/product-telemetry.md
+++ b/site/content/overview/product-telemetry.md
@@ -26,7 +26,7 @@ Telemetry data is collected once every 24 hours and sent to a service managed by
 - **Deployment Replica Count:** the count of NGINX Gateway Fabric Pods.
 - **Image Build Source:** whether the image was built by GitHub or locally (values are `gha`, `local`, or `unknown`). The source repository of the images is **not** collected.
 - **Deployment Flags:** a list of NGINX Gateway Fabric Deployment flags that are specified by a user. The actual values of non-boolean flags are **not** collected; we only record that they are either `true` or `false` for boolean flags and `default` or `user-defined` for the rest.
-- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `Secrets`, `Services`, `BackendTLSPolicy`, and `Endpoints`. The data within these resources is **not** collected.
+- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `Secrets`, `Services`, `BackendTLSPolicies`, and `Endpoints`. The data within these resources is **not** collected.
 
 This data is used to identify the following information:
 

--- a/site/content/overview/product-telemetry.md
+++ b/site/content/overview/product-telemetry.md
@@ -26,7 +26,7 @@ Telemetry data is collected once every 24 hours and sent to a service managed by
 - **Deployment Replica Count:** the count of NGINX Gateway Fabric Pods.
 - **Image Build Source:** whether the image was built by GitHub or locally (values are `gha`, `local`, or `unknown`). The source repository of the images is **not** collected.
 - **Deployment Flags:** a list of NGINX Gateway Fabric Deployment flags that are specified by a user. The actual values of non-boolean flags are **not** collected; we only record that they are either `true` or `false` for boolean flags and `default` or `user-defined` for the rest.
-- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`, `Secrets`, `Services`, and `Endpoints`. The data within these resources is **not** collected.
+- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `Secrets`, `Services`, `BackendTLSPolicy`, and `Endpoints`. The data within these resources is **not** collected.
 
 This data is used to identify the following information:
 

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -95,6 +95,8 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 				"SecretCount: Int(0)",
 				"ServiceCount: Int(0)",
 				"EndpointCount: Int(0)",
+				"GRPCRouteCount: Int(0)",
+				"BackendTLSPolicyCount: Int(0)",
 				"NGFReplicaCount: Int(1)",
 			},
 		)


### PR DESCRIPTION
### Proposed changes

Problem: As a maintainer of NGF
I want to collect the GRPCRoute and BackendTLSPolicy count from all NGF/NIC installations
So that I can understand many GRPCRoute and BackendTLSPolicy are being configured using NGF. 

Solution: Adding two new fields `GRPCRouteCount`, `BackendTLSPolicyCount` to telemetry data collector.

Testing: Manual Testing 

No GRPCRoute and BackendPolicy is configured
```
{"level":"debug","ts":"2024-05-09T23:46:14Z","logger":"telemetryExporter","msg":"Exporting telemetry","data":{"ImageSource":"local","ProjectName":"NGF","ProjectVersion":"edge","ProjectArchitecture":"arm64","ClusterID":"a7992d83-18d6-4e71-a9b7-bc5327f18ba2","ClusterVersion":"1.29.2","ClusterPlatform":"kind","InstallationID":"c19e4ddd-d5dc-4a56-bb4a-68b32a8ae4c4","ClusterNodeCount":1,"FlagNames":["config","gateway","gateway-api-experimental-features","gateway-ctlr-name","gatewayclass","health-disable","health-port","help","leader-election-disable","leader-election-lock-name","metrics-disable","metrics-port","metrics-secure-serving","nginx-plus","product-telemetry-disable","service","update-gatewayclass-status","usage-report-cluster-name","usage-report-secret","usage-report-server-url","usage-report-skip-verify"],"FlagValues":["user-defined","default","true","user-defined","user-defined","false","default","false","false","user-defined","false","default","false","false","false","user-defined","true","default","default","default","false"],"GatewayCount":1,"GatewayClassCount":1,"HTTPRouteCount":1,"SecretCount":0,"ServiceCount":1,"EndpointCount":1,"GRPCRouteCount":0,"BackendTLSPolicyCount":1,"NGFReplicaCount":1}}
```

With 4 GRPCRoute configured following [example](https://github.com/nginxinc/nginx-gateway-fabric/tree/main/examples/grpc-routing) 

```
{"level":"debug","ts":"2024-05-09T23:57:38Z","logger":"telemetryExporter","msg":"Exporting telemetry","data":{"ImageSource":"local","ProjectName":"NGF","ProjectVersion":"edge","ProjectArchitecture":"arm64","ClusterID":"a7992d83-18d6-4e71-a9b7-bc5327f18ba2","ClusterVersion":"1.29.2","ClusterPlatform":"kind","InstallationID":"c19e4ddd-d5dc-4a56-bb4a-68b32a8ae4c4","ClusterNodeCount":1,"FlagNames":["config","gateway","gateway-api-experimental-features","gateway-ctlr-name","gatewayclass","health-disable","health-port","help","leader-election-disable","leader-election-lock-name","metrics-disable","metrics-port","metrics-secure-serving","nginx-plus","product-telemetry-disable","service","update-gatewayclass-status","usage-report-cluster-name","usage-report-secret","usage-report-server-url","usage-report-skip-verify"],"FlagValues":["user-defined","default","true","user-defined","user-defined","false","default","false","false","user-defined","false","default","false","false","false","user-defined","true","default","default","default","false"],"GatewayCount":3,"GatewayClassCount":1,"HTTPRouteCount":1,"SecretCount":0,"ServiceCount":1,"EndpointCount":1,"GRPCRouteCount":4,"BackendTLSPolicyCount":1,"NGFReplicaCount":1}}
```

With [GRPCRoute](https://github.com/nginxinc/nginx-gateway-fabric/tree/main/examples/grpc-routing) and [BackendTLSPolicy](https://docs.nginx.com/nginx-gateway-fabric/how-to/traffic-management/securing-backend-traffic/) configured

```
{"level":"debug","ts":"2024-05-10T00:01:19Z","logger":"telemetryExporter","msg":"Exporting telemetry","data":{"ImageSource":"local","ProjectName":"NGF","ProjectVersion":"edge","ProjectArchitecture":"arm64","ClusterID":"a7992d83-18d6-4e71-a9b7-bc5327f18ba2","ClusterVersion":"1.29.2","ClusterPlatform":"kind","InstallationID":"c19e4ddd-d5dc-4a56-bb4a-68b32a8ae4c4","ClusterNodeCount":1,"FlagNames":["config","gateway","gateway-api-experimental-features","gateway-ctlr-name","gatewayclass","health-disable","health-port","help","leader-election-disable","leader-election-lock-name","metrics-disable","metrics-port","metrics-secure-serving","nginx-plus","product-telemetry-disable","service","update-gatewayclass-status","usage-report-cluster-name","usage-report-secret","usage-report-server-url","usage-report-skip-verify"],"FlagValues":["user-defined","default","true","user-defined","user-defined","false","default","false","false","user-defined","false","default","false","false","false","user-defined","true","default","default","default","false"],"GatewayCount":3,"GatewayClassCount":1,"HTTPRouteCount":1,"SecretCount":0,"ServiceCount":1,"EndpointCount":1,"GRPCRouteCount":4,"BackendTLSPolicyCount":1,"NGFReplicaCount":1}}
```

Closes #1615 
Closes #1839 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Collects BackendTLSPolicy and GRPCRoute counts configured with NGINX Gateway Fabric
```
