### PR TITLE
Check for ReferenceGrants from GRPCRoutes to Services

### DIFF
--- a/internal/mode/static/state/graph/graph_test.go
+++ b/internal/mode/static/state/graph/graph_test.go
@@ -306,9 +306,9 @@ func TestBuildGraph(t *testing.T) {
 		},
 	}
 
-	rgService := &v1beta1.ReferenceGrant{
+	hrToServiceNsRefGrant := &v1beta1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rg-service",
+			Name:      "hr-to-service",
 			Namespace: "service",
 		},
 		Spec: v1beta1.ReferenceGrantSpec{
@@ -316,6 +316,27 @@ func TestBuildGraph(t *testing.T) {
 				{
 					Group:     gatewayv1.GroupName,
 					Kind:      kinds.HTTPRoute,
+					Namespace: gatewayv1.Namespace(testNs),
+				},
+			},
+			To: []v1beta1.ReferenceGrantTo{
+				{
+					Kind: "Service",
+				},
+			},
+		},
+	}
+
+	grToServiceNsRefGrant := &v1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gr-to-service",
+			Namespace: "service",
+		},
+		Spec: v1beta1.ReferenceGrantSpec{
+			From: []v1beta1.ReferenceGrantFrom{
+				{
+					Group:     gatewayv1.GroupName,
+					Kind:      kinds.GRPCRoute,
 					Namespace: gatewayv1.Namespace(testNs),
 				},
 			},
@@ -443,8 +464,9 @@ func TestBuildGraph(t *testing.T) {
 				client.ObjectKeyFromObject(ns): ns,
 			},
 			ReferenceGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				client.ObjectKeyFromObject(rgSecret):  rgSecret,
-				client.ObjectKeyFromObject(rgService): rgService,
+				client.ObjectKeyFromObject(rgSecret):              rgSecret,
+				client.ObjectKeyFromObject(hrToServiceNsRefGrant): hrToServiceNsRefGrant,
+				client.ObjectKeyFromObject(grToServiceNsRefGrant): grToServiceNsRefGrant,
 			},
 			Secrets: map[types.NamespacedName]*v1.Secret{
 				client.ObjectKeyFromObject(secret): secret,

--- a/internal/mode/static/state/graph/reference_grant.go
+++ b/internal/mode/static/state/graph/reference_grant.go
@@ -73,6 +73,14 @@ func fromHTTPRoute(namespace string) fromResource {
 	}
 }
 
+func fromGRPCRoute(namespace string) fromResource {
+	return fromResource{
+		group:     v1.GroupName,
+		kind:      kinds.GRPCRoute,
+		namespace: namespace,
+	}
+}
+
 // newReferenceGrantResolver creates a new referenceGrantResolver.
 func newReferenceGrantResolver(refGrants map[types.NamespacedName]*v1beta1.ReferenceGrant) *referenceGrantResolver {
 	allowed := make(map[allowedReference]struct{})
@@ -136,4 +144,12 @@ func (r *referenceGrantResolver) refAllowed(to toResource, from fromResource) bo
 	}
 
 	return false
+}
+
+// refAllowedFrom returns a closure function that takes a toResource parameter
+// and checks if a reference from the specified fromResource to the given toResource is allowed.
+func (r *referenceGrantResolver) refAllowedFrom(from fromResource) func(to toResource) bool {
+	return func(to toResource) bool {
+		return r.refAllowed(to, from)
+	}
 }


### PR DESCRIPTION
### Proposed changes

Problem: ReferenceGrants that permit GRPCRoutes to reference Services in different namespaces are ignored by NGF., effectively preventing all cross-namespace routing for GRPC traffic.

Solution: Check for ReferenceGrants from GRPCRoutes to Services when validating GRPCRoutes. If a ReferenceGrant exists that permits the cross-namespace reference, allow it. 

Testing: Verified that a GRPCRoute that references a Service in a different namespace is allowed if and only if a ReferenceGrant exits for that particular reference.

Closes #2333 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Honor ReferenceGrants that allow GRPCRoutes to reference Services in different namespaces
```
