### PR TITLE
Fix conformance release upload

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -151,7 +151,7 @@ jobs:
         working-directory: ./tests
 
       - name: Upload profile to release
-        if: ${{ inputs.k8s-version == 'latest' && startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} conformance-profile.yaml --clobber


### PR DESCRIPTION
Problem: A recent change in a CI variable prevented the conformance profile from being uploaded at release time.

Solution: Remove the check for k8s-version. It shouldn't matter which version of k8s the tests were run on for the release conformance profile.
