### PR TITLE
Replace TODO route condition with an Accepted/False condition

### DIFF
--- a/internal/mode/static/state/change_processor_test.go
+++ b/internal/mode/static/state/change_processor_test.go
@@ -886,11 +886,11 @@ var _ = Describe("ChangeProcessor", func() {
 					expGraph.Routes[routeKey2] = expRouteHR2
 					expGraph.Routes[routeKey2].ParentRefs[0].Attachment = &graph.ParentRefAttachmentStatus{
 						AcceptedHostnames: map[string][]string{},
-						FailedCondition:   staticConds.NewTODO("Gateway is ignored"),
+						FailedCondition:   staticConds.NewRouteNotAcceptedGatewayIgnored(),
 					}
 					expGraph.Routes[routeKey2].ParentRefs[1].Attachment = &graph.ParentRefAttachmentStatus{
 						AcceptedHostnames: map[string][]string{},
-						FailedCondition:   staticConds.NewTODO("Gateway is ignored"),
+						FailedCondition:   staticConds.NewRouteNotAcceptedGatewayIgnored(),
 					}
 					expGraph.ReferencedSecrets[client.ObjectKeyFromObject(diffNsTLSSecret)] = &graph.Secret{
 						Source: diffNsTLSSecret,

--- a/internal/mode/static/state/conditions/conditions.go
+++ b/internal/mode/static/state/conditions/conditions.go
@@ -85,15 +85,20 @@ const (
 	// PolicyMessageTelemetryNotEnabled is a message used with the PolicyReasonNginxProxyConfigNotSet reason
 	// when telemetry is not enabled in the NginxProxy resource.
 	PolicyMessageTelemetryNotEnabled = "Telemetry is not enabled in the NginxProxy resource"
+
+	// GatewayIgnoredReason is used with v1.RouteConditionAccepted when the route references a Gateway that is ignored
+	// by NGF.
+	GatewayIgnoredReason v1.RouteConditionReason = "GatewayIgnored"
 )
 
-// NewTODO returns a Condition that can be used as a placeholder for a condition that is not yet implemented.
-func NewTODO(msg string) conditions.Condition {
+// NewRouteNotAcceptedGatewayIgnored returns a Condition that indicates that the Route is not accepted by the Gateway
+// because the Gateway is ignored by NGF.
+func NewRouteNotAcceptedGatewayIgnored() conditions.Condition {
 	return conditions.Condition{
-		Type:    "TODO",
-		Status:  metav1.ConditionTrue,
-		Reason:  "TODO",
-		Message: fmt.Sprintf("The condition for this has not been implemented yet: %s", msg),
+		Type:    string(v1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(GatewayIgnoredReason),
+		Message: "The Gateway is ignored by the controller",
 	}
 }
 

--- a/internal/mode/static/state/graph/route_common.go
+++ b/internal/mode/static/state/graph/route_common.go
@@ -301,7 +301,7 @@ func bindRouteToListeners(
 		referencesWinningGw := ref.Gateway.Namespace == gw.Source.Namespace && ref.Gateway.Name == gw.Source.Name
 
 		if !referencesWinningGw {
-			attachment.FailedCondition = staticConds.NewTODO("Gateway is ignored")
+			attachment.FailedCondition = staticConds.NewRouteNotAcceptedGatewayIgnored()
 			continue
 		}
 

--- a/internal/mode/static/state/graph/route_common_test.go
+++ b/internal/mode/static/state/graph/route_common_test.go
@@ -687,7 +687,7 @@ func TestBindRouteToListeners(t *testing.T) {
 					SectionName: hr.Spec.ParentRefs[0].SectionName,
 					Attachment: &ParentRefAttachmentStatus{
 						Attached:          false,
-						FailedCondition:   staticConds.NewTODO("Gateway is ignored"),
+						FailedCondition:   staticConds.NewRouteNotAcceptedGatewayIgnored(),
 						AcceptedHostnames: map[string][]string{},
 					},
 				},

--- a/site/content/overview/gateway-api-compatibility.md
+++ b/site/content/overview/gateway-api-compatibility.md
@@ -173,6 +173,7 @@ See the [static-mode]({{< relref "/reference/cli-help.md#static-mode">}}) comman
       - `Accepted/False/UnsupportedValue`: Custom reason for when the HTTPRoute includes an invalid or unsupported value.
       - `Accepted/False/InvalidListener`: Custom reason for when the HTTPRoute references an invalid listener.
       - `Accepted/False/GatewayNotProgrammed`: Custom reason for when the Gateway is not Programmed. HTTPRoute can be valid and configured, but will maintain this status as long as the Gateway is not Programmed.
+      - `Accepted/False/GatewayIgnored`: Custom reason for when the Gateway is ignored by NGINX Gateway Fabric. NGINX Gateway Fabric only supports one Gateway.
       - `ResolvedRefs/True/ResolvedRefs`
       - `ResolvedRefs/False/InvalidKind`
       - `ResolvedRefs/False/RefNotPermitted`


### PR DESCRIPTION
### Proposed changes

Problem: When a route references a Gateway that is ignored, NGF adds the TODO condition: `The condition for this has not been implemented yet: Gateway is ignored`. This does not communicate to the user that the route is not accepted because the Gateway it references is ignored. 

Solution: Change this condition to be Accepted/False/GatewayIgnored. 

Testing: Verified that the condition is added to routes that reference an ignored Gateway.

Closes #2015 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
