### PR TITLE
Collect ClientSettingsPolicy, ObservabilityPolicy, and NginxProxy count

### DIFF
--- a/internal/mode/static/telemetry/collector.go
+++ b/internal/mode/static/telemetry/collector.go
@@ -201,9 +201,9 @@ func collectGraphResourceCount(
 	ngfResourceCounts.BackendTLSPolicyCount = int64(len(g.BackendTLSPolicies))
 
 	for policyKey, policy := range g.NGFPolicies {
-		switch gvk := policyKey.GVK; gvk.Kind {
+		switch policyKey.GVK.Kind {
 		case kinds.ClientSettingsPolicy:
-			if policy.TargetRefs == nil {
+			if len(policy.TargetRefs) == 0 {
 				continue
 			}
 

--- a/internal/mode/static/telemetry/collector.go
+++ b/internal/mode/static/telemetry/collector.go
@@ -79,8 +79,8 @@ type NGFResourceCounts struct {
 	RouteAttachedClientSettingsPolicyCount int64
 	// ObservabilityPolicyCount is the number of relevant ObservabilityPolicies.
 	ObservabilityPolicyCount int64
-	// NGINXProxyCount is the number of NGINXProxies.
-	NGINXProxyCount int64
+	// NginxProxyCount is the number of NginxProxies.
+	NginxProxyCount int64
 }
 
 // DataCollectorConfig holds configuration parameters for DataCollectorImpl.
@@ -218,7 +218,7 @@ func collectGraphResourceCount(
 	}
 
 	if g.NginxProxy != nil {
-		ngfResourceCounts.NGINXProxyCount = 1
+		ngfResourceCounts.NginxProxyCount = 1
 	}
 
 	return ngfResourceCounts, nil

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -530,6 +530,10 @@ var _ = Describe("Collector", Ordered, func() {
 						GVK:    schema.GroupVersionKind{Kind: kinds.ClientSettingsPolicy},
 					}: {TargetRefs: []graph.PolicyTargetRef{{Kind: kinds.HTTPRoute}}},
 					{
+						NsName: types.NamespacedName{Namespace: "test", Name: "ClientSettingsPolicy-empty"},
+						GVK:    schema.GroupVersionKind{Kind: kinds.ClientSettingsPolicy},
+					}: {},
+					{
 						NsName: types.NamespacedName{Namespace: "test", Name: "ObservabilityPolicy-1"},
 						GVK:    schema.GroupVersionKind{Kind: kinds.ObservabilityPolicy},
 					}: {},

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -12,11 +12,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/events/eventsfakes"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/kinds"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/config"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/graph"
@@ -304,6 +306,25 @@ var _ = Describe("Collector", Ordered, func() {
 						{Namespace: "test", Name: "backendTLSPolicy-2"}: {},
 						{Namespace: "test", Name: "backendTLSPolicy-3"}: {},
 					},
+					NGFPolicies: map[graph.PolicyKey]*graph.Policy{
+						{
+							NsName: types.NamespacedName{Namespace: "test", Name: "ClientSettingsPolicy-1"},
+							GVK:    schema.GroupVersionKind{Kind: kinds.ClientSettingsPolicy},
+						}: {TargetRefs: []graph.PolicyTargetRef{{Kind: kinds.Gateway}}},
+						{
+							NsName: types.NamespacedName{Namespace: "test", Name: "ClientSettingsPolicy-2"},
+							GVK:    schema.GroupVersionKind{Kind: kinds.ClientSettingsPolicy},
+						}: {TargetRefs: []graph.PolicyTargetRef{{Kind: kinds.HTTPRoute}}},
+						{
+							NsName: types.NamespacedName{Namespace: "test", Name: "ClientSettingsPolicy-3"},
+							GVK:    schema.GroupVersionKind{Kind: kinds.ClientSettingsPolicy},
+						}: {TargetRefs: []graph.PolicyTargetRef{{Kind: kinds.GRPCRoute}}},
+						{
+							NsName: types.NamespacedName{Namespace: "test", Name: "ObservabilityPolicy-1"},
+							GVK:    schema.GroupVersionKind{Kind: kinds.ObservabilityPolicy},
+						}: {},
+					},
+					NginxProxy: &graph.NginxProxy{},
 				}
 
 				config := &dataplane.Configuration{
@@ -342,14 +363,18 @@ var _ = Describe("Collector", Ordered, func() {
 
 				expData.ClusterNodeCount = 3
 				expData.NGFResourceCounts = telemetry.NGFResourceCounts{
-					GatewayCount:          3,
-					GatewayClassCount:     3,
-					HTTPRouteCount:        3,
-					SecretCount:           3,
-					ServiceCount:          3,
-					EndpointCount:         4,
-					GRPCRouteCount:        2,
-					BackendTLSPolicyCount: 3,
+					GatewayCount:                             3,
+					GatewayClassCount:                        3,
+					HTTPRouteCount:                           3,
+					SecretCount:                              3,
+					ServiceCount:                             3,
+					EndpointCount:                            4,
+					GRPCRouteCount:                           2,
+					BackendTLSPolicyCount:                    3,
+					GatewayAttachedClientSettingsPolicyCount: 1,
+					RouteAttachedClientSettingsPolicyCount:   2,
+					ObservabilityPolicyCount:                 1,
+					NGINXProxyCount:                          1,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"
@@ -495,6 +520,21 @@ var _ = Describe("Collector", Ordered, func() {
 				ReferencedServices: map[types.NamespacedName]struct{}{
 					client.ObjectKeyFromObject(svc): {},
 				},
+				NGFPolicies: map[graph.PolicyKey]*graph.Policy{
+					{
+						NsName: types.NamespacedName{Namespace: "test", Name: "ClientSettingsPolicy-1"},
+						GVK:    schema.GroupVersionKind{Kind: kinds.ClientSettingsPolicy},
+					}: {TargetRefs: []graph.PolicyTargetRef{{Kind: kinds.Gateway}}},
+					{
+						NsName: types.NamespacedName{Namespace: "test", Name: "ClientSettingsPolicy-2"},
+						GVK:    schema.GroupVersionKind{Kind: kinds.ClientSettingsPolicy},
+					}: {TargetRefs: []graph.PolicyTargetRef{{Kind: kinds.HTTPRoute}}},
+					{
+						NsName: types.NamespacedName{Namespace: "test", Name: "ObservabilityPolicy-1"},
+						GVK:    schema.GroupVersionKind{Kind: kinds.ObservabilityPolicy},
+					}: {},
+				},
+				NginxProxy: &graph.NginxProxy{},
 			}
 
 			config1 = &dataplane.Configuration{
@@ -557,12 +597,16 @@ var _ = Describe("Collector", Ordered, func() {
 				fakeConfigurationGetter.GetLatestConfigurationReturns(config1)
 
 				expData.NGFResourceCounts = telemetry.NGFResourceCounts{
-					GatewayCount:      1,
-					GatewayClassCount: 1,
-					HTTPRouteCount:    1,
-					SecretCount:       1,
-					ServiceCount:      1,
-					EndpointCount:     1,
+					GatewayCount:                             1,
+					GatewayClassCount:                        1,
+					HTTPRouteCount:                           1,
+					SecretCount:                              1,
+					ServiceCount:                             1,
+					EndpointCount:                            1,
+					GatewayAttachedClientSettingsPolicyCount: 1,
+					RouteAttachedClientSettingsPolicyCount:   1,
+					ObservabilityPolicyCount:                 1,
+					NGINXProxyCount:                          1,
 				}
 
 				data, err := dataCollector.Collect(ctx)
@@ -575,14 +619,18 @@ var _ = Describe("Collector", Ordered, func() {
 				fakeGraphGetter.GetLatestGraphReturns(&graph.Graph{})
 				fakeConfigurationGetter.GetLatestConfigurationReturns(invalidUpstreamsConfig)
 				expData.NGFResourceCounts = telemetry.NGFResourceCounts{
-					GatewayCount:          0,
-					GatewayClassCount:     0,
-					HTTPRouteCount:        0,
-					SecretCount:           0,
-					ServiceCount:          0,
-					EndpointCount:         0,
-					GRPCRouteCount:        0,
-					BackendTLSPolicyCount: 0,
+					GatewayCount:                             0,
+					GatewayClassCount:                        0,
+					HTTPRouteCount:                           0,
+					SecretCount:                              0,
+					ServiceCount:                             0,
+					EndpointCount:                            0,
+					GRPCRouteCount:                           0,
+					BackendTLSPolicyCount:                    0,
+					GatewayAttachedClientSettingsPolicyCount: 0,
+					RouteAttachedClientSettingsPolicyCount:   0,
+					ObservabilityPolicyCount:                 0,
+					NGINXProxyCount:                          0,
 				}
 
 				data, err := dataCollector.Collect(ctx)

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -374,7 +374,7 @@ var _ = Describe("Collector", Ordered, func() {
 					GatewayAttachedClientSettingsPolicyCount: 1,
 					RouteAttachedClientSettingsPolicyCount:   2,
 					ObservabilityPolicyCount:                 1,
-					NGINXProxyCount:                          1,
+					NginxProxyCount:                          1,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"
@@ -610,7 +610,7 @@ var _ = Describe("Collector", Ordered, func() {
 					GatewayAttachedClientSettingsPolicyCount: 1,
 					RouteAttachedClientSettingsPolicyCount:   1,
 					ObservabilityPolicyCount:                 1,
-					NGINXProxyCount:                          1,
+					NginxProxyCount:                          1,
 				}
 
 				data, err := dataCollector.Collect(ctx)
@@ -634,7 +634,7 @@ var _ = Describe("Collector", Ordered, func() {
 					GatewayAttachedClientSettingsPolicyCount: 0,
 					RouteAttachedClientSettingsPolicyCount:   0,
 					ObservabilityPolicyCount:                 0,
-					NGINXProxyCount:                          0,
+					NginxProxyCount:                          0,
 				}
 
 				data, err := dataCollector.Collect(ctx)

--- a/internal/mode/static/telemetry/data.avdl
+++ b/internal/mode/static/telemetry/data.avdl
@@ -68,6 +68,19 @@ Each value is either 'true' or 'false' for boolean flags and 'default' or 'user-
 		/** BackendTLSPolicyCount is the number of relevant BackendTLSPolicies. */
 		long? BackendTLSPolicyCount = null;
 		
+		/** GatewayAttachedClientSettingsPolicyCount is the number of relevant ClientSettingsPolicies
+attached at the Gateway level. */
+		long? GatewayAttachedClientSettingsPolicyCount = null;
+		
+		/** RouteAttachedClientSettingsPolicyCount is the number of relevant ClientSettingsPolicies attached at the Route level. */
+		long? RouteAttachedClientSettingsPolicyCount = null;
+		
+		/** ObservabilityPolicyCount is the number of relevant ObservabilityPolicies. */
+		long? ObservabilityPolicyCount = null;
+		
+		/** NGINXProxyCount is the number of NGINXProxies. */
+		long? NGINXProxyCount = null;
+		
 		/** NGFReplicaCount is the number of replicas of the NGF Pod. */
 		long? NGFReplicaCount = null;
 		

--- a/internal/mode/static/telemetry/data.avdl
+++ b/internal/mode/static/telemetry/data.avdl
@@ -78,8 +78,8 @@ attached at the Gateway level. */
 		/** ObservabilityPolicyCount is the number of relevant ObservabilityPolicies. */
 		long? ObservabilityPolicyCount = null;
 		
-		/** NGINXProxyCount is the number of NGINXProxies. */
-		long? NGINXProxyCount = null;
+		/** NginxProxyCount is the number of NginxProxies. */
+		long? NginxProxyCount = null;
 		
 		/** NGFReplicaCount is the number of replicas of the NGF Pod. */
 		long? NGFReplicaCount = null;

--- a/internal/mode/static/telemetry/data_test.go
+++ b/internal/mode/static/telemetry/data_test.go
@@ -35,7 +35,7 @@ func TestDataAttributes(t *testing.T) {
 			GatewayAttachedClientSettingsPolicyCount: 9,
 			RouteAttachedClientSettingsPolicyCount:   10,
 			ObservabilityPolicyCount:                 11,
-			NGINXProxyCount:                          12,
+			NginxProxyCount:                          12,
 		},
 		NGFReplicaCount: 3,
 	}
@@ -64,7 +64,7 @@ func TestDataAttributes(t *testing.T) {
 		attribute.Int64("GatewayAttachedClientSettingsPolicyCount", 9),
 		attribute.Int64("RouteAttachedClientSettingsPolicyCount", 10),
 		attribute.Int64("ObservabilityPolicyCount", 11),
-		attribute.Int64("NGINXProxyCount", 12),
+		attribute.Int64("NginxProxyCount", 12),
 		attribute.Int64("NGFReplicaCount", 3),
 	}
 
@@ -101,7 +101,7 @@ func TestDataAttributesWithEmptyData(t *testing.T) {
 		attribute.Int64("GatewayAttachedClientSettingsPolicyCount", 0),
 		attribute.Int64("RouteAttachedClientSettingsPolicyCount", 0),
 		attribute.Int64("ObservabilityPolicyCount", 0),
-		attribute.Int64("NGINXProxyCount", 0),
+		attribute.Int64("NginxProxyCount", 0),
 		attribute.Int64("NGFReplicaCount", 0),
 	}
 

--- a/internal/mode/static/telemetry/data_test.go
+++ b/internal/mode/static/telemetry/data_test.go
@@ -24,14 +24,18 @@ func TestDataAttributes(t *testing.T) {
 		FlagNames:  []string{"test-flag"},
 		FlagValues: []string{"test-value"},
 		NGFResourceCounts: NGFResourceCounts{
-			GatewayCount:          1,
-			GatewayClassCount:     2,
-			HTTPRouteCount:        3,
-			SecretCount:           4,
-			ServiceCount:          5,
-			EndpointCount:         6,
-			GRPCRouteCount:        7,
-			BackendTLSPolicyCount: 8,
+			GatewayCount:                             1,
+			GatewayClassCount:                        2,
+			HTTPRouteCount:                           3,
+			SecretCount:                              4,
+			ServiceCount:                             5,
+			EndpointCount:                            6,
+			GRPCRouteCount:                           7,
+			BackendTLSPolicyCount:                    8,
+			GatewayAttachedClientSettingsPolicyCount: 9,
+			RouteAttachedClientSettingsPolicyCount:   10,
+			ObservabilityPolicyCount:                 11,
+			NGINXProxyCount:                          12,
 		},
 		NGFReplicaCount: 3,
 	}
@@ -57,6 +61,10 @@ func TestDataAttributes(t *testing.T) {
 		attribute.Int64("EndpointCount", 6),
 		attribute.Int64("GRPCRouteCount", 7),
 		attribute.Int64("BackendTLSPolicyCount", 8),
+		attribute.Int64("GatewayAttachedClientSettingsPolicyCount", 9),
+		attribute.Int64("RouteAttachedClientSettingsPolicyCount", 10),
+		attribute.Int64("ObservabilityPolicyCount", 11),
+		attribute.Int64("NGINXProxyCount", 12),
 		attribute.Int64("NGFReplicaCount", 3),
 	}
 
@@ -90,6 +98,10 @@ func TestDataAttributesWithEmptyData(t *testing.T) {
 		attribute.Int64("EndpointCount", 0),
 		attribute.Int64("GRPCRouteCount", 0),
 		attribute.Int64("BackendTLSPolicyCount", 0),
+		attribute.Int64("GatewayAttachedClientSettingsPolicyCount", 0),
+		attribute.Int64("RouteAttachedClientSettingsPolicyCount", 0),
+		attribute.Int64("ObservabilityPolicyCount", 0),
+		attribute.Int64("NGINXProxyCount", 0),
 		attribute.Int64("NGFReplicaCount", 0),
 	}
 

--- a/internal/mode/static/telemetry/ngfresourcecounts_attributes_generated.go
+++ b/internal/mode/static/telemetry/ngfresourcecounts_attributes_generated.go
@@ -26,7 +26,7 @@ func (d *NGFResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("GatewayAttachedClientSettingsPolicyCount", d.GatewayAttachedClientSettingsPolicyCount))
 	attrs = append(attrs, attribute.Int64("RouteAttachedClientSettingsPolicyCount", d.RouteAttachedClientSettingsPolicyCount))
 	attrs = append(attrs, attribute.Int64("ObservabilityPolicyCount", d.ObservabilityPolicyCount))
-	attrs = append(attrs, attribute.Int64("NGINXProxyCount", d.NGINXProxyCount))
+	attrs = append(attrs, attribute.Int64("NginxProxyCount", d.NginxProxyCount))
 	
 
 	return attrs

--- a/internal/mode/static/telemetry/ngfresourcecounts_attributes_generated.go
+++ b/internal/mode/static/telemetry/ngfresourcecounts_attributes_generated.go
@@ -23,6 +23,10 @@ func (d *NGFResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("EndpointCount", d.EndpointCount))
 	attrs = append(attrs, attribute.Int64("GRPCRouteCount", d.GRPCRouteCount))
 	attrs = append(attrs, attribute.Int64("BackendTLSPolicyCount", d.BackendTLSPolicyCount))
+	attrs = append(attrs, attribute.Int64("GatewayAttachedClientSettingsPolicyCount", d.GatewayAttachedClientSettingsPolicyCount))
+	attrs = append(attrs, attribute.Int64("RouteAttachedClientSettingsPolicyCount", d.RouteAttachedClientSettingsPolicyCount))
+	attrs = append(attrs, attribute.Int64("ObservabilityPolicyCount", d.ObservabilityPolicyCount))
+	attrs = append(attrs, attribute.Int64("NGINXProxyCount", d.NGINXProxyCount))
 	
 
 	return attrs

--- a/site/content/overview/product-telemetry.md
+++ b/site/content/overview/product-telemetry.md
@@ -26,7 +26,7 @@ Telemetry data is collected once every 24 hours and sent to a service managed by
 - **Deployment Replica Count:** the count of NGINX Gateway Fabric Pods.
 - **Image Build Source:** whether the image was built by GitHub or locally (values are `gha`, `local`, or `unknown`). The source repository of the images is **not** collected.
 - **Deployment Flags:** a list of NGINX Gateway Fabric Deployment flags that are specified by a user. The actual values of non-boolean flags are **not** collected; we only record that they are either `true` or `false` for boolean flags and `default` or `user-defined` for the rest.
-- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `Secrets`, `Services`, `BackendTLSPolicies`, and `Endpoints`. The data within these resources is **not** collected.
+- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `Secrets`, `Services`, `BackendTLSPolicies`, `ClientSettingsPolicies`, `NGINXProxies`, `ObservabilityPolicies`, and `Endpoints`. The data within these resources is **not** collected.
 
 This data is used to identify the following information:
 

--- a/site/content/overview/product-telemetry.md
+++ b/site/content/overview/product-telemetry.md
@@ -26,7 +26,7 @@ Telemetry data is collected once every 24 hours and sent to a service managed by
 - **Deployment Replica Count:** the count of NGINX Gateway Fabric Pods.
 - **Image Build Source:** whether the image was built by GitHub or locally (values are `gha`, `local`, or `unknown`). The source repository of the images is **not** collected.
 - **Deployment Flags:** a list of NGINX Gateway Fabric Deployment flags that are specified by a user. The actual values of non-boolean flags are **not** collected; we only record that they are either `true` or `false` for boolean flags and `default` or `user-defined` for the rest.
-- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `Secrets`, `Services`, `BackendTLSPolicies`, `ClientSettingsPolicies`, `NGINXProxies`, `ObservabilityPolicies`, and `Endpoints`. The data within these resources is **not** collected.
+- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `Secrets`, `Services`, `BackendTLSPolicies`, `ClientSettingsPolicies`, `NginxProxies`, `ObservabilityPolicies`, and `Endpoints`. The data within these resources is **not** collected.
 
 This data is used to identify the following information:
 

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -80,6 +80,10 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 				"EndpointCount: Int(0)",
 				"GRPCRouteCount: Int(0)",
 				"BackendTLSPolicyCount: Int(0)",
+				"GatewayAttachedClientSettingsPolicyCount: Int(0)",
+				"RouteAttachedClientSettingsPolicyCount: Int(0)",
+				"ObservabilityPolicyCount: Int(0)",
+				"NGINXProxyCount: Int(0)",
 				"NGFReplicaCount: Int(1)",
 			},
 		)

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 				"GatewayAttachedClientSettingsPolicyCount: Int(0)",
 				"RouteAttachedClientSettingsPolicyCount: Int(0)",
 				"ObservabilityPolicyCount: Int(0)",
-				"NGINXProxyCount: Int(0)",
+				"NginxProxyCount: Int(0)",
 				"NGFReplicaCount: Int(1)",
 			},
 		)


### PR DESCRIPTION
Collect count for ClientSettingsPolicies attached at the Gateway level, ClientSettingsPolicies attached at the Route level, ObservabilityPolicies, and NginxProxy.

Problem: I want to collect the number of ClientSettings, Observability, and NginxProxy Policies used in NGF for each context they are used in.

Solution: Collect the counts of the resources.

Testing: Manual testing and addition to unit tests.

Output with a Gateway level ClientSettingsPolicy, a Route level ClientSettingsPolicy, an ObservabilityPolicy, and the NGINXProxy attached.
```
{"level":"debug","ts":"2024-06-27T21:53:53Z","logger":"telemetryExporter","msg":"Exporting telemetry","data":{"ImageSource":"local","ProjectName":"NGF"…"GatewayAttachedClientSettingsPolicyCount":1,"RouteAttachedClientSettingsPolicyCount":1,"ObservabilityPolicyCount":1,"NginxProxyCount":1,"NGFReplicaCount":1}}
```

Output with none of the above resources attached:
```
{"level":"debug","ts":"2024-06-27T21:59:53Z","logger":"telemetryExporter","msg":"Exporting telemetry","data":{"ImageSource":"local","ProjectName":"NGF"…"GatewayAttachedClientSettingsPolicyCount":0,"RouteAttachedClientSettingsPolicyCount":0,"ObservabilityPolicyCount":0,"NginxProxyCount":0,"NGFReplicaCount":1}}
```

Closes #1898

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Collect Policy and NGINXProxy count for telemetry data
```
