### PR TITLE
Disallow route to attach to listener if not present in allowed routes.

### DIFF
--- a/internal/mode/static/state/change_processor_test.go
+++ b/internal/mode/static/state/change_processor_test.go
@@ -519,12 +519,15 @@ var _ = Describe("ChangeProcessor", func() {
 						Source: gw1,
 						Listeners: []*graph.Listener{
 							{
-								Name:           "listener-80-1",
-								Source:         gw1.Spec.Listeners[0],
-								Valid:          true,
-								Attachable:     true,
-								Routes:         map[graph.RouteKey]*graph.L7Route{routeKey1: expRouteHR1},
-								SupportedKinds: []v1.RouteGroupKind{{Kind: kinds.HTTPRoute}},
+								Name:       "listener-80-1",
+								Source:     gw1.Spec.Listeners[0],
+								Valid:      true,
+								Attachable: true,
+								Routes:     map[graph.RouteKey]*graph.L7Route{routeKey1: expRouteHR1},
+								SupportedKinds: []v1.RouteGroupKind{
+									{Kind: v1.Kind(kinds.HTTPRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
+									{Kind: v1.Kind(kinds.GRPCRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
+								},
 							},
 							{
 								Name:           "listener-443-1",
@@ -533,7 +536,10 @@ var _ = Describe("ChangeProcessor", func() {
 								Attachable:     true,
 								Routes:         map[graph.RouteKey]*graph.L7Route{routeKey1: expRouteHR1},
 								ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(diffNsTLSSecret)),
-								SupportedKinds: []v1.RouteGroupKind{{Kind: kinds.HTTPRoute}},
+								SupportedKinds: []v1.RouteGroupKind{
+									{Kind: v1.Kind(kinds.HTTPRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
+									{Kind: v1.Kind(kinds.GRPCRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
+								},
 							},
 						},
 						Valid: true,

--- a/internal/mode/static/state/graph/gateway_listener.go
+++ b/internal/mode/static/state/graph/gateway_listener.go
@@ -11,6 +11,7 @@ import (
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/kinds"
 	staticConds "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/conditions"
 )
@@ -228,18 +229,10 @@ func getAndValidateListenerSupportedKinds(listener v1.Listener) (
 	[]conditions.Condition,
 	[]v1.RouteGroupKind,
 ) {
-	if listener.AllowedRoutes == nil || listener.AllowedRoutes.Kinds == nil {
-		return nil, []v1.RouteGroupKind{
-			{
-				Kind: kinds.HTTPRoute,
-			},
-		}
-	}
 	var conds []conditions.Condition
+	supportedKinds := make([]v1.RouteGroupKind, 0)
 
-	supportedKinds := make([]v1.RouteGroupKind, 0, len(listener.AllowedRoutes.Kinds))
-
-	validHTTPProtocolRouteKind := func(kind v1.RouteGroupKind) bool {
+	validRouteKind := func(kind v1.RouteGroupKind) bool {
 		if kind.Kind != v1.Kind(kinds.HTTPRoute) && kind.Kind != v1.Kind(kinds.GRPCRoute) {
 			return false
 		}
@@ -249,17 +242,25 @@ func getAndValidateListenerSupportedKinds(listener v1.Listener) (
 		return true
 	}
 
-	switch listener.Protocol {
-	case v1.HTTPProtocolType, v1.HTTPSProtocolType:
+	if listener.AllowedRoutes != nil && listener.AllowedRoutes.Kinds != nil {
 		for _, kind := range listener.AllowedRoutes.Kinds {
-			if !validHTTPProtocolRouteKind(kind) {
+			if !validRouteKind(kind) {
 				msg := fmt.Sprintf("Unsupported route kind \"%s/%s\"", *kind.Group, kind.Kind)
 				conds = append(conds, staticConds.NewListenerInvalidRouteKinds(msg)...)
 				continue
 			}
 			supportedKinds = append(supportedKinds, kind)
 		}
+	} else {
+		switch listener.Protocol {
+		case v1.HTTPProtocolType, v1.HTTPSProtocolType:
+			supportedKinds = []v1.RouteGroupKind{
+				{Kind: v1.Kind(kinds.HTTPRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
+				{Kind: v1.Kind(kinds.GRPCRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
+			}
+		}
 	}
+
 	return conds, supportedKinds
 }
 

--- a/internal/mode/static/state/graph/gateway_listener.go
+++ b/internal/mode/static/state/graph/gateway_listener.go
@@ -225,12 +225,15 @@ func validateListenerHostname(listener v1.Listener) (conds []conditions.Conditio
 	return nil, true
 }
 
+// getAndValidateListenerSupportedKinds validates the route kind and returns the supported kinds for the listener.
+// The supported kinds are determined based on the listener's allowedRoutes field.
+// If the listener does not specify allowedRoutes, listener determines allowed routes based on its protocol.
 func getAndValidateListenerSupportedKinds(listener v1.Listener) (
 	[]conditions.Condition,
 	[]v1.RouteGroupKind,
 ) {
 	var conds []conditions.Condition
-	supportedKinds := make([]v1.RouteGroupKind, 0)
+	var supportedKinds []v1.RouteGroupKind
 
 	validRouteKind := func(kind v1.RouteGroupKind) bool {
 		if kind.Kind != v1.Kind(kinds.HTTPRoute) && kind.Kind != v1.Kind(kinds.GRPCRoute) {
@@ -243,6 +246,7 @@ func getAndValidateListenerSupportedKinds(listener v1.Listener) (
 	}
 
 	if listener.AllowedRoutes != nil && listener.AllowedRoutes.Kinds != nil {
+		supportedKinds = make([]v1.RouteGroupKind, 0, len(listener.AllowedRoutes.Kinds))
 		for _, kind := range listener.AllowedRoutes.Kinds {
 			if !validRouteKind(kind) {
 				msg := fmt.Sprintf("Unsupported route kind \"%s/%s\"", *kind.Group, kind.Kind)

--- a/internal/mode/static/state/graph/gateway_listener_test.go
+++ b/internal/mode/static/state/graph/gateway_listener_test.go
@@ -314,7 +314,7 @@ func TestGetAndValidateListenerSupportedKinds(t *testing.T) {
 			protocol:  v1.TCPProtocolType,
 			expectErr: false,
 			name:      "unsupported protocol is ignored",
-			expected:  []v1.RouteGroupKind{},
+			expected:  nil,
 		},
 		{
 			protocol: v1.HTTPProtocolType,

--- a/internal/mode/static/state/graph/gateway_listener_test.go
+++ b/internal/mode/static/state/graph/gateway_listener_test.go
@@ -289,11 +289,13 @@ func TestValidateListenerHostname(t *testing.T) {
 }
 
 func TestGetAndValidateListenerSupportedKinds(t *testing.T) {
-	HTTPRouteGroupKind := []v1.RouteGroupKind{
-		{
-			Kind:  kinds.HTTPRoute,
-			Group: helpers.GetPointer[v1.Group](v1.GroupName),
-		},
+	HTTPRouteGroupKind := v1.RouteGroupKind{
+		Kind:  kinds.HTTPRoute,
+		Group: helpers.GetPointer[v1.Group](v1.GroupName),
+	}
+	GRPCRouteGroupKind := v1.RouteGroupKind{
+		Kind:  kinds.GRPCRoute,
+		Group: helpers.GetPointer[v1.Group](v1.GroupName),
 	}
 	TCPRouteGroupKind := []v1.RouteGroupKind{
 		{
@@ -312,7 +314,6 @@ func TestGetAndValidateListenerSupportedKinds(t *testing.T) {
 			protocol:  v1.TCPProtocolType,
 			expectErr: false,
 			name:      "unsupported protocol is ignored",
-			kind:      TCPRouteGroupKind,
 			expected:  []v1.RouteGroupKind{},
 		},
 		{
@@ -336,35 +337,30 @@ func TestGetAndValidateListenerSupportedKinds(t *testing.T) {
 		},
 		{
 			protocol:  v1.HTTPProtocolType,
-			kind:      HTTPRouteGroupKind,
+			kind:      []v1.RouteGroupKind{HTTPRouteGroupKind},
 			expectErr: false,
 			name:      "valid HTTP",
-			expected:  HTTPRouteGroupKind,
+			expected:  []v1.RouteGroupKind{HTTPRouteGroupKind},
 		},
 		{
 			protocol:  v1.HTTPSProtocolType,
-			kind:      HTTPRouteGroupKind,
+			kind:      []v1.RouteGroupKind{HTTPRouteGroupKind},
 			expectErr: false,
 			name:      "valid HTTPS",
-			expected:  HTTPRouteGroupKind,
+			expected:  []v1.RouteGroupKind{HTTPRouteGroupKind},
 		},
 		{
 			protocol:  v1.HTTPSProtocolType,
 			expectErr: false,
 			name:      "valid HTTPS no kind specified",
 			expected: []v1.RouteGroupKind{
-				{
-					Kind: kinds.HTTPRoute,
-				},
+				HTTPRouteGroupKind, GRPCRouteGroupKind,
 			},
 		},
 		{
 			protocol: v1.HTTPProtocolType,
 			kind: []v1.RouteGroupKind{
-				{
-					Kind:  kinds.HTTPRoute,
-					Group: helpers.GetPointer[v1.Group](v1.GroupName),
-				},
+				HTTPRouteGroupKind,
 				{
 					Kind:  "bad-kind",
 					Group: helpers.GetPointer[v1.Group](v1.GroupName),
@@ -372,7 +368,7 @@ func TestGetAndValidateListenerSupportedKinds(t *testing.T) {
 			},
 			expectErr: true,
 			name:      "valid and invalid kinds",
-			expected:  HTTPRouteGroupKind,
+			expected:  []v1.RouteGroupKind{HTTPRouteGroupKind},
 		},
 	}
 

--- a/internal/mode/static/state/graph/gateway_test.go
+++ b/internal/mode/static/state/graph/gateway_test.go
@@ -347,6 +347,11 @@ func TestBuildGateway(t *testing.T) {
 		Valid: false,
 	}
 
+	supportedKindsForListeners := []v1.RouteGroupKind{
+		{Kind: v1.Kind(kinds.HTTPRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
+		{Kind: v1.Kind(kinds.GRPCRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
+	}
+
 	tests := []struct {
 		gateway      *v1.Gateway
 		gatewayClass *GatewayClass
@@ -361,24 +366,20 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: []*Listener{
 					{
-						Name:       "foo-80-1",
-						Source:     foo80Listener1,
-						Valid:      true,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "foo-80-1",
+						Source:         foo80Listener1,
+						Valid:          true,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
-						Name:       "foo-8080",
-						Source:     foo8080Listener,
-						Valid:      true,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "foo-8080",
+						Source:         foo8080Listener,
+						Valid:          true,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,
@@ -400,9 +401,7 @@ func TestBuildGateway(t *testing.T) {
 						Attachable:     true,
 						Routes:         map[RouteKey]*L7Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:           "foo-8443-https",
@@ -411,9 +410,7 @@ func TestBuildGateway(t *testing.T) {
 						Attachable:     true,
 						Routes:         map[RouteKey]*L7Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,
@@ -479,9 +476,7 @@ func TestBuildGateway(t *testing.T) {
 						Attachable:     true,
 						Routes:         map[RouteKey]*L7Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretDiffNamespace)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,
@@ -502,10 +497,8 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerRefNotPermitted(
 							`Certificate ref to secret diff-ns/secret not permitted by any ReferenceGrant`,
 						),
-						Routes: map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,
@@ -550,10 +543,8 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedProtocol(
 							`protocol: Unsupported value: "TCP": supported values: "HTTP", "HTTPS"`,
 						),
-						Routes: map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: []v1.RouteGroupKind{},
 					},
 				},
 				Valid: true,
@@ -582,10 +573,8 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedValue(
 							`port: Invalid value: 0: port must be between 1-65535`,
 						),
-						Routes: map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:       "invalid-https-port",
@@ -595,10 +584,8 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedValue(
 							`port: Invalid value: 65536: port must be between 1-65535`,
 						),
-						Routes: map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:       "invalid-protected-port",
@@ -608,10 +595,8 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedValue(
 							`port: Invalid value: 9113: port is already in use as MetricsPort`,
 						),
-						Routes: map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,
@@ -627,24 +612,20 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: []*Listener{
 					{
-						Name:       "invalid-hostname",
-						Source:     invalidHostnameListener,
-						Valid:      false,
-						Conditions: staticConds.NewListenerUnsupportedValue(invalidHostnameMsg),
-						Routes:     map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "invalid-hostname",
+						Source:         invalidHostnameListener,
+						Valid:          false,
+						Conditions:     staticConds.NewListenerUnsupportedValue(invalidHostnameMsg),
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
-						Name:       "invalid-https-hostname",
-						Source:     invalidHTTPSHostnameListener,
-						Valid:      false,
-						Conditions: staticConds.NewListenerUnsupportedValue(invalidHostnameMsg),
-						Routes:     map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "invalid-https-hostname",
+						Source:         invalidHTTPSHostnameListener,
+						Valid:          false,
+						Conditions:     staticConds.NewListenerUnsupportedValue(invalidHostnameMsg),
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,
@@ -666,9 +647,7 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerInvalidCertificateRef(
 							`tls.certificateRefs[0]: Invalid value: test/does-not-exist: secret does not exist`,
 						),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,
@@ -695,34 +674,28 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: []*Listener{
 					{
-						Name:       "foo-80-1",
-						Source:     foo80Listener1,
-						Valid:      true,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "foo-80-1",
+						Source:         foo80Listener1,
+						Valid:          true,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
-						Name:       "foo-8080",
-						Source:     foo8080Listener,
-						Valid:      true,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "foo-8080",
+						Source:         foo8080Listener,
+						Valid:          true,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
-						Name:       "foo-8081",
-						Source:     foo8081Listener,
-						Valid:      true,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "foo-8081",
+						Source:         foo8081Listener,
+						Valid:          true,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:           "foo-443-https-1",
@@ -731,9 +704,7 @@ func TestBuildGateway(t *testing.T) {
 						Attachable:     true,
 						Routes:         map[RouteKey]*L7Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:           "foo-8443-https",
@@ -742,19 +713,15 @@ func TestBuildGateway(t *testing.T) {
 						Attachable:     true,
 						Routes:         map[RouteKey]*L7Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
-						Name:       "bar-80",
-						Source:     bar80Listener,
-						Valid:      true,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "bar-80",
+						Source:         bar80Listener,
+						Valid:          true,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:           "bar-443-https",
@@ -763,9 +730,7 @@ func TestBuildGateway(t *testing.T) {
 						Attachable:     true,
 						Routes:         map[RouteKey]*L7Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:           "bar-8443-https",
@@ -774,9 +739,7 @@ func TestBuildGateway(t *testing.T) {
 						Attachable:     true,
 						Routes:         map[RouteKey]*L7Route{},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,
@@ -801,37 +764,31 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: []*Listener{
 					{
-						Name:       "foo-80-1",
-						Source:     foo80Listener1,
-						Valid:      false,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						Conditions: staticConds.NewListenerProtocolConflict(conflict80PortMsg),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "foo-80-1",
+						Source:         foo80Listener1,
+						Valid:          false,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						Conditions:     staticConds.NewListenerProtocolConflict(conflict80PortMsg),
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
-						Name:       "bar-80",
-						Source:     bar80Listener,
-						Valid:      false,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						Conditions: staticConds.NewListenerProtocolConflict(conflict80PortMsg),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "bar-80",
+						Source:         bar80Listener,
+						Valid:          false,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						Conditions:     staticConds.NewListenerProtocolConflict(conflict80PortMsg),
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
-						Name:       "foo-443",
-						Source:     foo443Listener,
-						Valid:      false,
-						Attachable: true,
-						Routes:     map[RouteKey]*L7Route{},
-						Conditions: staticConds.NewListenerProtocolConflict(conflict443PortMsg),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						Name:           "foo-443",
+						Source:         foo443Listener,
+						Valid:          false,
+						Attachable:     true,
+						Routes:         map[RouteKey]*L7Route{},
+						Conditions:     staticConds.NewListenerProtocolConflict(conflict443PortMsg),
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:           "foo-80-https",
@@ -841,9 +798,7 @@ func TestBuildGateway(t *testing.T) {
 						Routes:         map[RouteKey]*L7Route{},
 						Conditions:     staticConds.NewListenerProtocolConflict(conflict80PortMsg),
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:           "foo-443-https-1",
@@ -853,9 +808,7 @@ func TestBuildGateway(t *testing.T) {
 						Routes:         map[RouteKey]*L7Route{},
 						Conditions:     staticConds.NewListenerProtocolConflict(conflict443PortMsg),
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 					{
 						Name:           "bar-443-https",
@@ -865,9 +818,7 @@ func TestBuildGateway(t *testing.T) {
 						Routes:         map[RouteKey]*L7Route{},
 						Conditions:     staticConds.NewListenerProtocolConflict(conflict443PortMsg),
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secretSameNs)),
-						SupportedKinds: []v1.RouteGroupKind{
-							{Kind: kinds.HTTPRoute},
-						},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid: true,

--- a/internal/mode/static/state/graph/gateway_test.go
+++ b/internal/mode/static/state/graph/gateway_test.go
@@ -543,8 +543,7 @@ func TestBuildGateway(t *testing.T) {
 						Conditions: staticConds.NewListenerUnsupportedProtocol(
 							`protocol: Unsupported value: "TCP": supported values: "HTTP", "HTTPS"`,
 						),
-						Routes:         map[RouteKey]*L7Route{},
-						SupportedKinds: []v1.RouteGroupKind{},
+						Routes: map[RouteKey]*L7Route{},
 					},
 				},
 				Valid: true,

--- a/internal/mode/static/state/graph/graph_test.go
+++ b/internal/mode/static/state/graph/graph_test.go
@@ -534,6 +534,11 @@ func TestBuildGraph(t *testing.T) {
 		},
 	}
 
+	supportedKindsForListeners := []gatewayv1.RouteGroupKind{
+		{Kind: gatewayv1.Kind(kinds.HTTPRoute), Group: helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName)},
+		{Kind: gatewayv1.Kind(kinds.GRPCRoute), Group: helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName)},
+	}
+
 	createExpectedGraphWithGatewayClass := func(gc *gatewayv1.GatewayClass) *Graph {
 		return &Graph{
 			GatewayClass: &GatewayClass{
@@ -553,7 +558,7 @@ func TestBuildGraph(t *testing.T) {
 							CreateRouteKey(hr1): routeHR1,
 							CreateRouteKey(gr):  routeGR,
 						},
-						SupportedKinds:            []gatewayv1.RouteGroupKind{{Kind: kinds.HTTPRoute}},
+						SupportedKinds:            supportedKindsForListeners,
 						AllowedRouteLabelSelector: labels.SelectorFromSet(map[string]string{"app": "allowed"}),
 					},
 					{
@@ -563,7 +568,7 @@ func TestBuildGraph(t *testing.T) {
 						Attachable:     true,
 						Routes:         map[RouteKey]*L7Route{CreateRouteKey(hr3): routeHR3},
 						ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(secret)),
-						SupportedKinds: []gatewayv1.RouteGroupKind{{Kind: kinds.HTTPRoute}},
+						SupportedKinds: supportedKindsForListeners,
 					},
 				},
 				Valid:    true,

--- a/internal/mode/static/state/graph/route_common.go
+++ b/internal/mode/static/state/graph/route_common.go
@@ -538,13 +538,12 @@ func isRouteNamespaceAllowedByListener(
 // If the listener specifies allowed kinds, the route kind must be in the list.
 // If the listener does not specify allowedRoutes, allowed routes are determined using the listener protocol.
 func isRouteTypeAllowedByListener(listener *Listener, routeType RouteType) bool {
-	if listener.Source.AllowedRoutes != nil && listener.Source.AllowedRoutes.Kinds != nil {
-		for _, kind := range listener.Source.AllowedRoutes.Kinds {
-			switch kind.Kind {
-			case kinds.HTTPRoute:
-				return routeType == RouteTypeHTTP
-			case kinds.GRPCRoute:
-				return routeType == RouteTypeGRPC
+	allowedRoutes := listener.Source.AllowedRoutes
+	if allowedRoutes != nil && allowedRoutes.Kinds != nil {
+		for _, kind := range allowedRoutes.Kinds {
+			if (kind.Kind == kinds.HTTPRoute && routeType == RouteTypeHTTP) ||
+				(kind.Kind == kinds.GRPCRoute && routeType == RouteTypeGRPC) {
+				return true
 			}
 		}
 		return false

--- a/internal/mode/static/state/graph/route_common.go
+++ b/internal/mode/static/state/graph/route_common.go
@@ -550,9 +550,11 @@ func isRouteTypeAllowedByListener(listener *Listener, routeType RouteType) bool 
 		return false
 	}
 
-	if listener.Source.Protocol == v1.HTTPProtocolType || listener.Source.Protocol == v1.HTTPSProtocolType {
+	switch listener.Source.Protocol {
+	case v1.HTTPProtocolType, v1.HTTPSProtocolType:
 		return routeType == RouteTypeHTTP || routeType == RouteTypeGRPC
 	}
+
 	return false
 }
 

--- a/internal/mode/static/state/graph/route_common.go
+++ b/internal/mode/static/state/graph/route_common.go
@@ -538,21 +538,11 @@ func isRouteNamespaceAllowedByListener(
 // If the listener specifies allowed kinds, the route kind must be in the list.
 // If the listener does not specify allowedRoutes, allowed routes are determined using the listener protocol.
 func isRouteTypeAllowedByListener(listener *Listener, routeType RouteType) bool {
-	allowedRoutes := listener.Source.AllowedRoutes
-	if allowedRoutes != nil && allowedRoutes.Kinds != nil {
-		for _, kind := range allowedRoutes.Kinds {
-			if kind.Kind == convertRouteType(routeType) {
-				return true
-			}
+	for _, kind := range listener.SupportedKinds {
+		if kind.Kind == convertRouteType(routeType) {
+			return true
 		}
-		return false
 	}
-
-	switch listener.Source.Protocol {
-	case v1.HTTPProtocolType, v1.HTTPSProtocolType:
-		return routeType == RouteTypeHTTP || routeType == RouteTypeGRPC
-	}
-
 	return false
 }
 

--- a/internal/mode/static/state/graph/route_common.go
+++ b/internal/mode/static/state/graph/route_common.go
@@ -541,8 +541,7 @@ func isRouteTypeAllowedByListener(listener *Listener, routeType RouteType) bool 
 	allowedRoutes := listener.Source.AllowedRoutes
 	if allowedRoutes != nil && allowedRoutes.Kinds != nil {
 		for _, kind := range allowedRoutes.Kinds {
-			if (kind.Kind == kinds.HTTPRoute && routeType == RouteTypeHTTP) ||
-				(kind.Kind == kinds.GRPCRoute && routeType == RouteTypeGRPC) {
+			if kind.Kind == convertRouteType(routeType) {
 				return true
 			}
 		}
@@ -555,6 +554,17 @@ func isRouteTypeAllowedByListener(listener *Listener, routeType RouteType) bool 
 	}
 
 	return false
+}
+
+func convertRouteType(routeType RouteType) v1.Kind {
+	switch routeType {
+	case RouteTypeHTTP:
+		return kinds.HTTPRoute
+	case RouteTypeGRPC:
+		return kinds.GRPCRoute
+	default:
+		return ""
+	}
 }
 
 func getHostname(h *v1.Hostname) string {

--- a/internal/mode/static/state/graph/route_common.go
+++ b/internal/mode/static/state/graph/route_common.go
@@ -535,8 +535,6 @@ func isRouteNamespaceAllowedByListener(
 }
 
 // isRouteKindAllowedByListener checks if the route is allowed to attach to the listener.
-// If the listener specifies allowed kinds, the route kind must be in the list.
-// If the listener does not specify allowedRoutes, allowed routes are determined using the listener protocol.
 func isRouteTypeAllowedByListener(listener *Listener, routeType RouteType) bool {
 	for _, kind := range listener.SupportedKinds {
 		if kind.Kind == convertRouteType(routeType) {
@@ -553,7 +551,7 @@ func convertRouteType(routeType RouteType) v1.Kind {
 	case RouteTypeGRPC:
 		return kinds.GRPCRoute
 	default:
-		return ""
+		panic(fmt.Sprintf("unsupported route type: %s", routeType))
 	}
 }
 

--- a/internal/mode/static/state/graph/route_common_test.go
+++ b/internal/mode/static/state/graph/route_common_test.go
@@ -1743,7 +1743,7 @@ func TestAllowedRouteType(t *testing.T) {
 		expResult bool
 	}{
 		{
-			name:      "httpRoute with listener protocol http",
+			name:      "httpRoute attaches to listener with protocol http",
 			routeType: RouteTypeHTTP,
 			listener: &Listener{
 				Source: gatewayv1.Listener{
@@ -1753,7 +1753,7 @@ func TestAllowedRouteType(t *testing.T) {
 			expResult: true,
 		},
 		{
-			name:      "grpcRoute with listener protocol https",
+			name:      "grpcRoute attaches to listener with protocol https",
 			routeType: RouteTypeGRPC,
 			listener: &Listener{
 				Source: gatewayv1.Listener{
@@ -1763,7 +1763,31 @@ func TestAllowedRouteType(t *testing.T) {
 			expResult: true,
 		},
 		{
-			name:      "grpcRoute with listener allowedRoutes set to httpRoute is not allowed",
+			name:      "grpcRoute is not allowed to attach to listener with tcp protocol",
+			routeType: RouteTypeGRPC,
+			listener: &Listener{
+				Source: gatewayv1.Listener{
+					Protocol: gatewayv1.TCPProtocolType,
+				},
+			},
+			expResult: false,
+		},
+		{
+			name:      "grpcRoute attaches to listener with allowedRoutes set to grpcRoute",
+			routeType: RouteTypeGRPC,
+			listener: &Listener{
+				Source: gatewayv1.Listener{
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Kinds: []gatewayv1.RouteGroupKind{
+							{Kind: kinds.GRPCRoute},
+						},
+					},
+				},
+			},
+			expResult: true,
+		},
+		{
+			name:      "grpcRoute not allowed to attach to listener with allowedRoutes set to httpRoute",
 			routeType: RouteTypeGRPC,
 			listener: &Listener{
 				Source: gatewayv1.Listener{
@@ -1777,7 +1801,7 @@ func TestAllowedRouteType(t *testing.T) {
 			expResult: false,
 		},
 		{
-			name:      "httpRoute with listener allowedRoutes set to grpcRoute is not allowed",
+			name:      "httpRoute not allowed to attach to listener with allowedRoutes set to grpcRoute",
 			routeType: RouteTypeHTTP,
 			listener: &Listener{
 				Source: gatewayv1.Listener{
@@ -1791,18 +1815,18 @@ func TestAllowedRouteType(t *testing.T) {
 			expResult: false,
 		},
 		{
-			name:      "grpcRoute with listener allowedRoutes set to grpcRoute is allowed",
+			name:      "grpcRoute not allowed to attach to listener with allowedRoutes set to testRoute",
 			routeType: RouteTypeGRPC,
 			listener: &Listener{
 				Source: gatewayv1.Listener{
 					AllowedRoutes: &gatewayv1.AllowedRoutes{
 						Kinds: []gatewayv1.RouteGroupKind{
-							{Kind: kinds.GRPCRoute},
+							{Kind: gatewayv1.Kind("testRoute")},
 						},
 					},
 				},
 			},
-			expResult: true,
+			expResult: false,
 		},
 	}
 

--- a/internal/mode/static/state/graph/route_common_test.go
+++ b/internal/mode/static/state/graph/route_common_test.go
@@ -1787,6 +1787,21 @@ func TestAllowedRouteType(t *testing.T) {
 			expResult: true,
 		},
 		{
+			name:      "grpcRoute attaches to listener with allowedRoutes set to grpcRoute and httpRoute",
+			routeType: RouteTypeGRPC,
+			listener: &Listener{
+				Source: gatewayv1.Listener{
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Kinds: []gatewayv1.RouteGroupKind{
+							{Kind: kinds.HTTPRoute},
+							{Kind: kinds.GRPCRoute},
+						},
+					},
+				},
+			},
+			expResult: true,
+		},
+		{
 			name:      "grpcRoute not allowed to attach to listener with allowedRoutes set to httpRoute",
 			routeType: RouteTypeGRPC,
 			listener: &Listener{

--- a/internal/mode/static/state/graph/route_common_test.go
+++ b/internal/mode/static/state/graph/route_common_test.go
@@ -1743,7 +1743,7 @@ func TestAllowedRouteType(t *testing.T) {
 		expResult bool
 	}{
 		{
-			name:      "grpcRoute attaches to listener with allowedRoutes set to grpcRoute",
+			name:      "grpcRoute is allowed when listener supports grpcRoute kind",
 			routeType: RouteTypeGRPC,
 			listener: &Listener{
 				SupportedKinds: []gatewayv1.RouteGroupKind{
@@ -1753,7 +1753,7 @@ func TestAllowedRouteType(t *testing.T) {
 			expResult: true,
 		},
 		{
-			name:      "grpcRoute attaches to listener with allowedRoutes set to grpcRoute and httpRoute",
+			name:      "grpcRoute is allowed when listener supports grpcRoute and httpRoute kind",
 			routeType: RouteTypeGRPC,
 			listener: &Listener{
 				SupportedKinds: []gatewayv1.RouteGroupKind{
@@ -1764,7 +1764,7 @@ func TestAllowedRouteType(t *testing.T) {
 			expResult: true,
 		},
 		{
-			name:      "grpcRoute not allowed to attach to listener with allowedRoutes set to httpRoute",
+			name:      "grpcRoute is allowed when listener supports httpRoute kind",
 			routeType: RouteTypeGRPC,
 			listener: &Listener{
 				SupportedKinds: []gatewayv1.RouteGroupKind{
@@ -1774,7 +1774,7 @@ func TestAllowedRouteType(t *testing.T) {
 			expResult: false,
 		},
 		{
-			name:      "httpRoute not allowed to attach to listener with allowedRoutes set to grpcRoute",
+			name:      "httpRoute not allowed when listener supports grpcRoute kind",
 			routeType: RouteTypeHTTP,
 			listener: &Listener{
 				SupportedKinds: []gatewayv1.RouteGroupKind{


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: NGF allows all route kinds to attach to a listener regardless of the kinds specified in the listener AllowedRoutes.Kinds field

Solution: Add check to reject a route trying to attach to a listener which doesn't allow its kind.

Testing: Manual testing

1. Case 1: Gateway has a listener of type GRPCRoute, HTTPRoute Created with that listener

```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: gateway
spec:
  gatewayClassName: nginx
  listeners:
  - name: grpc
    port: 80
    protocol: HTTP
    hostname: "*.example.com"
    allowedRoutes:
      kinds:
        - kind: "GRPCRoute"
 ---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: coffee
spec:
  parentRefs:
  - name: gateway
    sectionName: grpc
  hostnames:
  - "cafe.example.com"
  rules:
  - backendRefs:
    - name: coffee
      port: 80
```

```
kubectl describe httproute coffee

Status:
  Parents:
    Conditions:
      Last Transition Time:  2024-07-30T23:36:19Z
      Message:               All references are resolved
      Observed Generation:   3
      Reason:                ResolvedRefs
      Status:                True
      Type:                  ResolvedRefs
      Last Transition Time:  2024-07-30T23:36:19Z
      Message:               Route is not allowed by any listener
      Observed Generation:   3
      Reason:                NotAllowedByListeners
      Status:                False
      Type:                  Accepted
    Controller Name:
```


2. Case 2:  Gateway has a listener of type GRPCRoute, GRPC Created with that listener

```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: same-namespace
spec:
  gatewayClassName: nginx
  listeners:
  - name: http
    port: 80
    protocol: HTTP
    allowedRoutes:
      namespaces:
        from: Same
      kinds:
        - kind: "GRPCRoute"
---
apiVersion: gateway.networking.k8s.io/v1
kind: GRPCRoute
metadata:
  name: exact-matching
spec:
  parentRefs:
  - name: same-namespace
    sectionName: http
  rules:
  - matches:
    - method:
        service: helloworld.Greeter
        method: SayHello
    backendRefs:
    - name: grpc-infra-backend-v1
      port: 8080
```

```
grpcurl -plaintext -proto grpc.proto -authority bar.com -d '{"name": "exact"}' ${GW_IP}:${GW_PORT} helloworld.Greeter/SayHello
Handling connection for 8080
{
  "message": "Hello exact"
}
```

```
kubectl describe grpcroute exact-matching
Name:         exact-matching
Namespace:    default
Labels:       <none>
Annotations:  <none>
.
.
.
      Last Transition Time:  2024-07-31T19:40:25Z
      Message:               The route is accepted
      Observed Generation:   2
      Reason:                Accepted
      Status:                True
      Type:                  Accepted
      Last Transition Time:  2024-07-31T19:40:25Z
      Message:               All references are resolved
      Observed Generation:   2
      Reason:                ResolvedRefs
      Status:                True
      Type:                  ResolvedRefs
    Controller Name:         gateway.nginx.org/nginx-gateway-controller
```

3. Gateway has a listener of type HTTPRoute, GRPCRoute not allowed to attach to that listener

```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: same-namespace
spec:
  gatewayClassName: nginx
  listeners:
  - name: http
    port: 80
    protocol: HTTP
    allowedRoutes:
      namespaces:
        from: Same
      kinds:
        - kind: "HTTPRoute"
---
apiVersion: gateway.networking.k8s.io/v1
kind: GRPCRoute
metadata:
  name: exact-matching
spec:
  parentRefs:
  - name: same-namespace
    sectionName: http
  rules:
  - matches:
    - method:
        service: helloworld.Greeter
        method: SayHello
    backendRefs:
    - name: grpc-infra-backend-v1
      port: 8080
```

```
kubectl describe grpcroute exact-matching
Name:         exact-matching
.
.
.
      Last Transition Time:  2024-08-01T01:25:35Z
      Message:               All references are resolved
      Observed Generation:   2
      Reason:                ResolvedRefs
      Status:                True
      Type:                  ResolvedRefs
      Last Transition Time:  2024-08-01T01:25:35Z
      Message:               Route is not allowed by any listener
      Observed Generation:   2
      Reason:                NotAllowedByListeners
      Status:                False
      Type:                  Accepted
    Controller Name:         gateway.nginx.org/nginx-gateway-controller
```

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #2299 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
