### PR TITLE
Add missing upstream remote command to quickstart guide

### DIFF
--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -31,10 +31,10 @@ Follow these steps to set up your development environment.
    ```
 
 2. [Fork the project repository](https://github.com/nginxinc/nginx-gateway-fabric/fork)
-3. Clone your repository, and install the project dependencies:
+3. Clone your repository with ssh, and install the project dependencies:
 
    ```shell
-   git clone https://github.com/<YOUR-USERNAME>/nginx-gateway-fabric.git
+   git clone git@github.com:<YOUR-USERNAME>/nginx-gateway-fabric.git
    cd nginx-gateway-fabric
    ```
 
@@ -48,6 +48,12 @@ Follow these steps to set up your development environment.
 
    ```makefile
    make deps
+   ```
+
+4. Finally, add the original project repository as the remote upstream:
+
+   ```shell
+   git remote add upstream git@github.com:nginxinc/nginx-gateway-fabric.git
    ```
 
 


### PR DESCRIPTION
### Proposed changes

Problem: The Quickstart instructions were missing the command to the upstream remote

Solution: I added the missing command to add the upstream remote

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
