### PR TITLE
Fix GRPCRoute check in tests

### DIFF
--- a/tests/framework/resourcemanager.go
+++ b/tests/framework/resourcemanager.go
@@ -398,6 +398,13 @@ func (rm *ResourceManager) waitForHTTPRoutesToBeReady(ctx context.Context, names
 }
 
 func (rm *ResourceManager) waitForGRPCRoutesToBeReady(ctx context.Context, namespace string) error {
+	// First, check if grpcroute even exists for v1. If not, ignore.
+	var routeList v1.GRPCRouteList
+	err := rm.K8sClient.List(ctx, &routeList, client.InNamespace(namespace))
+	if err != nil && strings.Contains(err.Error(), "no matches for kind") {
+		return nil
+	}
+
 	return wait.PollUntilContextCancel(
 		ctx,
 		500*time.Millisecond,


### PR DESCRIPTION
Problem: When running the upgrade tests, the grpcroute check fails because they don't exist in the previous version of the API.

Solution: Check that grpcroutes even exist first, don't return an error if they don't.

Testing: Verified that NFR tests now pass.
