### PR TITLE
Add minimum k8s version in Helm

### DIFF
--- a/charts/nginx-gateway-fabric/Chart.yaml
+++ b/charts/nginx-gateway-fabric/Chart.yaml
@@ -4,6 +4,7 @@ description: NGINX Gateway Fabric
 type: application
 version: 1.2.0
 appVersion: "edge"
+kubeVersion: ">= 1.25.0-0"
 home: https://github.com/nginxinc/nginx-gateway-fabric
 icon: https://raw.githubusercontent.com/nginxinc/nginx-gateway-fabric/main/charts/nginx-gateway-fabric/chart-icon.png
 sources:


### PR DESCRIPTION
### Proposed changes

Problem: The minimum version of k8s is not enforced in Helm. This would cause problems for people trying to install our chart in an unsupported version of k8s.

Solution: Add the minimum supported version in Chart.yaml

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
