### PR TITLE
Add PRs with release-notes labels to the CHANGELOG

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,8 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: Changelog
+      labels:
+        - release-notes

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Branch
         id: branch
@@ -30,6 +32,13 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           ref: ${{ steps.branch.outputs.branch }}
+
+      - name: Get Release Notes
+        id: notes
+        uses: lucacome/draft-release@8a63d32c79a171ae6048e614a8988f0ac3ed56d4 # v1.1.0
+        with:
+          config-path: .github/release-notes.yml
+          dry-run: true
 
       - name: Vars
         id: vars
@@ -76,6 +85,7 @@ jobs:
           sed -i -e "s/VERSION = edge/VERSION = ${{ inputs.version }}/g" Makefile
           sed -i "6r .github/CHANGELOG_TEMPLATE.md" CHANGELOG.md
           sed -i -e "s/%%VERSION%%/${{ inputs.version }}/g" CHANGELOG.md
+          sed -i "8a ${{ join(fromJson(steps.notes.outputs.release-sections).release-notes, '\n') }}\n" CHANGELOG.md
           make generate-manifests
 
       - name: Create Pull Request


### PR DESCRIPTION
### Proposed changes

Problem: Looking for all the PRs that have the release-notes label is a manual process

Solution: As a first step in automating this process, we add the list of PRs to the top of the CHANGELOG so they can be manually moved to the appropriate sections

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
