### PR TITLE
Update Docker frontend and remove noisy summaries for tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write # needed for uploading release artifacts
+    env:
+      DOCKER_BUILD_NO_SUMMARY: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -21,6 +21,8 @@ jobs:
   functional-tests:
     name: Run Tests
     runs-on: ubuntu-22.04
+    env:
+      DOCKER_BUILD_NO_SUMMARY: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,33 +1,33 @@
-# syntax=docker/dockerfile:1.7
-FROM golang:1.22 as builder
+# syntax=docker/dockerfile:1.8
+FROM golang:1.22 AS builder
 
 WORKDIR /go/src/github.com/nginxinc/nginx-gateway-fabric
 
-COPY go.mod go.sum /go/src/github.com/nginxinc/nginx-gateway-fabric
+COPY go.mod go.sum /go/src/github.com/nginxinc/nginx-gateway-fabric/
 RUN go mod download
 
 COPY . /go/src/github.com/nginxinc/nginx-gateway-fabric
 RUN make build
 
-FROM golang:1.22 as ca-certs-provider
+FROM golang:1.22 AS ca-certs-provider
 
-FROM alpine:3.20 as capabilizer
+FROM alpine:3.20 AS capabilizer
 RUN apk add --no-cache libcap
 
-FROM capabilizer as local-capabilizer
+FROM capabilizer AS local-capabilizer
 COPY ./build/out/gateway /usr/bin/
 RUN setcap 'cap_kill=+ep' /usr/bin/gateway
 
-FROM capabilizer as container-capabilizer
+FROM capabilizer AS container-capabilizer
 COPY --from=builder /go/src/github.com/nginxinc/nginx-gateway-fabric/build/out/gateway /usr/bin/
 RUN setcap 'cap_kill=+ep' /usr/bin/gateway
 
-FROM capabilizer as goreleaser-capabilizer
+FROM capabilizer AS goreleaser-capabilizer
 ARG TARGETARCH
 COPY dist/gateway_linux_$TARGETARCH*/gateway /usr/bin/
 RUN setcap 'cap_kill=+ep' /usr/bin/gateway
 
-FROM scratch as common
+FROM scratch AS common
 # CA certs are needed for telemetry report and NGINX Plus usage report features, so that
 # NGF can verify the server's certificate.
 COPY --from=ca-certs-provider --link /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -36,11 +36,11 @@ ARG BUILD_AGENT
 ENV BUILD_AGENT=${BUILD_AGENT}
 ENTRYPOINT [ "/usr/bin/gateway" ]
 
-FROM common as container
+FROM common AS container
 COPY --from=container-capabilizer /usr/bin/gateway /usr/bin/
 
-FROM common as local
+FROM common AS local
 COPY --from=local-capabilizer /usr/bin/gateway /usr/bin/
 
-FROM common as goreleaser
+FROM common AS goreleaser
 COPY --from=goreleaser-capabilizer /usr/bin/gateway /usr/bin/

--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.8
 FROM nginx:1.27.0-alpine-otel
 
 ARG NJS_DIR

--- a/build/Dockerfile.nginxplus
+++ b/build/Dockerfile.nginxplus
@@ -1,5 +1,5 @@
-# syntax=docker/dockerfile:1.7
-FROM scratch as nginx-files
+# syntax=docker/dockerfile:1.8
+FROM scratch AS nginx-files
 
 # the following links can be replaced with local files if needed, i.e. ADD --chown=101:1001 <local_file> <container_file>
 ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.pub nginx_signing.rsa.pub

--- a/debug/Dockerfile
+++ b/debug/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.8
 # This Dockerfile builds an image with the dlv debugger. See the debugging guide in the developer docs for details
 # on how to use it.
 FROM golang:1.22-alpine AS builder

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,3 +1,3 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.8
 # this is here so we can grab the latest version of kind and have dependabot keep it up to date
 FROM kindest/node:v1.30.0

--- a/tests/conformance/Dockerfile
+++ b/tests/conformance/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.8
 FROM golang:1.22
 
 WORKDIR /go/src/github.com/nginxinc/nginx-gateway-fabric/tests/conformance


### PR DESCRIPTION
### Proposed changes

Problem: Docker added summaries for the GitHub Action, but are very noisy and we don't need them for test images. There's also a new fronted that adds linting.

Solution: Remove the summaries for test builds and update Dockerfile with the new fronted. Fix warnings found.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
