### PR TITLE
Add options for chart version and add command output

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,11 @@ linters-settings:
       - name: blank-imports
       - name: context-as-argument
       - name: context-keys-type
+      - name: dot-imports
+        arguments:
+          - allowedPackages:
+              - github.com/onsi/gomega
+              - github.com/onsi/ginkgo/v2
       - name: empty-block
       - name: error-naming
       - name: error-return
@@ -40,6 +45,10 @@ linters-settings:
   dupword:
     ignore:
       - "test"
+  stylecheck:
+    dot-import-whitelist:
+      - github.com/onsi/gomega
+      - github.com/onsi/ginkgo/v2
 linters:
   enable:
     - asasalint

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,7 @@ GW_API_VERSION ?= $(shell sed -n 's/.*ref=v\(.*\)/\1/p' ../config/crd/gateway-ap
 GW_API_PREV_VERSION ?= 1.1.0## Supported Gateway API version from previous NGF release
 GW_SERVICE_TYPE = NodePort## Service type to use for the gateway
 GW_SVC_GKE_INTERNAL = false
-NGF_VERSION ?= $(shell git describe --tags $(shell git rev-list --tags --max-count=1))## NGF version to be tested (defaults to latest tag)
+NGF_VERSION ?= edge## NGF version to be tested
 PULL_POLICY = Never## Pull policy for the images
 PROVISIONER_MANIFEST = conformance/provisioner/provisioner.yaml
 SUPPORTED_FEATURES = HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,GatewayPort8080,HTTPRouteResponseHeaderModification,GRPCExactMethodMatching,GRPCRouteListenerHostnameMatching,GRPCRouteHeaderMatching

--- a/tests/scripts/sync-files-to-vm.sh
+++ b/tests/scripts/sync-files-to-vm.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 
 source scripts/vars.env
 
-NGF_DIR=$(dirname "$PWD")
+NGF_DIR=$(dirname "$PWD")/
 
 gcloud compute config-ssh --ssh-config-file ngf-gcp.ssh >/dev/null
 
-rsync -ave 'ssh -F ngf-gcp.ssh' "${NGF_DIR}" username@"${RESOURCE_NAME}"."${GKE_CLUSTER_ZONE}"."${GKE_PROJECT}":~
+rsync -ave 'ssh -F ngf-gcp.ssh' "${NGF_DIR}" username@"${RESOURCE_NAME}"."${GKE_CLUSTER_ZONE}"."${GKE_PROJECT}":~/nginx-gateway-fabric

--- a/tests/suite/system_suite_test.go
+++ b/tests/suite/system_suite_test.go
@@ -73,6 +73,7 @@ var (
 	localChartPath    string
 	address           string
 	version           string
+	chartVersion      string
 	clusterInfo       framework.ClusterInfo
 	skipNFRTests      bool
 )
@@ -173,6 +174,11 @@ func setup(cfg setupConfig, extraInstallArgs ...string) {
 		}
 		installCfg.ImageTag = *imageTag
 		installCfg.ImagePullPolicy = *imagePullPolicy
+	} else {
+		if version == "edge" {
+			chartVersion = "0.0.0-edge"
+			installCfg.ChartVersion = chartVersion
+		}
 	}
 
 	output, err := framework.InstallGatewayAPI(cfg.gwAPIVersion)

--- a/tests/suite/upgrade_test.go
+++ b/tests/suite/upgrade_test.go
@@ -92,6 +92,7 @@ var _ = Describe("Upgrade testing", Label("nfr", "upgrade"), func() {
 			ReleaseName:          releaseName,
 			Namespace:            ngfNamespace,
 			ChartPath:            localChartPath,
+			ChartVersion:         chartVersion,
 			NgfImageRepository:   *ngfImageRepository,
 			NginxImageRepository: nginxImage,
 			ImageTag:             *imageTag,


### PR DESCRIPTION
### Proposed changes

Problem: There's not a way to specify the version of the Chart and to see the command used to install.

Solution: Add a parameter to specify the version of the Chart. When installing from a registry if no version is specified the latest tag will be installed. For now only the edge version will set the edge tag. Also output the command used to install.
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
