### PR TITLE
Fix error in uninstall gateway api resources doc

### DIFF
--- a/site/content/includes/installation/uninstall-gateway-api-resources.md
+++ b/site/content/includes/installation/uninstall-gateway-api-resources.md
@@ -7,7 +7,7 @@ docs: "DOCS-1436"
 To uninstall the Gateway API resources, run the following:
 
 ```shell
-kubectl kustomize "https://github.com/nginxinc/nginx-gateway-fabric/config/crd/gateway-api/experimental?ref=v1.3.0" | kubectl delete -f -
+kubectl kustomize "https://github.com/nginxinc/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v1.3.0" | kubectl delete -f -
 ```
 
 Alternatively, if you installed the Gateway APIs from the experimental channel, run the following:


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: The uninstall Gateway API resources doc default command uninstalls the experimental versions of the CRDs instead of the standard.

Solution: Fix command to point to standard.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
