### PR TITLE
Add documentation for nginx_reloads_milliseconds metrics

### DIFF
--- a/site/content/how-to/monitoring/prometheus.md
+++ b/site/content/how-to/monitoring/prometheus.md
@@ -85,7 +85,7 @@ Metrics specific to NGINX Gateway Fabric include:
 - `nginx_reloads_total`: Counts successful NGINX reloads.
 - `nginx_reload_errors_total`: Counts NGINX reload failures.
 - `nginx_stale_config`: Indicates if NGINX Gateway Fabric couldn't update NGINX with the latest configuration, resulting in a stale version.
-- `nginx_last_reload_milliseconds`: Time in milliseconds for NGINX reloads.
+- `nginx_reloads_milliseconds`: Time in milliseconds for NGINX reloads.
 - `event_batch_processing_milliseconds`: Time in milliseconds to process batches of Kubernetes events.
 
 All these metrics are under the `nginx_gateway_fabric` namespace and include a `class` label set to the Gateway class of NGINX Gateway Fabric. For example, `nginx_gateway_fabric_nginx_reloads_total{class="nginx"}`.


### PR DESCRIPTION
### Proposed changes

Problem:  Documentation for `nginx_reloads_milliseconds` metrics is missing in NGF [docs](https://docs.nginx.com/nginx-gateway-fabric/how-to/monitoring/prometheus/). 

Solution: Add documentation for `nginx_reloads_milliseconds`.

Testing: TODO

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #1861 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
