### PR TITLE
Replace yq with sed

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,13 +4,13 @@ CONFORMANCE_TAG = latest## Tag for the conformance test runner image
 GATEWAY_CLASS = nginx## Gateway class to use
 GINKGO_FLAGS =
 GINKGO_LABEL =
-GW_API_VERSION ?= $(shell yq eval '.resources[0] | split("ref=v") | .[1]' ../config/crd/gateway-api/standard/kustomization.yaml)## Supported Gateway API version from current NGF
+GW_API_VERSION ?= $(shell sed -n 's/.*ref=v\(.*\)/\1/p' ../config/crd/gateway-api/standard/kustomization.yaml)## Supported Gateway API version from current NGF
 GW_API_PREV_VERSION ?= 1.0.0## Supported Gateway API version from previous NGF release
-GW_SERVICE_TYPE=NodePort## Service type to use for the gateway
-GW_SVC_GKE_INTERNAL=false
+GW_SERVICE_TYPE = NodePort## Service type to use for the gateway
+GW_SVC_GKE_INTERNAL = false
 K8S_VERSION ?= latest## Kubernetes version to use. Expected format: 1.24 (major.minor) or latest
 NGF_VERSION ?= $(shell git describe --tags $(shell git rev-list --tags --max-count=1))## NGF version to be tested (defaults to latest tag)
-PULL_POLICY=Never## Pull policy for the images
+PULL_POLICY = Never## Pull policy for the images
 PROVISIONER_MANIFEST = conformance/provisioner/provisioner.yaml
 SUPPORTED_FEATURES = HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,GatewayPort8080,HTTPRouteResponseHeaderModification,GRPCExactMethodMatching,GRPCRouteListenerHostnameMatching,GRPCRouteHeaderMatching
 


### PR DESCRIPTION
### Proposed changes

Problem: yq is not installed by default in all systems

Solution: Replace it with sed, which is more popular

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
