### PR TITLE
Update secrets on resource version change only

### DIFF
--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -420,6 +420,9 @@ func registerControllers(
 		},
 		{
 			objectType: &apiv1.Secret{},
+			options: []controller.Option{
+				controller.WithK8sPredicate(k8spredicate.ResourceVersionChangedPredicate{}),
+			},
 		},
 		{
 			objectType: &discoveryV1.EndpointSlice{},


### PR DESCRIPTION
### Proposed changes

Problem: Controller-runtime forces a reconciliation after a certain amount of time, even if the resources have not changed (default is [10 hours](https://github.com/kubernetes-sigs/controller-runtime/blob/2e9781e9fc6054387cf0901c70db56f0b0a63083/pkg/cache/cache.go#L148). For many resources, we have a generation changed predicate, meaning we do not process any changes unless there is a change in the spec. Secrets, however, do not have a generation ID and so cannot have such a predicate.

Solution: Secrets do have a resource version, and the controller-runtime provides a ResourceVersionChangedPredicate we can use similarly to the GenerationChangedPredicate we use elsewhere.

Testing: Left running overnight and confirmed the behaviour (reconciliation of the secrets) no longer occurred. 

Please focus on (optional): Please note that this approach does not introspect the cert and key for changes, and a reconciliation will still occur where the cert and key remains the same but a different property (e.g. an annotation) changes meaning the resource version will have changed.

Closes #1112 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
