### PR TITLE
Bump kindest/node from v1.29.2 to v1.30.0 in /tests

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,3 +1,3 @@
 # syntax=docker/dockerfile:1.7
 # this is here so we can grab the latest version of kind and have dependabot keep it up to date
-FROM kindest/node:v1.29.2
+FROM kindest/node:v1.30.0


### PR DESCRIPTION
### Proposed changes

Dependabot is stuck after the directory structure changed and thinks there's already a PR open for this...but there isn't.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
