### PR TITLE
Add NFR scale test to GitHub actions pipeline

### DIFF
--- a/.github/workflows/nfr.yml
+++ b/.github/workflows/nfr.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: all
         type: choice
-        options: [performance, upgrade, all]
+        options: [performance, upgrade, scale, all]
       version:
         description: Version of NGF under test
         required: true
@@ -129,6 +129,8 @@ jobs:
         echo "PLUS_ENABLED=${{ inputs.nginx_plus }}" >> vars.env
         echo "GINKGO_LABEL=" >> vars.env
         echo "NGF_VERSION=${{ inputs.version }}" >> vars.env
+        echo "GKE_NUM_NODES=12" >> vars.env
+        echo "GKE_MACHINE_TYPE=n2d-standard-16" >> vars.env
 
     - name: Create GKE cluster
       working-directory: ./tests


### PR DESCRIPTION
### Proposed changes

Problem:
Scale test is not part of Github actions pipeline

Solution:
- Add NFR scale test to GitHub actions pipeline along other NFR tests.
- Increase the size of the cluster used for NFR tests, as the scale test requires bigger size.

Testing:
- Successfully run with NGINX -- https://github.com/nginxinc/nginx-gateway-fabric/pull/2002
- Successfully run with NGINX Plus -- https://github.com/nginxinc/nginx-gateway-fabric/pull/2017

Some scale test issues were discovered:
- https://github.com/nginxinc/nginx-gateway-fabric/issues/2023
- https://github.com/nginxinc/nginx-gateway-fabric/issues/2009

Closes https://github.com/nginxinc/nginx-gateway-fabric/issues/1927

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
