### PR TITLE
Add specific instruction for upgrading NGF from OSS to Plus

### DIFF
--- a/site/content/installation/installing-ngf/helm.md
+++ b/site/content/installation/installing-ngf/helm.md
@@ -37,7 +37,7 @@ helm install ngf oci://ghcr.io/nginxinc/charts/nginx-gateway-fabric --create-nam
 
 ##### For NGINX Plus
 
-{{< note >}}Replace `private-registry.nginx.com` with the proper registry for your NGINX Plus image, and if applicable, replace `nginx-plus-registry-secret` with your Secret name containing the registry credentials.{{< /note >}}
+{{< note >}}If applicable, replace the F5 Container registry `private-registry.nginx.com` with your internal registry for your NGINX Plus image, and replace `nginx-plus-registry-secret` with your Secret name containing the registry credentials.{{< /note >}}
 
 {{< important >}}Ensure that you [Enable Usage Reporting]({{< relref "installation/usage-reporting.md" >}}) when installing.{{< /important >}}
 
@@ -182,6 +182,20 @@ To upgrade the CRDs, take the following steps:
    ```
 
    If needed, replace `ngf` with your chosen release name.
+
+## How to upgrade from NGINX OSS to NGINX Plus
+
+- To upgrade from NGINX OSS to NGINX Plus, update the Helm command to include the necessary values for Plus:
+
+  {{< note >}}If applicable, replace the F5 Container registry `private-registry.nginx.com` with your internal registry for your NGINX Plus image, and replace `nginx-plus-registry-secret` with your Secret name containing the registry credentials.{{< /note >}}
+
+  {{< important >}}Ensure that you [Enable Usage Reporting]({{< relref "installation/usage-reporting.md" >}}) when installing.{{< /important >}}
+
+  ```shell
+  helm upgrade ngf oci://ghcr.io/nginxinc/charts/nginx-gateway-fabric  --set nginx.image.repository=private-registry.nginx.com/nginx-gateway-fabric/nginx-plus --set nginx.plus=true --set serviceAccount.imagePullSecret=nginx-plus-registry-secret -n nginx-gateway
+  ```
+
+  If needed, replace `ngf` with your chosen release name.
 
 ## Delay pod termination for zero downtime upgrades {#configure-delayed-pod-termination-for-zero-downtime-upgrades}
 

--- a/site/content/installation/installing-ngf/manifests.md
+++ b/site/content/installation/installing-ngf/manifests.md
@@ -183,7 +183,7 @@ To upgrade NGINX Gateway Fabric and get the latest features and improvements, ta
      kubectl apply -f nginx-plus-gateway.yaml
      ```
 
-   - To upgrade the deployment from NGINX OSS to NGINX Plus, simply follow the above instructions for upgrading your Plus deployment.
+   - To upgrade the deployment from NGINX OSS to NGINX Plus, follow the above instructions for upgrading your Plus deployment.
 
     {{< important >}}Ensure that you [Enable Usage Reporting]({{< relref "installation/usage-reporting.md" >}}) before applying.{{< /important >}}
 

--- a/site/content/installation/installing-ngf/manifests.md
+++ b/site/content/installation/installing-ngf/manifests.md
@@ -167,11 +167,25 @@ To upgrade NGINX Gateway Fabric and get the latest features and improvements, ta
 
 1. **Upgrade NGINX Gateway Fabric deployment:**
 
-   - To upgrade the deployment, run:
+   - To upgrade your OSS deployment, run:
 
      ```shell
      kubectl apply -f https://github.com/nginxinc/nginx-gateway-fabric/releases/download/v1.2.0/nginx-gateway.yaml
      ```
+
+   - To upgrade your Plus deployment:
+
+     Download the [deployment YAML](https://github.com/nginxinc/nginx-gateway-fabric/releases/download/v1.2.0/nginx-plus-gateway.yaml).
+
+     Update the `nginx-plus-gateway.yaml` file to include your chosen NGINX Plus image from the F5 Container registry or your custom image.
+
+     ```shell
+     kubectl apply -f nginx-plus-gateway.yaml
+     ```
+
+   - To upgrade the deployment from NGINX OSS to NGINX Plus, simply follow the above instructions for upgrading your Plus deployment.
+
+    {{< important >}}Ensure that you [Enable Usage Reporting]({{< relref "installation/usage-reporting.md" >}}) before applying.{{< /important >}}
 
 ## Delay pod termination for zero downtime upgrades {#configure-delayed-pod-termination-for-zero-downtime-upgrades}
 


### PR DESCRIPTION
### Proposed changes

Problem: There is a doc that covers pulling the N+ image, however there is no clear explanation for supported customers at how they would go through the process of moving from the free implementation to the paid implementation (replacing NGINX OSS with NGINX Plus).

Solution: Add sections to the installation docs that covers this use-case

Testing: Ran through the steps locally

Please focus on (optional): This could be a separate doc, but I'm not sure of its value. Upgrading from OSS to Plus is very straight-forward

Closes #1933 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
