### PR TITLE
Fix ObservabilityPolicy TargetRefs documentation

### DIFF
--- a/apis/v1alpha1/observabilitypolicy_types.go
+++ b/apis/v1alpha1/observabilitypolicy_types.go
@@ -45,7 +45,7 @@ type ObservabilityPolicySpec struct {
 
 	// TargetRefs identifies the API object(s) to apply the policy to.
 	// Objects must be in the same namespace as the policy.
-	// Support: HTTPRoute
+	// Support: HTTPRoute, GRPCRoute.
 	//
 	// +kubebuilder:validation:MaxItems=16
 	// +kubebuilder:validation:XValidation:message="TargetRef Kind must be: HTTPRoute or GRPCRoute",rule="(self.exists(t, t.kind=='HTTPRoute') || self.exists(t, t.kind=='GRPCRoute'))"

--- a/config/crd/bases/gateway.nginx.org_observabilitypolicies.yaml
+++ b/config/crd/bases/gateway.nginx.org_observabilitypolicies.yaml
@@ -54,7 +54,7 @@ spec:
                 description: |-
                   TargetRefs identifies the API object(s) to apply the policy to.
                   Objects must be in the same namespace as the policy.
-                  Support: HTTPRoute
+                  Support: HTTPRoute, GRPCRoute.
                 items:
                   description: |-
                     LocalPolicyTargetReference identifies an API object to apply a direct or

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -836,7 +836,7 @@ spec:
                 description: |-
                   TargetRefs identifies the API object(s) to apply the policy to.
                   Objects must be in the same namespace as the policy.
-                  Support: HTTPRoute
+                  Support: HTTPRoute, GRPCRoute.
                 items:
                   description: |-
                     LocalPolicyTargetReference identifies an API object to apply a direct or

--- a/site/content/reference/api.md
+++ b/site/content/reference/api.md
@@ -416,7 +416,7 @@ Tracing
 <td>
 <p>TargetRefs identifies the API object(s) to apply the policy to.
 Objects must be in the same namespace as the policy.
-Support: HTTPRoute</p>
+Support: HTTPRoute, GRPCRoute.</p>
 </td>
 </tr>
 </table>
@@ -949,7 +949,7 @@ Tracing
 <td>
 <p>TargetRefs identifies the API object(s) to apply the policy to.
 Objects must be in the same namespace as the policy.
-Support: HTTPRoute</p>
+Support: HTTPRoute, GRPCRoute.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
### Proposed changes

Problem:
- The documentation for the targetRefs field of ObservabilityPolicy doesn't include GRPCRoute as supported kind.

Solution:
- Fix that.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
