### PR TITLE
Group otel and k8s.io updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
       - "**/*"
     schedule:
       interval: daily
+    groups:
+      otel:
+        patterns:
+          - "go.opentelemetry.io/otel*"
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
 
   - package-ecosystem: docker
     directories:


### PR DESCRIPTION
### Proposed changes

Problem: Otel and k8s dependencies are often upgraded all at once and depend on one another

Solution: Instruct dependabot to group all the dependencies of the same set of libraries in a single PR

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
