### PR TITLE
Upload Plus Docker images to GAR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,23 @@ jobs:
           password: ${{ github.actor }}
         if: ${{ github.event_name != 'pull_request' && contains(inputs.image, 'plus') }}
 
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+        if: ${{ github.event_name != 'pull_request' && contains(inputs.image, 'plus') }}
+
+      - name: Login to GAR
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+        if: ${{ github.event_name != 'pull_request' && contains(inputs.image, 'plus') }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
@@ -88,6 +105,7 @@ jobs:
             name=ghcr.io/nginxinc/nginx-gateway-fabric,enable=${{ inputs.image == 'ngf' && github.event_name != 'pull_request' }}
             name=ghcr.io/nginxinc/nginx-gateway-fabric/nginx,enable=${{ inputs.image == 'nginx' && github.event_name != 'pull_request' }}
             name=docker-mgmt.nginx.com/nginx-gateway-fabric/nginx-plus,enable=${{ inputs.image == 'plus' && github.event_name != 'pull_request' }}
+            name=us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/nginx-gateway-fabric/nginx-plus,enable=${{ inputs.image == 'plus' && github.event_name != 'pull_request' }}
             name=localhost:5000/nginx-gateway-fabric/${{ inputs.image }}
           flavor: |
             latest=${{ (inputs.tag != '' && 'true') || 'auto' }}

--- a/.github/workflows/nfr.yml
+++ b/.github/workflows/nfr.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       test_label:
-        description: NFR test to run. Choose between performance, upgrade, or all
+        description: NFR test to run. Choose between performance, upgrade, scale, or all
         required: true
         default: all
         type: choice
@@ -47,28 +47,6 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-    - name: Setup Golang Environment
-      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
-      with:
-        go-version: stable
-
-    - name: Set GOPATH
-      run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-
-    - name: Docker Buildx
-      if: ${{ inputs.nginx_plus == true }}
-      uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
-
-    - name: NGINX Docker meta
-      id: nginx-meta
-      if: ${{ inputs.nginx_plus == true }}
-      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
-      with:
-        images: |
-          name=gcr.io/${{ secrets.GCP_PROJECT_ID }}/ngf-nfr/nginx-gateway-fabric/nginx-plus
-        tags: |
-          type=raw,value=${{ inputs.image_tag }}
-
     - name: Authenticate to Google Cloud
       id: auth
       uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
@@ -83,29 +61,6 @@ jobs:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         install_components: kubectl
 
-    - name: Login to GCR
-      if: ${{ inputs.nginx_plus == true }}
-      run: gcloud auth configure-docker gcr.io -q
-
-    - name: Build NGINX Plus Docker Image
-      if: ${{ inputs.nginx_plus == true }}
-      uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v6.2.0
-      with:
-        file: build/Dockerfile.nginxplus
-        tags: ${{ steps.nginx-meta.outputs.tags }}
-        context: "."
-        platforms: linux/amd64
-        provenance: false
-        pull: true
-        push: true
-        build-args: |
-          NJS_DIR=internal/mode/static/nginx/modules/src
-          NGINX_CONF_DIR=internal/mode/static/nginx/conf
-          BUILD_AGENT=gha
-        secrets: |
-          ${{ format('"nginx-repo.crt={0}"', secrets.NGINX_CRT) }}
-          ${{ format('"nginx-repo.key={0}"', secrets.NGINX_KEY) }}
-
     - name: Setup dotenv file
       working-directory: ./tests/scripts
       run: |
@@ -113,7 +68,7 @@ jobs:
         echo "TAG=${{ inputs.image_tag }}" >> vars.env
         echo "PREFIX=ghcr.io/nginxinc/nginx-gateway-fabric" >> vars.env
         echo "NGINX_PREFIX=ghcr.io/nginxinc/nginx-gateway-fabric/nginx" >> vars.env
-        echo "NGINX_PLUS_PREFIX=gcr.io/${{ secrets.GCP_PROJECT_ID }}/ngf-nfr/nginx-gateway-fabric/nginx-plus" >> vars.env
+        echo "NGINX_PLUS_PREFIX=us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/nginx-gateway-fabric/nginx-plus" >> vars.env
         echo "GKE_CLUSTER_NAME=nfr-tests-${{ github.run_id }}" >> vars.env
         echo "GKE_CLUSTER_ZONE=us-east1-b" >> vars.env
         echo "GKE_CLUSTER_REGION=us-east1" >> vars.env


### PR DESCRIPTION
### Proposed changes

Problem: We want to be able to use NGINX Plus images built from `edge` and release branches in the NFR workflow

Solution: Start pushing Plus images to GAR so they're available to other workflows

Closes #2143

Note: We're already pushing all the other images to ghcr.io for `edge` and release branches

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
