### PR TITLE
Hide NGINX version

### DIFF
--- a/internal/mode/static/nginx/conf/nginx-plus.conf
+++ b/internal/mode/static/nginx/conf/nginx-plus.conf
@@ -27,6 +27,8 @@ http {
   sendfile on;
   tcp_nopush on;
 
+  server_tokens off;
+
   server {
     listen 127.0.0.1:8765;
     root /usr/share/nginx/html;

--- a/internal/mode/static/nginx/conf/nginx.conf
+++ b/internal/mode/static/nginx/conf/nginx.conf
@@ -27,6 +27,8 @@ http {
   sendfile on;
   tcp_nopush on;
 
+  server_tokens off;
+
   server {
     listen unix:/var/run/nginx/nginx-status.sock;
     access_log off;


### PR DESCRIPTION
Problem: As a user of NGF, I want the NGINX version of my installation of NGF hidden by default, so that I do not inadvertently expose which vulnerabilities my version of NGINX is vulnerable to.

Solution: Hide the nginx version that's included in responses.

Testing: Verified in the browser and using curl that the nginx version is not included.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #1507

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Hide NGINX version that is included in responses.
```
