### PR TITLE
Properly disable leader election

### DIFF
--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -312,7 +312,7 @@ func createManager(cfg config.Config, nginxChecker *nginxConfiguredOnStartChecke
 		// Note: when the leadership is lost, the manager will return an error in the Start() method.
 		// However, it will not wait for any Runnable it starts to finish, meaning any in-progress operations
 		// might get terminated half-way.
-		LeaderElection:          true,
+		LeaderElection:          cfg.LeaderElection.Enabled,
 		LeaderElectionNamespace: cfg.GatewayPodConfig.Namespace,
 		LeaderElectionID:        cfg.LeaderElection.LockName,
 		// We're not enabling LeaderElectionReleaseOnCancel because when the Manager stops gracefully, it waits


### PR DESCRIPTION
Problem: NGF does not honor the `--leader-election-disable` command-line flag.

Solution: Use the proper variable instead of a hardcoded boolean.

Testing: Verified that disabling leader election actually disables it.

Closes #2283 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix bug where leader election couldn't be disabled.
```
