### PR TITLE
Fix directory creation and permissions

### DIFF
--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -6,7 +6,7 @@ ARG NGINX_CONF_DIR
 ARG BUILD_AGENT
 
 RUN apk add --no-cache libcap \
-    && mkdir -p /var/lib/nginx /usr/lib/nginx/modules \
+    && mkdir -p /usr/lib/nginx/modules \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && apk del libcap
@@ -16,7 +16,7 @@ COPY ${NGINX_CONF_DIR}/nginx.conf /etc/nginx/nginx.conf
 COPY ${NGINX_CONF_DIR}/grpc-error-locations.conf /etc/nginx/grpc-error-locations.conf
 COPY ${NGINX_CONF_DIR}/grpc-error-pages.conf /etc/nginx/grpc-error-pages.conf
 
-RUN chown -R 101:1001 /etc/nginx /var/cache/nginx /var/lib/nginx
+RUN chown -R 101:1001 /etc/nginx /var/cache/nginx /var/run/nginx
 
 LABEL org.nginx.ngf.image.build.agent="${BUILD_AGENT}"
 

--- a/build/Dockerfile.nginxplus
+++ b/build/Dockerfile.nginxplus
@@ -19,7 +19,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
     && printf "%s\n" "https://pkgs.nginx.com/plus/${NGINX_PLUS_VERSION}/alpine/v$(grep -E -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
     && apk add --no-cache nginx-plus nginx-plus-module-njs nginx-plus-module-otel libcap \
-    && mkdir -p /var/lib/nginx /usr/lib/nginx/modules \
+    && mkdir -p /usr/lib/nginx/modules \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && apk del libcap \
@@ -32,7 +32,7 @@ COPY ${NGINX_CONF_DIR}/nginx-plus.conf /etc/nginx/nginx.conf
 COPY ${NGINX_CONF_DIR}/grpc-error-locations.conf /etc/nginx/grpc-error-locations.conf
 COPY ${NGINX_CONF_DIR}/grpc-error-pages.conf /etc/nginx/grpc-error-pages.conf
 
-RUN chown -R 101:1001 /etc/nginx /var/cache/nginx /var/lib/nginx
+RUN chown -R 101:1001 /etc/nginx /var/cache/nginx /var/run/nginx
 
 USER 101:1001
 


### PR DESCRIPTION
Problem: In our Dockerfiles, we create a directory that is no longer used, and don't set user permissions for others.

Solution: Removed the unnecessary directory and set proper permissions.
