### PR TITLE
fix: update kubectl exec syntax to remove deprecation warning

### DIFF
--- a/site/content/how-to/monitoring/troubleshooting.md
+++ b/site/content/how-to/monitoring/troubleshooting.md
@@ -73,7 +73,7 @@ LAST SEEN   TYPE      REASON              OBJECT                                
 Getting shell access to containers allows developers and operators to view the environment of a running container, see its logs or diagnose any problems. To get shell access to the NGINX container, use `kubectl exec`:
 
 ```shell
-kubectl exec -it -n nginx-gateway  <ngf-pod-name> -c nginx /bin/sh
+kubectl exec -it -n nginx-gateway  <ngf-pod-name> -c nginx -- /bin/sh
 ```
 
 #### Logs


### PR DESCRIPTION
### Proposed changes

Problem: Deprecation warning from kubectl when using exec without the `--`

```shell
❯ kubectl exec -it -n nginx-gateway $NGINX_POD -c nginx /bin/sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
E0710 07:52:34.700510   45075 websocket.go:296] Unknown stream id 1, discarding message
/ $
```

Solution: 

add the `--` syntax before the command to be executed

Testing: 

```shell
❯ kubectl exec -it -n nginx-gateway $NGINX_POD -c nginx -- /bin/sh
/ $ 
```

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #2217 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
