### PR TITLE
Get correct leader election holder ID in upgrade test

### DIFF
--- a/tests/suite/upgrade_test.go
+++ b/tests/suite/upgrade_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Upgrade testing", Label("nfr", "upgrade"), func() {
 
 				if lease.Spec.HolderIdentity != nil {
 					for _, podName := range podNames {
-						if podName == strings.Split(*lease.Spec.HolderIdentity, "_")[0] {
+						if strings.Contains(*lease.Spec.HolderIdentity, podName) {
 							return true, nil
 						}
 					}

--- a/tests/suite/upgrade_test.go
+++ b/tests/suite/upgrade_test.go
@@ -208,11 +208,12 @@ var _ = Describe("Upgrade testing", Label("nfr", "upgrade"), func() {
 			500*time.Millisecond,
 			true, /* poll immediately */
 			func(_ context.Context) (bool, error) {
+				defer GinkgoRecover()
 				Expect(k8sClient.Get(leaseCtx, key, &lease)).To(Succeed())
 
 				if lease.Spec.HolderIdentity != nil {
 					for _, podName := range podNames {
-						if podName == *lease.Spec.HolderIdentity {
+						if podName == strings.Split(*lease.Spec.HolderIdentity, "_")[0] {
 							return true, nil
 						}
 					}


### PR DESCRIPTION
### Proposed changes

Problem: The upgrade NFR test is not working.

Solution: The issue is around the leader election lease holder ID not being equal to one of the upgraded pod names, which is what the test expects. Instead, the holder ID is in the format `<pod-name_uid>`. The fix is to split the holder ID on the underscore, and then instead make sure the first part of the string matches one of the upgraded pod names.

Also added `defer GinkgoRecover()` so that Ginkgo handles its internal panic correctly when an assertion fails within this nested function. See https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure for more info.

Testing: Ran the test locally and confirmed it now passes successfully.

Closes #1891 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
