### PR TITLE
Add support for TLS Passthrough using TLSRoutes

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           ngf_prefix=ghcr.io/nginxinc/nginx-gateway-fabric
           ngf_tag=${{ steps.ngf-meta.outputs.version }}
+          if [ ${{ inputs.enable-experimental }} == "true" ]; then export ENABLE_EXPERIMENTAL=true; fi
           make generate-static-deployment PLUS_ENABLED=${{ inputs.image == 'plus' && 'true' || 'false' }} PREFIX=${ngf_prefix} TAG=${ngf_tag}
         working-directory: ./tests
 
@@ -146,6 +147,7 @@ jobs:
 
       - name: Run conformance tests
         run: |
+          if [ ${{ inputs.enable-experimental }} == "true" ]; then export ENABLE_EXPERIMENTAL=true; fi
           make run-conformance-tests CONFORMANCE_TAG=${{ github.sha }} NGF_VERSION=${{ github.ref_name }} CLUSTER_NAME=${{ github.run_id }}
           core_result=$(cat conformance-profile.yaml | yq '.profiles[0].core.result')
           extended_result=$(cat conformance-profile.yaml | yq '.profiles[0].extended.result')

--- a/charts/nginx-gateway-fabric/templates/clusterrole.yaml
+++ b/charts/nginx-gateway-fabric/templates/clusterrole.yaml
@@ -72,6 +72,7 @@ rules:
   - grpcroutes
 {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
   - backendtlspolicies
+  - tlsroutes
 {{- end }}
   verbs:
   - list
@@ -85,6 +86,7 @@ rules:
   - grpcroutes/status
 {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
   - backendtlspolicies/status
+  - tlsroutes/status
 {{- end }}
   verbs:
   - update

--- a/charts/nginx-gateway-fabric/templates/deployment.yaml
+++ b/charts/nginx-gateway-fabric/templates/deployment.yaml
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-stream-conf
+          mountPath: /etc/nginx/stream-conf.d
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -166,6 +168,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-stream-conf
+          mountPath: /etc/nginx/stream-conf.d
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -199,6 +203,8 @@ spec:
       {{- end }}
       volumes:
       - name: nginx-conf
+        emptyDir: {}
+      - name: nginx-stream-conf
         emptyDir: {}
       - name: module-includes
         emptyDir: {}

--- a/charts/nginx-gateway-fabric/templates/deployment.yaml
+++ b/charts/nginx-gateway-fabric/templates/deployment.yaml
@@ -129,8 +129,10 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+          {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
         - name: nginx-stream-conf
           mountPath: /etc/nginx/stream-conf.d
+          {{ end }}
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -168,8 +170,10 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+          {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
         - name: nginx-stream-conf
           mountPath: /etc/nginx/stream-conf.d
+          {{ end }}
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -204,8 +208,10 @@ spec:
       volumes:
       - name: nginx-conf
         emptyDir: {}
+        {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
       - name: nginx-stream-conf
         emptyDir: {}
+        {{ end }}
       - name: module-includes
         emptyDir: {}
       - name: nginx-secrets

--- a/charts/nginx-gateway-fabric/templates/deployment.yaml
+++ b/charts/nginx-gateway-fabric/templates/deployment.yaml
@@ -129,10 +129,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
-          {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
         - name: nginx-stream-conf
           mountPath: /etc/nginx/stream-conf.d
-          {{ end }}
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -170,10 +168,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
-          {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
         - name: nginx-stream-conf
           mountPath: /etc/nginx/stream-conf.d
-          {{ end }}
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -208,10 +204,8 @@ spec:
       volumes:
       - name: nginx-conf
         emptyDir: {}
-        {{- if .Values.nginxGateway.gwAPIExperimentalFeatures.enable }}
       - name: nginx-stream-conf
         emptyDir: {}
-        {{ end }}
       - name: module-includes
         emptyDir: {}
       - name: nginx-secrets

--- a/config/tests/static-deployment.yaml
+++ b/config/tests/static-deployment.yaml
@@ -72,6 +72,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-stream-conf
+          mountPath: /etc/nginx/stream-conf.d
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -102,6 +104,8 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
+        - name: nginx-stream-conf
+          mountPath: /etc/nginx/stream-conf.d
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -120,6 +124,8 @@ spec:
         runAsNonRoot: true
       volumes:
       - name: nginx-conf
+        emptyDir: {}
+      - name: nginx-stream-conf
         emptyDir: {}
       - name: module-includes
         emptyDir: {}

--- a/config/tests/static-deployment.yaml
+++ b/config/tests/static-deployment.yaml
@@ -72,8 +72,6 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
-        - name: nginx-stream-conf
-          mountPath: /etc/nginx/stream-conf.d
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -104,8 +102,6 @@ spec:
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx/conf.d
-        - name: nginx-stream-conf
-          mountPath: /etc/nginx/stream-conf.d
         - name: module-includes
           mountPath: /etc/nginx/module-includes
         - name: nginx-secrets
@@ -124,8 +120,6 @@ spec:
         runAsNonRoot: true
       volumes:
       - name: nginx-conf
-        emptyDir: {}
-      - name: nginx-stream-conf
         emptyDir: {}
       - name: module-includes
         emptyDir: {}

--- a/deploy/aws-nlb/deploy.yaml
+++ b/deploy/aws-nlb/deploy.yaml
@@ -246,8 +246,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -278,8 +276,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -299,8 +295,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
-      - emptyDir: {}
-        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/aws-nlb/deploy.yaml
+++ b/deploy/aws-nlb/deploy.yaml
@@ -246,6 +246,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -276,6 +278,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -295,6 +299,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
+      - emptyDir: {}
+        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/azure/deploy.yaml
+++ b/deploy/azure/deploy.yaml
@@ -243,6 +243,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -273,6 +275,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -294,6 +298,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
+      - emptyDir: {}
+        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/azure/deploy.yaml
+++ b/deploy/azure/deploy.yaml
@@ -243,8 +243,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -275,8 +273,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -298,8 +294,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
-      - emptyDir: {}
-        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/default/deploy.yaml
+++ b/deploy/default/deploy.yaml
@@ -243,6 +243,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -273,6 +275,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -292,6 +296,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
+      - emptyDir: {}
+        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/default/deploy.yaml
+++ b/deploy/default/deploy.yaml
@@ -243,8 +243,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -275,8 +273,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -296,8 +292,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
-      - emptyDir: {}
-        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/experimental-nginx-plus/deploy.yaml
+++ b/deploy/experimental-nginx-plus/deploy.yaml
@@ -256,6 +256,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -286,6 +288,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -305,6 +309,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
+      - emptyDir: {}
+        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/experimental-nginx-plus/deploy.yaml
+++ b/deploy/experimental-nginx-plus/deploy.yaml
@@ -82,6 +82,7 @@ rules:
   - referencegrants
   - grpcroutes
   - backendtlspolicies
+  - tlsroutes
   verbs:
   - list
   - watch
@@ -93,6 +94,7 @@ rules:
   - gatewayclasses/status
   - grpcroutes/status
   - backendtlspolicies/status
+  - tlsroutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/experimental/deploy.yaml
+++ b/deploy/experimental/deploy.yaml
@@ -74,6 +74,7 @@ rules:
   - referencegrants
   - grpcroutes
   - backendtlspolicies
+  - tlsroutes
   verbs:
   - list
   - watch
@@ -85,6 +86,7 @@ rules:
   - gatewayclasses/status
   - grpcroutes/status
   - backendtlspolicies/status
+  - tlsroutes/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/experimental/deploy.yaml
+++ b/deploy/experimental/deploy.yaml
@@ -247,6 +247,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -277,6 +279,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -296,6 +300,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
+      - emptyDir: {}
+        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/nginx-plus/deploy.yaml
+++ b/deploy/nginx-plus/deploy.yaml
@@ -254,8 +254,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -286,8 +284,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -307,8 +303,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
-      - emptyDir: {}
-        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/nginx-plus/deploy.yaml
+++ b/deploy/nginx-plus/deploy.yaml
@@ -254,6 +254,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -284,6 +286,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -303,6 +307,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
+      - emptyDir: {}
+        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/nodeport/deploy.yaml
+++ b/deploy/nodeport/deploy.yaml
@@ -243,6 +243,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -273,6 +275,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -292,6 +296,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
+      - emptyDir: {}
+        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/nodeport/deploy.yaml
+++ b/deploy/nodeport/deploy.yaml
@@ -243,8 +243,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -275,8 +273,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -296,8 +292,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
-      - emptyDir: {}
-        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -251,8 +251,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -283,8 +281,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
-        - mountPath: /etc/nginx/stream-conf.d
-          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -304,8 +300,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
-      - emptyDir: {}
-        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -251,6 +251,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -281,6 +283,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-conf
+        - mountPath: /etc/nginx/stream-conf.d
+          name: nginx-stream-conf
         - mountPath: /etc/nginx/module-includes
           name: module-includes
         - mountPath: /etc/nginx/secrets
@@ -300,6 +304,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: nginx-conf
+      - emptyDir: {}
+        name: nginx-stream-conf
       - emptyDir: {}
         name: module-includes
       - emptyDir: {}

--- a/internal/framework/gatewayclass/validate.go
+++ b/internal/framework/gatewayclass/validate.go
@@ -23,6 +23,7 @@ var gatewayCRDs = map[string]apiVersion{
 	"referencegrants.gateway.networking.k8s.io":    {},
 	"backendtlspolicies.gateway.networking.k8s.io": {},
 	"grpcroutes.gateway.networking.k8s.io":         {},
+	"tlsroutes.gateway.networking.k8s.io":          {},
 }
 
 type apiVersion struct {

--- a/internal/framework/kinds/kinds.go
+++ b/internal/framework/kinds/kinds.go
@@ -19,6 +19,8 @@ const (
 	HTTPRoute = "HTTPRoute"
 	// GRPCRoute is the GRPCRoute kind.
 	GRPCRoute = "GRPCRoute"
+	// TLSRoute is the TLSRoute kind.
+	TLSRoute = "TLSRoute"
 )
 
 // NGINX Gateway Fabric kinds.

--- a/internal/mode/static/handler.go
+++ b/internal/mode/static/handler.go
@@ -246,6 +246,7 @@ func (h *eventHandlerImpl) updateStatuses(ctx context.Context, logger logr.Logge
 		gcReqs = status.PrepareGatewayClassRequests(graph.GatewayClass, graph.IgnoredGatewayClasses, transitionTime)
 	}
 	routeReqs := status.PrepareRouteRequests(
+		graph.L4Routes,
 		graph.Routes,
 		transitionTime,
 		h.latestReloadResult,

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -31,6 +31,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	k8spredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -73,6 +74,7 @@ func init() {
 	utilruntime.Must(gatewayv1beta1.Install(scheme))
 	utilruntime.Must(gatewayv1.Install(scheme))
 	utilruntime.Must(gatewayv1alpha3.Install(scheme))
+	utilruntime.Must(gatewayv1alpha2.Install(scheme))
 	utilruntime.Must(apiv1.AddToScheme(scheme))
 	utilruntime.Must(discoveryV1.AddToScheme(scheme))
 	utilruntime.Must(ngfAPI.AddToScheme(scheme))
@@ -489,6 +491,12 @@ func registerControllers(
 				// https://github.com/nginxinc/nginx-gateway-fabric/issues/1545
 				objectType: &apiv1.ConfigMap{},
 			},
+			{
+				objectType: &gatewayv1alpha2.TLSRoute{},
+				options: []controller.Option{
+					controller.WithK8sPredicate(k8spredicate.GenerationChangedPredicate{}),
+				},
+			},
 		}
 		controllerRegCfgs = append(controllerRegCfgs, gwExpFeatures...)
 	}
@@ -663,6 +671,7 @@ func prepareFirstEventBatchPreparerArgs(
 			objectLists,
 			&gatewayv1alpha3.BackendTLSPolicyList{},
 			&apiv1.ConfigMapList{},
+			&gatewayv1alpha2.TLSRouteList{},
 		)
 	}
 

--- a/internal/mode/static/manager_test.go
+++ b/internal/mode/static/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -105,6 +106,7 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 				&ngfAPI.NginxProxyList{},
 				partialObjectMetadataList,
 				&gatewayv1alpha3.BackendTLSPolicyList{},
+				&gatewayv1alpha2.TLSRouteList{},
 				&gatewayv1.GRPCRouteList{},
 				&ngfAPI.ClientSettingsPolicyList{},
 				&ngfAPI.ObservabilityPolicyList{},

--- a/internal/mode/static/nginx/conf/nginx-plus.conf
+++ b/internal/mode/static/nginx/conf/nginx-plus.conf
@@ -55,18 +55,17 @@ http {
 }
 
 stream {
-	variables_hash_bucket_size 512;
-    variables_hash_max_size 1024;
+  variables_hash_bucket_size 512;
+  variables_hash_max_size 1024;
 
-    map_hash_max_size 2048;
-    map_hash_bucket_size 256;
+  map_hash_max_size 2048;
+  map_hash_bucket_size 256;
 
-    log_format stream-main '$remote_addr [$time_local] '
+  log_format stream-main '$remote_addr [$time_local] '
                               '$protocol $status $bytes_sent $bytes_received '
                               '$session_time "$ssl_preread_server_name"';
-    access_log /dev/stdout stream-main;
-
-	include /etc/nginx/stream-conf.d/*.conf;
+  access_log /dev/stdout stream-main;
+  include /etc/nginx/stream-conf.d/*.conf;
 }
 
 mgmt {

--- a/internal/mode/static/nginx/conf/nginx-plus.conf
+++ b/internal/mode/static/nginx/conf/nginx-plus.conf
@@ -62,8 +62,8 @@ stream {
   map_hash_bucket_size 256;
 
   log_format stream-main '$remote_addr [$time_local] '
-                              '$protocol $status $bytes_sent $bytes_received '
-                              '$session_time "$ssl_preread_server_name"';
+                         '$protocol $status $bytes_sent $bytes_received '
+                         '$session_time "$ssl_preread_server_name"';
   access_log /dev/stdout stream-main;
   include /etc/nginx/stream-conf.d/*.conf;
 }

--- a/internal/mode/static/nginx/conf/nginx-plus.conf
+++ b/internal/mode/static/nginx/conf/nginx-plus.conf
@@ -54,6 +54,21 @@ http {
   }
 }
 
+stream {
+	variables_hash_bucket_size 512;
+    variables_hash_max_size 1024;
+
+    map_hash_max_size 2048;
+    map_hash_bucket_size 256;
+
+    log_format stream-main '$remote_addr [$time_local] '
+                              '$protocol $status $bytes_sent $bytes_received '
+                              '$session_time "$ssl_preread_server_name"';
+    access_log /dev/stdout stream-main;
+
+	include /etc/nginx/stream-conf.d/*.conf;
+}
+
 mgmt {
   usage_report interval=0s;
 }

--- a/internal/mode/static/nginx/conf/nginx.conf
+++ b/internal/mode/static/nginx/conf/nginx.conf
@@ -40,16 +40,15 @@ http {
 }
 
 stream {
-	variables_hash_bucket_size 512;
-    variables_hash_max_size 1024;
+  variables_hash_bucket_size 512;
+  variables_hash_max_size 1024;
 
-    map_hash_max_size 2048;
-    map_hash_bucket_size 256;
+  map_hash_max_size 2048;
+  map_hash_bucket_size 256;
 
-    log_format stream-main '$remote_addr [$time_local] '
+  log_format stream-main '$remote_addr [$time_local] '
                               '$protocol $status $bytes_sent $bytes_received '
                               '$session_time "$ssl_preread_server_name"';
-    access_log /dev/stdout stream-main;
-
-	include /etc/nginx/stream-conf.d/*.conf;
+  access_log /dev/stdout stream-main;
+  include /etc/nginx/stream-conf.d/*.conf;
 }

--- a/internal/mode/static/nginx/conf/nginx.conf
+++ b/internal/mode/static/nginx/conf/nginx.conf
@@ -38,3 +38,18 @@ http {
     }
   }
 }
+
+stream {
+	variables_hash_bucket_size 512;
+    variables_hash_max_size 1024;
+
+    map_hash_max_size 2048;
+    map_hash_bucket_size 256;
+
+    log_format stream-main '$remote_addr [$time_local] '
+                              '$protocol $status $bytes_sent $bytes_received '
+                              '$session_time "$ssl_preread_server_name"';
+    access_log /dev/stdout stream-main;
+
+	include /etc/nginx/stream-conf.d/*.conf;
+}

--- a/internal/mode/static/nginx/conf/nginx.conf
+++ b/internal/mode/static/nginx/conf/nginx.conf
@@ -47,8 +47,8 @@ stream {
   map_hash_bucket_size 256;
 
   log_format stream-main '$remote_addr [$time_local] '
-                              '$protocol $status $bytes_sent $bytes_received '
-                              '$session_time "$ssl_preread_server_name"';
+                         '$protocol $status $bytes_sent $bytes_received '
+                         '$session_time "$ssl_preread_server_name"';
   access_log /dev/stdout stream-main;
   include /etc/nginx/stream-conf.d/*.conf;
 }

--- a/internal/mode/static/nginx/config/base_http_config_template.go
+++ b/internal/mode/static/nginx/config/base_http_config_template.go
@@ -2,4 +2,20 @@ package config
 
 const baseHTTPTemplateText = `
 {{- if .HTTP2 }}http2 on;{{ end }}
+
+# Set $gw_api_compliant_host variable to the value of $http_host unless $http_host is empty, then set it to the value
+# of $host. We prefer $http_host because it contains the original value of the host header, which is required by the
+# Gateway API. However, in an HTTP/1.0 request, it's possible that $http_host can be empty. In this case, we will use
+# the value of $host. See http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host.
+map $http_host $gw_api_compliant_host {
+    '' $host;
+    default $http_host;
+}
+
+# Set $connection_header variable to upgrade when the $http_upgrade header is set, otherwise, set it to close. This
+# allows support for websocket connections. See https://nginx.org/en/docs/http/websocket.html.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
 `

--- a/internal/mode/static/nginx/config/base_http_config_template.go
+++ b/internal/mode/static/nginx/config/base_http_config_template.go
@@ -18,4 +18,9 @@ map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
 }
+
+## Returns just the path from the original request URI.
+map $request_uri $request_uri_path {
+  "~^(?P<path>[^?]*)(\?.*)?$"  $path;
+}
 `

--- a/internal/mode/static/nginx/config/base_http_config_test.go
+++ b/internal/mode/static/nginx/config/base_http_config_test.go
@@ -47,5 +47,7 @@ func TestExecuteBaseHttp(t *testing.T) {
 		res := executeBaseHTTPConfig(test.conf)
 		g.Expect(res).To(HaveLen(1))
 		g.Expect(test.expCount).To(Equal(strings.Count(string(res[0].data), expSubStr)))
+		g.Expect(strings.Count(string(res[0].data), "map $http_host $gw_api_compliant_host {")).To(Equal(1))
+		g.Expect(strings.Count(string(res[0].data), "map $http_upgrade $connection_upgrade {")).To(Equal(1))
 	}
 }

--- a/internal/mode/static/nginx/config/base_http_config_test.go
+++ b/internal/mode/static/nginx/config/base_http_config_test.go
@@ -49,5 +49,6 @@ func TestExecuteBaseHttp(t *testing.T) {
 		g.Expect(test.expCount).To(Equal(strings.Count(string(res[0].data), expSubStr)))
 		g.Expect(strings.Count(string(res[0].data), "map $http_host $gw_api_compliant_host {")).To(Equal(1))
 		g.Expect(strings.Count(string(res[0].data), "map $http_upgrade $connection_upgrade {")).To(Equal(1))
+		g.Expect(strings.Count(string(res[0].data), "map $request_uri $request_uri_path {")).To(Equal(1))
 	}
 }

--- a/internal/mode/static/nginx/config/generator.go
+++ b/internal/mode/static/nginx/config/generator.go
@@ -20,6 +20,9 @@ const (
 	// httpFolder is the folder where NGINX HTTP configuration files are stored.
 	httpFolder = configFolder + "/conf.d"
 
+	// streamFolder is the folder where NGINX Stream configuration files are stored.
+	streamFolder = configFolder + "/stream-conf.d"
+
 	// modulesIncludesFolder is the folder where the included "load_module" file is stored.
 	modulesIncludesFolder = configFolder + "/module-includes"
 
@@ -32,6 +35,9 @@ const (
 	// httpConfigFile is the path to the configuration file with HTTP configuration.
 	httpConfigFile = httpFolder + "/http.conf"
 
+	// streamConfigFile is the path to the configuration file with Stream configuration.
+	streamConfigFile = streamFolder + "/stream.conf"
+
 	// configVersionFile is the path to the config version configuration file.
 	configVersionFile = httpFolder + "/config-version.conf"
 
@@ -43,7 +49,7 @@ const (
 )
 
 // ConfigFolders is a list of folders where NGINX configuration files are stored.
-var ConfigFolders = []string{httpFolder, secretsFolder, includesFolder, modulesIncludesFolder}
+var ConfigFolders = []string{httpFolder, secretsFolder, includesFolder, modulesIncludesFolder, streamFolder}
 
 // Generator generates NGINX configuration files.
 // This interface is used for testing purposes only.
@@ -168,6 +174,9 @@ func (g GeneratorImpl) getExecuteFuncs(generator policies.Generator) []executeFu
 		executeSplitClients,
 		executeMaps,
 		executeTelemetry,
+		executeStreamServers,
+		g.executeStreamUpstreams,
+		executeStreamMaps,
 	}
 }
 

--- a/internal/mode/static/nginx/config/generator_test.go
+++ b/internal/mode/static/nginx/config/generator_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/file"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/resolver"
 )
 
 func TestGenerate(t *testing.T) {
@@ -62,8 +63,13 @@ func TestGenerate(t *testing.T) {
 		},
 		StreamUpstreams: []dataplane.Upstream{
 			{
-				Name:      "stream_up",
-				Endpoints: nil,
+				Name: "stream_up",
+				Endpoints: []resolver.Endpoint{
+					{
+						Address: "1.1.1.1",
+						Port:    80,
+					},
+				},
 			},
 		},
 		BackendGroups: []dataplane.BackendGroup{bg},

--- a/internal/mode/static/nginx/config/generator_test.go
+++ b/internal/mode/static/nginx/config/generator_test.go
@@ -47,9 +47,22 @@ func TestGenerate(t *testing.T) {
 				Port: 443,
 			},
 		},
+		TLSPassthroughServers: []dataplane.Layer4VirtualServer{
+			{
+				Hostname:     "app.example.com",
+				Port:         443,
+				UpstreamName: "stream_up",
+			},
+		},
 		Upstreams: []dataplane.Upstream{
 			{
 				Name:      "up",
+				Endpoints: nil,
+			},
+		},
+		StreamUpstreams: []dataplane.Upstream{
+			{
+				Name:      "stream_up",
 				Endpoints: nil,
 			},
 		},
@@ -81,7 +94,7 @@ func TestGenerate(t *testing.T) {
 
 	files := generator.Generate(conf)
 
-	g.Expect(files).To(HaveLen(6))
+	g.Expect(files).To(HaveLen(7))
 	arrange := func(i, j int) bool {
 		return files[i].Path < files[j].Path
 	}
@@ -98,7 +111,7 @@ func TestGenerate(t *testing.T) {
 	// Note: this only verifies that Generate() returns a byte array with upstream, server, and split_client blocks.
 	// It does not test the correctness of those blocks. That functionality is covered by other tests in this package.
 	g.Expect(httpCfg).To(ContainSubstring("listen 80"))
-	g.Expect(httpCfg).To(ContainSubstring("listen 443"))
+	g.Expect(httpCfg).To(ContainSubstring("listen unix:/var/run/nginx/https443.sock"))
 	g.Expect(httpCfg).To(ContainSubstring("upstream"))
 	g.Expect(httpCfg).To(ContainSubstring("split_clients"))
 
@@ -127,4 +140,12 @@ func TestGenerate(t *testing.T) {
 		Path:    "/etc/nginx/secrets/test-keypair.pem",
 		Content: []byte("test-cert\ntest-key"),
 	}))
+
+	g.Expect(files[6].Path).To(Equal("/etc/nginx/stream-conf.d/stream.conf"))
+	g.Expect(files[6].Type).To(Equal(file.TypeRegular))
+	streamCfg := string(files[6].Content)
+	g.Expect(streamCfg).To(ContainSubstring("listen unix:/var/run/nginx/app.example.com-443.sock"))
+	g.Expect(streamCfg).To(ContainSubstring("listen 443"))
+	g.Expect(streamCfg).To(ContainSubstring("app.example.com unix:/var/run/nginx/app.example.com-443.sock"))
+	g.Expect(streamCfg).To(ContainSubstring("example.com unix:/var/run/nginx/https443.sock"))
 }

--- a/internal/mode/static/nginx/config/http/config.go
+++ b/internal/mode/static/nginx/config/http/config.go
@@ -1,5 +1,7 @@
 package http
 
+import "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/shared"
+
 const InternalRoutePathPrefix = "/_ngf-internal"
 
 // Server holds all configuration for an HTTP server.
@@ -12,12 +14,7 @@ type Server struct {
 	IsDefaultHTTP bool
 	IsDefaultSSL  bool
 	GRPC          bool
-}
-
-// IPFamily holds the IP family configuration to be used by NGINX.
-type IPFamily struct {
-	IPv4 bool
-	IPv6 bool
+	IsSocket      bool
 }
 
 type LocationType string
@@ -113,7 +110,7 @@ type ProxySSLVerify struct {
 // ServerConfig holds configuration for an HTTP server and IP family to be used by NGINX.
 type ServerConfig struct {
 	Servers  []Server
-	IPFamily IPFamily
+	IPFamily shared.IPFamily
 }
 
 // Include defines a file that's included via the include directive.

--- a/internal/mode/static/nginx/config/http/config.go
+++ b/internal/mode/static/nginx/config/http/config.go
@@ -6,9 +6,9 @@ const InternalRoutePathPrefix = "/_ngf-internal"
 type Server struct {
 	SSL           *SSL
 	ServerName    string
+	Listen        string
 	Locations     []Location
 	Includes      []Include
-	Port          int32
 	IsDefaultHTTP bool
 	IsDefaultSSL  bool
 	GRPC          bool
@@ -102,19 +102,6 @@ type SplitClient struct {
 type SplitClientDistribution struct {
 	Percent string
 	Value   string
-}
-
-// Map defines an NGINX map.
-type Map struct {
-	Source     string
-	Variable   string
-	Parameters []MapParameter
-}
-
-// MapParameter defines a Value and Result pair in a Map.
-type MapParameter struct {
-	Value  string
-	Result string
 }
 
 // ProxySSLVerify holds the proxied HTTPS server verification configuration.

--- a/internal/mode/static/nginx/config/maps.go
+++ b/internal/mode/static/nginx/config/maps.go
@@ -5,11 +5,18 @@ import (
 	gotemplate "text/template"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
-	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/http"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/shared"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
 )
 
 var mapsTemplate = gotemplate.Must(gotemplate.New("maps").Parse(mapsTemplateText))
+
+// emptyStringSocket is used when the stream server has an invalid upstream. In this case, we pass the connection
+// to the empty socket so that NGINX will close the connection with an error in the error log --
+// no host in pass "" -- and set $status variable to 500 (logged by stream access log),
+// which will indicate the problem to the user.
+// https://nginx.org/en/docs/stream/ngx_stream_core_module.html#var_status
+const emptyStringSocket = `""`
 
 func executeMaps(conf dataplane.Configuration) []executeResult {
 	maps := buildAddHeaderMaps(append(conf.HTTPServers, conf.SSLServers...))
@@ -21,7 +28,81 @@ func executeMaps(conf dataplane.Configuration) []executeResult {
 	return []executeResult{result}
 }
 
-func buildAddHeaderMaps(servers []dataplane.VirtualServer) []http.Map {
+func executeStreamMaps(conf dataplane.Configuration) []executeResult {
+	maps := createStreamMaps(conf)
+
+	result := executeResult{
+		dest: streamConfigFile,
+		data: helpers.MustExecuteTemplate(mapsTemplate, maps),
+	}
+
+	return []executeResult{result}
+}
+
+func createStreamMaps(conf dataplane.Configuration) []shared.Map {
+	if len(conf.TLSPassthroughServers) == 0 {
+		return nil
+	}
+	portsToMap := make(map[int32]shared.Map)
+
+	for _, server := range conf.TLSPassthroughServers {
+		streamMap, portInUse := portsToMap[server.Port]
+
+		socket := emptyStringSocket
+
+		if server.UpstreamName != "" {
+			socket = getSocketNameTLS(server.Port, server.Hostname)
+		}
+
+		mapParam := shared.MapParameter{
+			Value:  server.Hostname,
+			Result: socket,
+		}
+
+		if !portInUse {
+			m := shared.Map{
+				Source:   "$ssl_preread_server_name",
+				Variable: getTLSPassthroughVarName(server.Port),
+				Parameters: []shared.MapParameter{
+					mapParam,
+				},
+				UseHostnames: true,
+			}
+			portsToMap[server.Port] = m
+		} else {
+			streamMap.Parameters = append(streamMap.Parameters, mapParam)
+			portsToMap[server.Port] = streamMap
+		}
+	}
+
+	for _, server := range conf.SSLServers {
+		streamMap, portInUse := portsToMap[server.Port]
+
+		hostname := server.Hostname
+
+		if server.IsDefault {
+			hostname = "default"
+		}
+
+		if portInUse {
+			streamMap.Parameters = append(streamMap.Parameters, shared.MapParameter{
+				Value:  hostname,
+				Result: getSocketNameHTTPS(server.Port),
+			})
+			portsToMap[server.Port] = streamMap
+		}
+	}
+
+	maps := make([]shared.Map, 0, len(portsToMap))
+
+	for _, m := range portsToMap {
+		maps = append(maps, m)
+	}
+
+	return maps
+}
+
+func buildAddHeaderMaps(servers []dataplane.VirtualServer) []shared.Map {
 	addHeaderNames := make(map[string]struct{})
 
 	for _, s := range servers {
@@ -39,7 +120,7 @@ func buildAddHeaderMaps(servers []dataplane.VirtualServer) []http.Map {
 		}
 	}
 
-	maps := make([]http.Map, 0, len(addHeaderNames))
+	maps := make([]shared.Map, 0, len(addHeaderNames))
 	for m := range addHeaderNames {
 		maps = append(maps, createAddHeadersMap(m))
 	}
@@ -52,11 +133,11 @@ const (
 	anyStringFmt = `~.*`
 )
 
-func createAddHeadersMap(name string) http.Map {
+func createAddHeadersMap(name string) shared.Map {
 	underscoreName := convertStringToSafeVariableName(name)
 	httpVarSource := "${http_" + underscoreName + "}"
 	mapVarName := generateAddHeaderMapVariableName(name)
-	params := []http.MapParameter{
+	params := []shared.MapParameter{
 		{
 			Value:  "default",
 			Result: "''",
@@ -66,7 +147,7 @@ func createAddHeadersMap(name string) http.Map {
 			Result: httpVarSource + ",",
 		},
 	}
-	return http.Map{
+	return shared.Map{
 		Source:     httpVarSource,
 		Variable:   "$" + mapVarName,
 		Parameters: params,

--- a/internal/mode/static/nginx/config/maps.go
+++ b/internal/mode/static/nginx/config/maps.go
@@ -11,12 +11,18 @@ import (
 
 var mapsTemplate = gotemplate.Must(gotemplate.New("maps").Parse(mapsTemplateText))
 
-// emptyStringSocket is used when the stream server has an invalid upstream. In this case, we pass the connection
-// to the empty socket so that NGINX will close the connection with an error in the error log --
-// no host in pass "" -- and set $status variable to 500 (logged by stream access log),
-// which will indicate the problem to the user.
-// https://nginx.org/en/docs/stream/ngx_stream_core_module.html#var_status
-const emptyStringSocket = `""`
+const (
+	// emptyStringSocket is used when the stream server has an invalid upstream. In this case, we pass the connection
+	// to the empty socket so that NGINX will close the connection with an error in the error log --
+	// no host in pass "" -- and set $status variable to 500 (logged by stream access log),
+	// which will indicate the problem to the user.
+	// https://nginx.org/en/docs/stream/ngx_stream_core_module.html#var_status
+	emptyStringSocket = `""`
+
+	// connectionClosedStreamServerSocket is used when we want to listen on a port but have no service configured,
+	// so we pass to this server that just returns an empty string to tell users that we are listening.
+	connectionClosedStreamServerSocket = "unix:/var/run/nginx/connection-closed-server.sock"
+)
 
 func executeMaps(conf dataplane.Configuration) []executeResult {
 	maps := buildAddHeaderMaps(append(conf.HTTPServers, conf.SSLServers...))
@@ -44,32 +50,43 @@ func createStreamMaps(conf dataplane.Configuration) []shared.Map {
 		return nil
 	}
 	portsToMap := make(map[int32]shared.Map)
+	portHasDefault := make(map[int32]struct{})
+	upstreams := make(map[string]dataplane.Upstream)
+
+	for _, u := range conf.StreamUpstreams {
+		upstreams[u.Name] = u
+	}
 
 	for _, server := range conf.TLSPassthroughServers {
 		streamMap, portInUse := portsToMap[server.Port]
 
 		socket := emptyStringSocket
 
-		if server.UpstreamName != "" {
+		if u, ok := upstreams[server.UpstreamName]; ok && server.UpstreamName != "" && len(u.Endpoints) > 0 {
 			socket = getSocketNameTLS(server.Port, server.Hostname)
 		}
 
-		mapParam := shared.MapParameter{
-			Value:  server.Hostname,
-			Result: socket,
+		if server.IsDefault {
+			socket = connectionClosedStreamServerSocket
 		}
 
 		if !portInUse {
-			m := shared.Map{
-				Source:   "$ssl_preread_server_name",
-				Variable: getTLSPassthroughVarName(server.Port),
-				Parameters: []shared.MapParameter{
-					mapParam,
-				},
+			streamMap = shared.Map{
+				Source:       "$ssl_preread_server_name",
+				Variable:     getTLSPassthroughVarName(server.Port),
+				Parameters:   make([]shared.MapParameter, 0),
 				UseHostnames: true,
 			}
-			portsToMap[server.Port] = m
-		} else {
+			portsToMap[server.Port] = streamMap
+		}
+
+		// If the hostname is empty, we don't want to add an entry to the map. This case occurs when
+		// the gateway listener hostname is not specified
+		if server.Hostname != "" {
+			mapParam := shared.MapParameter{
+				Value:  server.Hostname,
+				Result: socket,
+			}
 			streamMap.Parameters = append(streamMap.Parameters, mapParam)
 			portsToMap[server.Port] = streamMap
 		}
@@ -82,6 +99,7 @@ func createStreamMaps(conf dataplane.Configuration) []shared.Map {
 
 		if server.IsDefault {
 			hostname = "default"
+			portHasDefault[server.Port] = struct{}{}
 		}
 
 		if portInUse {
@@ -95,7 +113,13 @@ func createStreamMaps(conf dataplane.Configuration) []shared.Map {
 
 	maps := make([]shared.Map, 0, len(portsToMap))
 
-	for _, m := range portsToMap {
+	for p, m := range portsToMap {
+		if _, ok := portHasDefault[p]; !ok {
+			m.Parameters = append(m.Parameters, shared.MapParameter{
+				Value:  "default",
+				Result: connectionClosedStreamServerSocket,
+			})
+		}
 		maps = append(maps, m)
 	}
 

--- a/internal/mode/static/nginx/config/maps_template.go
+++ b/internal/mode/static/nginx/config/maps_template.go
@@ -3,34 +3,12 @@ package config
 const mapsTemplateText = `
 {{ range $m := . }}
 map {{ $m.Source }} {{ $m.Variable }} {
-	{{- if $m.UseHostnames -}}
+	{{- if $m.UseHostnames }}
 	hostnames;
 	{{ end }}
-
 	{{ range $p := $m.Parameters }}
 	{{ $p.Value }} {{ $p.Result }};
 	{{ end }}
 }
 {{- end }}
-
-# Set $gw_api_compliant_host variable to the value of $http_host unless $http_host is empty, then set it to the value
-# of $host. We prefer $http_host because it contains the original value of the host header, which is required by the
-# Gateway API. However, in an HTTP/1.0 request, it's possible that $http_host can be empty. In this case, we will use
-# the value of $host. See http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host.
-map $http_host $gw_api_compliant_host {
-    '' $host;
-    default $http_host;
-}
-
-# Set $connection_header variable to upgrade when the $http_upgrade header is set, otherwise, set it to close. This
-# allows support for websocket connections. See https://nginx.org/en/docs/http/websocket.html.
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    '' close;
-}
-
-## Returns just the path from the original request URI.
-map $request_uri $request_uri_path {
-  "~^(?P<path>[^?]*)(\?.*)?$"  $path;
-}
 `

--- a/internal/mode/static/nginx/config/maps_template.go
+++ b/internal/mode/static/nginx/config/maps_template.go
@@ -3,9 +3,13 @@ package config
 const mapsTemplateText = `
 {{ range $m := . }}
 map {{ $m.Source }} {{ $m.Variable }} {
-    {{ range $p := $m.Parameters }}
-    {{ $p.Value }} {{ $p.Result }};
-    {{ end }}
+	{{- if $m.UseHostnames -}}
+	hostnames;
+	{{ end }}
+
+	{{ range $p := $m.Parameters }}
+	{{ $p.Value }} {{ $p.Result }};
+	{{ end }}
 }
 {{- end }}
 

--- a/internal/mode/static/nginx/config/maps_test.go
+++ b/internal/mode/static/nginx/config/maps_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/http"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/shared"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
 )
 
@@ -162,11 +162,11 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 			IsDefault: true,
 		},
 	}
-	expectedMap := []http.Map{
+	expectedMap := []shared.Map{
 		{
 			Source:   "${http_my_add_header}",
 			Variable: "$my_add_header_header_var",
-			Parameters: []http.MapParameter{
+			Parameters: []shared.MapParameter{
 				{Value: "default", Result: "''"},
 				{
 					Value:  "~.*",
@@ -177,7 +177,7 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 		{
 			Source:   "${http_my_second_add_header}",
 			Variable: "$my_second_add_header_header_var",
-			Parameters: []http.MapParameter{
+			Parameters: []shared.MapParameter{
 				{Value: "default", Result: "''"},
 				{
 					Value:  "~.*",
@@ -189,4 +189,126 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 	maps := buildAddHeaderMaps(testServers)
 
 	g.Expect(maps).To(ConsistOf(expectedMap))
+}
+
+func TestExecuteStreamMaps(t *testing.T) {
+	g := NewWithT(t)
+	conf := dataplane.Configuration{
+		TLSPassthroughServers: []dataplane.Layer4VirtualServer{
+			{
+				Hostname:     "example.com",
+				Port:         8081,
+				UpstreamName: "backend1",
+			},
+			{
+				Hostname:     "example.com",
+				Port:         8080,
+				UpstreamName: "backend1",
+			},
+			{
+				Hostname:     "cafe.example.com",
+				Port:         8080,
+				UpstreamName: "backend2",
+			},
+		},
+		SSLServers: []dataplane.VirtualServer{
+			{
+				Hostname: "app.example.com",
+				Port:     8080,
+			},
+		},
+	}
+
+	expSubStrings := map[string]int{
+		"example.com unix:/var/run/nginx/example.com-8081.sock;":           1,
+		"example.com unix:/var/run/nginx/example.com-8080.sock;":           1,
+		"cafe.example.com unix:/var/run/nginx/cafe.example.com-8080.sock;": 1,
+		"app.example.com unix:/var/run/nginx/https8080.sock;":              1,
+		"hostnames": 2,
+	}
+
+	results := executeStreamMaps(conf)
+	g.Expect(results).To(HaveLen(1))
+	result := results[0]
+
+	g.Expect(result.dest).To(Equal(streamConfigFile))
+	for expSubStr, expCount := range expSubStrings {
+		g.Expect(strings.Count(string(result.data), expSubStr)).To(Equal(expCount))
+	}
+}
+
+func TestCreateStreamMaps(t *testing.T) {
+	g := NewWithT(t)
+	conf := dataplane.Configuration{
+		TLSPassthroughServers: []dataplane.Layer4VirtualServer{
+			{
+				Hostname:     "example.com",
+				Port:         8081,
+				UpstreamName: "backend1",
+			},
+			{
+				Hostname:     "example.com",
+				Port:         8080,
+				UpstreamName: "backend1",
+			},
+			{
+				Hostname:     "cafe.example.com",
+				Port:         8080,
+				UpstreamName: "backend2",
+			},
+			{
+				Hostname:     "wrong.example.com",
+				Port:         8080,
+				UpstreamName: "",
+			},
+		},
+		SSLServers: []dataplane.VirtualServer{
+			{
+				Hostname: "app.example.com",
+				Port:     8080,
+			},
+			{
+				Port:      8080,
+				IsDefault: true,
+			},
+		},
+	}
+
+	maps := createStreamMaps(conf)
+
+	expectedMaps := []shared.Map{
+		{
+			Source:   "$ssl_preread_server_name",
+			Variable: getTLSPassthroughVarName(8081),
+			Parameters: []shared.MapParameter{
+				{Value: "example.com", Result: getSocketNameTLS(8081, "example.com")},
+			},
+			UseHostnames: true,
+		},
+		{
+			Source:   "$ssl_preread_server_name",
+			Variable: getTLSPassthroughVarName(8080),
+			Parameters: []shared.MapParameter{
+				{Value: "example.com", Result: getSocketNameTLS(8080, "example.com")},
+				{Value: "cafe.example.com", Result: getSocketNameTLS(8080, "cafe.example.com")},
+				{Value: "wrong.example.com", Result: `""`},
+				{Value: "app.example.com", Result: getSocketNameHTTPS(8080)},
+				{Value: "default", Result: getSocketNameHTTPS(8080)},
+			},
+			UseHostnames: true,
+		},
+	}
+
+	g.Expect(maps).To(ConsistOf(expectedMaps))
+}
+
+func TestCreateStreamMapsWithEmpty(t *testing.T) {
+	g := NewWithT(t)
+	conf := dataplane.Configuration{
+		TLSPassthroughServers: nil,
+	}
+
+	maps := createStreamMaps(conf)
+
+	g.Expect(maps).To(BeNil())
 }

--- a/internal/mode/static/nginx/config/maps_test.go
+++ b/internal/mode/static/nginx/config/maps_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/shared"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/resolver"
 )
 
 func TestExecuteMaps(t *testing.T) {
@@ -84,9 +85,6 @@ func TestExecuteMaps(t *testing.T) {
 		"map ${http_my_second_add_header} $my_second_add_header_header_var {": 1,
 		"~.* ${http_my_second_add_header},;":                                  1,
 		"map ${http_my_set_header} $my_set_header_header_var {":               0,
-		"map $http_host $gw_api_compliant_host {":                             1,
-		"map $http_upgrade $connection_upgrade {":                             1,
-		"map $request_uri $request_uri_path {":                                1,
 	}
 
 	mapResult := executeMaps(conf)
@@ -217,6 +215,26 @@ func TestExecuteStreamMaps(t *testing.T) {
 				Port:     8080,
 			},
 		},
+		StreamUpstreams: []dataplane.Upstream{
+			{
+				Name: "backend1",
+				Endpoints: []resolver.Endpoint{
+					{
+						Address: "1.1.1.1",
+						Port:    80,
+					},
+				},
+			},
+			{
+				Name: "backend2",
+				Endpoints: []resolver.Endpoint{
+					{
+						Address: "1.1.1.1",
+						Port:    80,
+					},
+				},
+			},
+		},
 	}
 
 	expSubStrings := map[string]int{
@@ -225,6 +243,7 @@ func TestExecuteStreamMaps(t *testing.T) {
 		"cafe.example.com unix:/var/run/nginx/cafe.example.com-8080.sock;": 1,
 		"app.example.com unix:/var/run/nginx/https8080.sock;":              1,
 		"hostnames": 2,
+		"default":   2,
 	}
 
 	results := executeStreamMaps(conf)
@@ -257,9 +276,23 @@ func TestCreateStreamMaps(t *testing.T) {
 				UpstreamName: "backend2",
 			},
 			{
-				Hostname:     "wrong.example.com",
+				Hostname:     "dne.example.com",
 				Port:         8080,
-				UpstreamName: "",
+				UpstreamName: "backend-dne",
+			},
+			{
+				Port:     8082,
+				Hostname: "",
+			},
+			{
+				Hostname:  "*.example.com",
+				Port:      8080,
+				IsDefault: true,
+			},
+			{
+				Hostname:     "no-endpoints.example.com",
+				Port:         8080,
+				UpstreamName: "backend3",
 			},
 		},
 		SSLServers: []dataplane.VirtualServer{
@@ -272,6 +305,30 @@ func TestCreateStreamMaps(t *testing.T) {
 				IsDefault: true,
 			},
 		},
+		StreamUpstreams: []dataplane.Upstream{
+			{
+				Name: "backend1",
+				Endpoints: []resolver.Endpoint{
+					{
+						Address: "1.1.1.1",
+						Port:    80,
+					},
+				},
+			},
+			{
+				Name: "backend2",
+				Endpoints: []resolver.Endpoint{
+					{
+						Address: "1.1.1.1",
+						Port:    80,
+					},
+				},
+			},
+			{
+				Name:      "backend3",
+				Endpoints: nil,
+			},
+		},
 	}
 
 	maps := createStreamMaps(conf)
@@ -279,9 +336,18 @@ func TestCreateStreamMaps(t *testing.T) {
 	expectedMaps := []shared.Map{
 		{
 			Source:   "$ssl_preread_server_name",
+			Variable: getTLSPassthroughVarName(8082),
+			Parameters: []shared.MapParameter{
+				{Value: "default", Result: connectionClosedStreamServerSocket},
+			},
+			UseHostnames: true,
+		},
+		{
+			Source:   "$ssl_preread_server_name",
 			Variable: getTLSPassthroughVarName(8081),
 			Parameters: []shared.MapParameter{
 				{Value: "example.com", Result: getSocketNameTLS(8081, "example.com")},
+				{Value: "default", Result: connectionClosedStreamServerSocket},
 			},
 			UseHostnames: true,
 		},
@@ -291,7 +357,9 @@ func TestCreateStreamMaps(t *testing.T) {
 			Parameters: []shared.MapParameter{
 				{Value: "example.com", Result: getSocketNameTLS(8080, "example.com")},
 				{Value: "cafe.example.com", Result: getSocketNameTLS(8080, "cafe.example.com")},
-				{Value: "wrong.example.com", Result: `""`},
+				{Value: "dne.example.com", Result: emptyStringSocket},
+				{Value: "*.example.com", Result: connectionClosedStreamServerSocket},
+				{Value: "no-endpoints.example.com", Result: emptyStringSocket},
 				{Value: "app.example.com", Result: getSocketNameHTTPS(8080)},
 				{Value: "default", Result: getSocketNameHTTPS(8080)},
 			},

--- a/internal/mode/static/nginx/config/servers_template.go
+++ b/internal/mode/static/nginx/config/servers_template.go
@@ -5,10 +5,10 @@ js_preload_object matches from /etc/nginx/conf.d/matches.json;
 {{- range $s := .Servers -}}
     {{ if $s.IsDefaultSSL -}}
 server {
-        {{- if $.IPFamily.IPv4 }}
+        {{- if or ($.IPFamily.IPv4) ($s.IsSocket) }}
     listen {{ $s.Listen }} ssl default_server;
         {{- end }}
-        {{- if $.IPFamily.IPv6 }}
+        {{- if and ($.IPFamily.IPv6) (not $s.IsSocket) }}
     listen [::]:{{ $s.Listen }} ssl default_server;
         {{- end }}
 
@@ -29,10 +29,10 @@ server {
     {{- else }}
 server {
         {{- if $s.SSL }}
-          {{- if $.IPFamily.IPv4 }}
+          {{- if or ($.IPFamily.IPv4) ($s.IsSocket) }}
     listen {{ $s.Listen }} ssl;
           {{- end }}
-          {{- if $.IPFamily.IPv6 }}
+          {{- if and ($.IPFamily.IPv6) (not $s.IsSocket) }}
     listen [::]:{{ $s.Listen }} ssl;
           {{- end }}
     ssl_certificate {{ $s.SSL.Certificate }};

--- a/internal/mode/static/nginx/config/servers_template.go
+++ b/internal/mode/static/nginx/config/servers_template.go
@@ -6,10 +6,10 @@ js_preload_object matches from /etc/nginx/conf.d/matches.json;
     {{ if $s.IsDefaultSSL -}}
 server {
         {{- if $.IPFamily.IPv4 }}
-    listen {{ $s.Port }} ssl default_server;
+    listen {{ $s.Listen }} ssl default_server;
         {{- end }}
         {{- if $.IPFamily.IPv6 }}
-    listen [::]:{{ $s.Port }} ssl default_server;
+    listen [::]:{{ $s.Listen }} ssl default_server;
         {{- end }}
 
     ssl_reject_handshake on;
@@ -17,10 +17,10 @@ server {
     {{- else if $s.IsDefaultHTTP }}
 server {
         {{- if $.IPFamily.IPv4 }}
-    listen {{ $s.Port }} default_server;
+    listen {{ $s.Listen }} default_server;
         {{- end }}
         {{- if $.IPFamily.IPv6 }}
-    listen [::]:{{ $s.Port }} default_server;
+    listen [::]:{{ $s.Listen }} default_server;
         {{- end }}
 
     default_type text/html;
@@ -30,10 +30,10 @@ server {
 server {
         {{- if $s.SSL }}
           {{- if $.IPFamily.IPv4 }}
-    listen {{ $s.Port }} ssl;
+    listen {{ $s.Listen }} ssl;
           {{- end }}
           {{- if $.IPFamily.IPv6 }}
-    listen [::]:{{ $s.Port }} ssl;
+    listen [::]:{{ $s.Listen }} ssl;
           {{- end }}
     ssl_certificate {{ $s.SSL.Certificate }};
     ssl_certificate_key {{ $s.SSL.CertificateKey }};
@@ -43,10 +43,10 @@ server {
     }
         {{- else }}
           {{- if $.IPFamily.IPv4 }}
-    listen {{ $s.Port }};
+    listen {{ $s.Listen }};
           {{- end }}
           {{- if $.IPFamily.IPv6 }}
-    listen [::]:{{ $s.Port }};
+    listen [::]:{{ $s.Listen }};
           {{- end }}
         {{- end }}
 

--- a/internal/mode/static/nginx/config/servers_test.go
+++ b/internal/mode/static/nginx/config/servers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/http"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/policies"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/policies/policiesfakes"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/shared"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
 )
 
@@ -165,6 +166,26 @@ func TestExecuteServersForIPFamily(t *testing.T) {
 			Port: 8443,
 		},
 	}
+	sslServers443 := []dataplane.VirtualServer{
+		{
+			IsDefault: true,
+			Port:      443,
+		},
+		{
+			Hostname: "example.com",
+			SSL: &dataplane.SSL{
+				KeyPairID: "test-keypair",
+			},
+			Port: 443,
+		},
+	}
+	passThroughServers := []dataplane.Layer4VirtualServer{
+		{
+			IsDefault: true,
+			Hostname:  "*.example.com",
+			Port:      8443,
+		},
+	}
 	tests := []struct {
 		msg                string
 		expectedHTTPConfig map[string]int
@@ -191,23 +212,26 @@ func TestExecuteServersForIPFamily(t *testing.T) {
 			},
 		},
 		{
-			msg: "http and ssl servers with IPv6 IP family",
+			msg: "http, ssl servers, and tls servers with IPv6 IP family",
 			config: dataplane.Configuration{
 				HTTPServers: httpServers,
-				SSLServers:  sslServers,
+				SSLServers:  append(sslServers, sslServers443...),
 				BaseHTTPConfig: dataplane.BaseHTTPConfig{
 					IPFamily: dataplane.IPv6,
 				},
+				TLSPassthroughServers: passThroughServers,
 			},
 			expectedHTTPConfig: map[string]int{
-				"listen [::]:8080 default_server;":                         1,
-				"listen [::]:8080;":                                        1,
-				"listen [::]:8443 ssl default_server;":                     1,
-				"listen [::]:8443 ssl;":                                    1,
-				"server_name example.com;":                                 2,
-				"ssl_certificate /etc/nginx/secrets/test-keypair.pem;":     1,
-				"ssl_certificate_key /etc/nginx/secrets/test-keypair.pem;": 1,
-				"ssl_reject_handshake on;":                                 1,
+				"listen [::]:8080 default_server;":                              1,
+				"listen [::]:8080;":                                             1,
+				"listen [::]:443 ssl default_server;":                           1,
+				"listen [::]:443 ssl;":                                          1,
+				"listen unix:/var/run/nginx/https8443.sock ssl;":                1,
+				"listen unix:/var/run/nginx/https8443.sock ssl default_server;": 1,
+				"server_name example.com;":                                      3,
+				"ssl_certificate /etc/nginx/secrets/test-keypair.pem;":          2,
+				"ssl_certificate_key /etc/nginx/secrets/test-keypair.pem;":      2,
+				"ssl_reject_handshake on;":                                      2,
 			},
 		},
 		{
@@ -1216,6 +1240,7 @@ func TestCreateServers(t *testing.T) {
 		{
 			IsDefaultSSL: true,
 			Listen:       getSocketNameHTTPS(8443),
+			IsSocket:     true,
 		},
 		{
 			ServerName: "cafe.example.com",
@@ -1225,6 +1250,7 @@ func TestCreateServers(t *testing.T) {
 			},
 			Locations: getExpectedLocations(true),
 			Listen:    getSocketNameHTTPS(8443),
+			IsSocket:  true,
 			GRPC:      true,
 		},
 	}
@@ -2719,22 +2745,22 @@ func TestGetIPFamily(t *testing.T) {
 	test := []struct {
 		msg            string
 		baseHTTPConfig dataplane.BaseHTTPConfig
-		expected       http.IPFamily
+		expected       shared.IPFamily
 	}{
 		{
 			msg:            "ipv4",
 			baseHTTPConfig: dataplane.BaseHTTPConfig{IPFamily: dataplane.IPv4},
-			expected:       http.IPFamily{IPv4: true, IPv6: false},
+			expected:       shared.IPFamily{IPv4: true, IPv6: false},
 		},
 		{
 			msg:            "ipv6",
 			baseHTTPConfig: dataplane.BaseHTTPConfig{IPFamily: dataplane.IPv6},
-			expected:       http.IPFamily{IPv4: false, IPv6: true},
+			expected:       shared.IPFamily{IPv4: false, IPv6: true},
 		},
 		{
 			msg:            "dual",
 			baseHTTPConfig: dataplane.BaseHTTPConfig{IPFamily: dataplane.Dual},
-			expected:       http.IPFamily{IPv4: true, IPv6: true},
+			expected:       shared.IPFamily{IPv4: true, IPv6: true},
 		},
 	}
 

--- a/internal/mode/static/nginx/config/shared/config.go
+++ b/internal/mode/static/nginx/config/shared/config.go
@@ -1,0 +1,15 @@
+package shared
+
+// Map defines an NGINX map.
+type Map struct {
+	Source       string
+	Variable     string
+	Parameters   []MapParameter
+	UseHostnames bool
+}
+
+// MapParameter defines a Value and Result pair in a Map.
+type MapParameter struct {
+	Value  string
+	Result string
+}

--- a/internal/mode/static/nginx/config/shared/config.go
+++ b/internal/mode/static/nginx/config/shared/config.go
@@ -13,3 +13,9 @@ type MapParameter struct {
 	Value  string
 	Result string
 }
+
+// IPFamily holds the IP family configuration to be used by NGINX.
+type IPFamily struct {
+	IPv4 bool
+	IPv6 bool
+}

--- a/internal/mode/static/nginx/config/sockets.go
+++ b/internal/mode/static/nginx/config/sockets.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"fmt"
+)
+
+func getSocketNameTLS(port int32, hostname string) string {
+	return fmt.Sprintf("unix:/var/run/nginx/%s-%d.sock", hostname, port)
+}
+
+func getSocketNameHTTPS(port int32) string {
+	return fmt.Sprintf("unix:/var/run/nginx/https%d.sock", port)
+}
+
+func getTLSPassthroughVarName(port int32) string {
+	return fmt.Sprintf("$dest%d", port)
+}

--- a/internal/mode/static/nginx/config/sockets_test.go
+++ b/internal/mode/static/nginx/config/sockets_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetSocketNameTLS(t *testing.T) {
+	res := getSocketNameTLS(800, "*.cafe.example.com")
+
+	g := NewGomegaWithT(t)
+	g.Expect(res).To(Equal("unix:/var/run/nginx/*.cafe.example.com-800.sock"))
+}
+
+func TestGetSocketNameHTTPS(t *testing.T) {
+	res := getSocketNameHTTPS(800)
+
+	g := NewGomegaWithT(t)
+	g.Expect(res).To(Equal("unix:/var/run/nginx/https800.sock"))
+}
+
+func TestGetTLSPassthroughVarName(t *testing.T) {
+	res := getTLSPassthroughVarName(800)
+
+	g := NewGomegaWithT(t)
+	g.Expect(res).To(Equal("$dest800"))
+}

--- a/internal/mode/static/nginx/config/stream/config.go
+++ b/internal/mode/static/nginx/config/stream/config.go
@@ -1,0 +1,21 @@
+package stream
+
+// Server holds all configuration for a stream server.
+type Server struct {
+	Listen     string
+	ProxyPass  string
+	Pass       string
+	SSLPreread bool
+}
+
+// Upstream holds all configuration for a stream upstream.
+type Upstream struct {
+	Name     string
+	ZoneSize string // format: 512k, 1m
+	Servers  []UpstreamServer
+}
+
+// UpstreamServer holds all configuration for a stream upstream server.
+type UpstreamServer struct {
+	Address string
+}

--- a/internal/mode/static/nginx/config/stream/config.go
+++ b/internal/mode/static/nginx/config/stream/config.go
@@ -1,11 +1,14 @@
 package stream
 
+import "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/shared"
+
 // Server holds all configuration for a stream server.
 type Server struct {
 	Listen     string
 	ProxyPass  string
 	Pass       string
 	SSLPreread bool
+	IsSocket   bool
 }
 
 // Upstream holds all configuration for a stream upstream.
@@ -18,4 +21,10 @@ type Upstream struct {
 // UpstreamServer holds all configuration for a stream upstream server.
 type UpstreamServer struct {
 	Address string
+}
+
+// ServerConfig holds configuration for a stream server and IP family to be used by NGINX.
+type ServerConfig struct {
+	Servers  []Server
+	IPFamily shared.IPFamily
 }

--- a/internal/mode/static/nginx/config/stream_servers.go
+++ b/internal/mode/static/nginx/config/stream_servers.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"fmt"
+	gotemplate "text/template"
+
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/stream"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
+)
+
+var streamServersTemplate = gotemplate.Must(gotemplate.New("streamServers").Parse(streamServersTemplateText))
+
+func executeStreamServers(conf dataplane.Configuration) []executeResult {
+	streamServers := createStreamServers(conf)
+
+	streamServerResult := executeResult{
+		dest: streamConfigFile,
+		data: helpers.MustExecuteTemplate(streamServersTemplate, streamServers),
+	}
+
+	return []executeResult{
+		streamServerResult,
+	}
+}
+
+func createStreamServers(conf dataplane.Configuration) []stream.Server {
+	if len(conf.TLSPassthroughServers) == 0 {
+		return nil
+	}
+
+	streamServers := make([]stream.Server, 0, len(conf.TLSPassthroughServers)*2)
+	portSet := make(map[int32]struct{})
+
+	for _, server := range conf.TLSPassthroughServers {
+		if server.UpstreamName != "" {
+			streamServers = append(streamServers, stream.Server{
+				Listen:    getSocketNameTLS(server.Port, server.Hostname),
+				ProxyPass: server.UpstreamName,
+			})
+		}
+
+		if _, inPortSet := portSet[server.Port]; inPortSet {
+			continue
+		}
+
+		portSet[server.Port] = struct{}{}
+		streamServers = append(streamServers, stream.Server{
+			Listen:     fmt.Sprint(server.Port),
+			Pass:       getTLSPassthroughVarName(server.Port),
+			SSLPreread: true,
+		})
+	}
+
+	return streamServers
+}

--- a/internal/mode/static/nginx/config/stream_servers_template.go
+++ b/internal/mode/static/nginx/config/stream_servers_template.go
@@ -1,0 +1,21 @@
+package config
+
+const streamServersTemplateText = `
+{{- range $s := . }}
+server {
+	listen {{ $s.Listen }};
+
+	{{- if $s.ProxyPass }}
+	proxy_pass {{ $s.ProxyPass }};
+	{{- end }}
+
+	{{- if $s.Pass }}
+	pass {{ $s.Pass }};
+	{{- end }}
+
+	{{- if $s.SSLPreread }}
+	ssl_preread on;
+	{{- end }}
+}
+{{- end }}
+`

--- a/internal/mode/static/nginx/config/stream_servers_template.go
+++ b/internal/mode/static/nginx/config/stream_servers_template.go
@@ -1,21 +1,28 @@
 package config
 
 const streamServersTemplateText = `
-{{- range $s := . }}
+{{- range $s := .Servers }}
 server {
-	listen {{ $s.Listen }};
-
+	{{- if or ($.IPFamily.IPv4) ($s.IsSocket) }}
+    listen {{ $s.Listen }};
+	{{- end }}
+	{{- if and ($.IPFamily.IPv6) (not $s.IsSocket) }}
+    listen [::]:{{ $s.Listen }};
+	{{- end }}
 	{{- if $s.ProxyPass }}
-	proxy_pass {{ $s.ProxyPass }};
+    proxy_pass {{ $s.ProxyPass }};
 	{{- end }}
-
 	{{- if $s.Pass }}
-	pass {{ $s.Pass }};
+    pass {{ $s.Pass }};
 	{{- end }}
-
 	{{- if $s.SSLPreread }}
-	ssl_preread on;
+    ssl_preread on;
 	{{- end }}
 }
 {{- end }}
+
+server {
+    listen unix:/var/run/nginx/connection-closed-server.sock;
+    return "";
+}
 `

--- a/internal/mode/static/nginx/config/stream_servers_test.go
+++ b/internal/mode/static/nginx/config/stream_servers_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/stream"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
+)
+
+func TestExecuteStreamServers(t *testing.T) {
+	conf := dataplane.Configuration{
+		TLSPassthroughServers: []dataplane.Layer4VirtualServer{
+			{
+				Hostname:     "example.com",
+				Port:         8081,
+				UpstreamName: "backend1",
+			},
+			{
+				Hostname:     "example.com",
+				Port:         8080,
+				UpstreamName: "backend1",
+			},
+			{
+				Hostname:     "cafe.example.com",
+				Port:         8080,
+				UpstreamName: "backend2",
+			},
+		},
+	}
+
+	expSubStrings := map[string]int{
+		"pass $dest8081;": 1,
+		"pass $dest8080;": 1,
+		"ssl_preread on;": 2,
+		"proxy_pass":      3,
+	}
+	g := NewWithT(t)
+
+	results := executeStreamServers(conf)
+	g.Expect(results).To(HaveLen(1))
+	result := results[0]
+
+	g.Expect(result.dest).To(Equal(streamConfigFile))
+	for expSubStr, expCount := range expSubStrings {
+		g.Expect(strings.Count(string(result.data), expSubStr)).To(Equal(expCount))
+	}
+}
+
+func TestCreateStreamServers(t *testing.T) {
+	conf := dataplane.Configuration{
+		TLSPassthroughServers: []dataplane.Layer4VirtualServer{
+			{
+				Hostname:     "example.com",
+				Port:         8081,
+				UpstreamName: "backend1",
+			},
+			{
+				Hostname:     "example.com",
+				Port:         8080,
+				UpstreamName: "backend1",
+			},
+			{
+				Hostname:     "cafe.example.com",
+				Port:         8080,
+				UpstreamName: "backend2",
+			},
+			{
+				Hostname:     "wrong.example.com",
+				Port:         8081,
+				UpstreamName: "",
+			},
+		},
+	}
+
+	streamServers := createStreamServers(conf)
+
+	g := NewWithT(t)
+
+	expectedStreamServers := []stream.Server{
+		{
+			Listen:     getSocketNameTLS(conf.TLSPassthroughServers[0].Port, conf.TLSPassthroughServers[0].Hostname),
+			ProxyPass:  conf.TLSPassthroughServers[0].UpstreamName,
+			SSLPreread: false,
+		},
+		{
+			Listen:     getSocketNameTLS(conf.TLSPassthroughServers[1].Port, conf.TLSPassthroughServers[1].Hostname),
+			ProxyPass:  conf.TLSPassthroughServers[1].UpstreamName,
+			SSLPreread: false,
+		},
+		{
+			Listen:     getSocketNameTLS(conf.TLSPassthroughServers[2].Port, conf.TLSPassthroughServers[2].Hostname),
+			ProxyPass:  conf.TLSPassthroughServers[2].UpstreamName,
+			SSLPreread: false,
+		},
+		{
+			Listen:     fmt.Sprint(8081),
+			Pass:       getTLSPassthroughVarName(8081),
+			SSLPreread: true,
+		},
+		{
+			Listen:     fmt.Sprint(8080),
+			Pass:       getTLSPassthroughVarName(8080),
+			SSLPreread: true,
+		},
+	}
+	g.Expect(streamServers).To(ConsistOf(expectedStreamServers))
+}
+
+func TestCreateStreamServersWithNone(t *testing.T) {
+	conf := dataplane.Configuration{
+		TLSPassthroughServers: nil,
+	}
+
+	streamServers := createStreamServers(conf)
+
+	g := NewWithT(t)
+
+	g.Expect(streamServers).To(BeNil())
+}

--- a/internal/mode/static/nginx/config/upstreams.go
+++ b/internal/mode/static/nginx/config/upstreams.go
@@ -71,8 +71,12 @@ func (g GeneratorImpl) createStreamUpstream(up dataplane.Upstream) stream.Upstre
 
 	upstreamServers := make([]stream.UpstreamServer, len(up.Endpoints))
 	for idx, ep := range up.Endpoints {
+		format := "%s:%d"
+		if ep.IPv6 {
+			format = "[%s]:%d"
+		}
 		upstreamServers[idx] = stream.UpstreamServer{
-			Address: fmt.Sprintf("%s:%d", ep.Address, ep.Port),
+			Address: fmt.Sprintf(format, ep.Address, ep.Port),
 		}
 	}
 

--- a/internal/mode/static/nginx/config/upstreams.go
+++ b/internal/mode/static/nginx/config/upstreams.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/http"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/stream"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
 )
 
@@ -22,6 +23,10 @@ const (
 	ossZoneSize = "512k"
 	// plusZoneSize is the upstream zone size for nginx plus.
 	plusZoneSize = "1m"
+	// ossZoneSize is the upstream zone size for nginx open source.
+	ossZoneSizeStream = "512k"
+	// plusZoneSize is the upstream zone size for nginx plus.
+	plusZoneSizeStream = "1m"
 )
 
 func (g GeneratorImpl) executeUpstreams(conf dataplane.Configuration) []executeResult {
@@ -33,6 +38,49 @@ func (g GeneratorImpl) executeUpstreams(conf dataplane.Configuration) []executeR
 	}
 
 	return []executeResult{result}
+}
+
+func (g GeneratorImpl) executeStreamUpstreams(conf dataplane.Configuration) []executeResult {
+	upstreams := g.createStreamUpstreams(conf.StreamUpstreams)
+
+	result := executeResult{
+		dest: streamConfigFile,
+		data: helpers.MustExecuteTemplate(upstreamsTemplate, upstreams),
+	}
+
+	return []executeResult{result}
+}
+
+func (g GeneratorImpl) createStreamUpstreams(upstreams []dataplane.Upstream) []stream.Upstream {
+	ups := make([]stream.Upstream, 0, len(upstreams))
+
+	for _, u := range upstreams {
+		if len(u.Endpoints) != 0 {
+			ups = append(ups, g.createStreamUpstream(u))
+		}
+	}
+
+	return ups
+}
+
+func (g GeneratorImpl) createStreamUpstream(up dataplane.Upstream) stream.Upstream {
+	zoneSize := ossZoneSizeStream
+	if g.plus {
+		zoneSize = plusZoneSizeStream
+	}
+
+	upstreamServers := make([]stream.UpstreamServer, len(up.Endpoints))
+	for idx, ep := range up.Endpoints {
+		upstreamServers[idx] = stream.UpstreamServer{
+			Address: fmt.Sprintf("%s:%d", ep.Address, ep.Port),
+		}
+	}
+
+	return stream.Upstream{
+		Name:     up.Name,
+		ZoneSize: zoneSize,
+		Servers:  upstreamServers,
+	}
 }
 
 func (g GeneratorImpl) createUpstreams(upstreams []dataplane.Upstream) []http.Upstream {

--- a/internal/mode/static/nginx/config/upstreams_template.go
+++ b/internal/mode/static/nginx/config/upstreams_template.go
@@ -1,8 +1,9 @@
 package config
 
 // FIXME(kate-osborn): Dynamically calculate upstream zone size based on the number of upstreams.
-// 512k will support up to 648 upstream servers for OSS.
-// NGINX Plus needs 1m to support roughly the same amount of servers (556 upstream servers).
+// 512k will support up to 648 http upstream servers for OSS.
+// NGINX Plus needs 1m to support roughly the same amount of http servers (556 upstream servers).
+// For stream upstream servers, 512k will support 576 in OSS and 1m will support 991 in NGINX Plus
 // https://github.com/nginxinc/nginx-gateway-fabric/issues/483
 const upstreamsTemplateText = `
 {{ range $u := . }}

--- a/internal/mode/static/nginx/config/upstreams_test.go
+++ b/internal/mode/static/nginx/config/upstreams_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/http"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/config/stream"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/dataplane"
 	"github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/resolver"
 )
@@ -303,6 +304,187 @@ func TestCreateUpstreamPlus(t *testing.T) {
 	}
 
 	result := gen.createUpstream(stateUpstream)
+
+	g := NewWithT(t)
+	g.Expect(result).To(Equal(expectedUpstream))
+}
+
+func TestExecuteStreamUpstreams(t *testing.T) {
+	gen := GeneratorImpl{}
+	stateUpstreams := []dataplane.Upstream{
+		{
+			Name: "up1",
+			Endpoints: []resolver.Endpoint{
+				{
+					Address: "10.0.0.0",
+					Port:    80,
+				},
+			},
+		},
+		{
+			Name: "up2",
+			Endpoints: []resolver.Endpoint{
+				{
+					Address: "11.0.0.0",
+					Port:    80,
+				},
+			},
+		},
+		{
+			Name:      "up3",
+			Endpoints: []resolver.Endpoint{},
+		},
+	}
+
+	expectedSubStrings := []string{
+		"upstream up1",
+		"upstream up2",
+		"server 10.0.0.0:80;",
+		"server 11.0.0.0:80;",
+	}
+
+	upstreamResults := gen.executeStreamUpstreams(dataplane.Configuration{StreamUpstreams: stateUpstreams})
+	g := NewWithT(t)
+	g.Expect(upstreamResults).To(HaveLen(1))
+	upstreams := string(upstreamResults[0].data)
+
+	g.Expect(upstreamResults[0].dest).To(Equal(streamConfigFile))
+	for _, expSubString := range expectedSubStrings {
+		g.Expect(upstreams).To(ContainSubstring(expSubString))
+	}
+}
+
+func TestCreateStreamUpstreams(t *testing.T) {
+	gen := GeneratorImpl{}
+	stateUpstreams := []dataplane.Upstream{
+		{
+			Name: "up1",
+			Endpoints: []resolver.Endpoint{
+				{
+					Address: "10.0.0.0",
+					Port:    80,
+				},
+				{
+					Address: "10.0.0.1",
+					Port:    80,
+				},
+				{
+					Address: "10.0.0.2",
+					Port:    80,
+				},
+			},
+		},
+		{
+			Name: "up2",
+			Endpoints: []resolver.Endpoint{
+				{
+					Address: "11.0.0.0",
+					Port:    80,
+				},
+			},
+		},
+		{
+			Name:      "up3",
+			Endpoints: []resolver.Endpoint{},
+		},
+	}
+
+	expUpstreams := []stream.Upstream{
+		{
+			Name:     "up1",
+			ZoneSize: ossZoneSize,
+			Servers: []stream.UpstreamServer{
+				{
+					Address: "10.0.0.0:80",
+				},
+				{
+					Address: "10.0.0.1:80",
+				},
+				{
+					Address: "10.0.0.2:80",
+				},
+			},
+		},
+		{
+			Name:     "up2",
+			ZoneSize: ossZoneSize,
+			Servers: []stream.UpstreamServer{
+				{
+					Address: "11.0.0.0:80",
+				},
+			},
+		},
+	}
+
+	g := NewWithT(t)
+	result := gen.createStreamUpstreams(stateUpstreams)
+	g.Expect(result).To(Equal(expUpstreams))
+}
+
+func TestCreateStreamUpstream(t *testing.T) {
+	gen := GeneratorImpl{}
+	up := dataplane.Upstream{
+		Name: "multiple-endpoints",
+		Endpoints: []resolver.Endpoint{
+			{
+				Address: "10.0.0.1",
+				Port:    80,
+			},
+			{
+				Address: "10.0.0.2",
+				Port:    80,
+			},
+			{
+				Address: "10.0.0.3",
+				Port:    80,
+			},
+		},
+	}
+
+	expectedUpstream := stream.Upstream{
+		Name:     "multiple-endpoints",
+		ZoneSize: ossZoneSize,
+		Servers: []stream.UpstreamServer{
+			{
+				Address: "10.0.0.1:80",
+			},
+			{
+				Address: "10.0.0.2:80",
+			},
+			{
+				Address: "10.0.0.3:80",
+			},
+		},
+	}
+
+	g := NewWithT(t)
+	result := gen.createStreamUpstream(up)
+	g.Expect(result).To(Equal(expectedUpstream))
+}
+
+func TestCreateStreamUpstreamPlus(t *testing.T) {
+	gen := GeneratorImpl{plus: true}
+
+	stateUpstream := dataplane.Upstream{
+		Name: "multiple-endpoints",
+		Endpoints: []resolver.Endpoint{
+			{
+				Address: "10.0.0.1",
+				Port:    80,
+			},
+		},
+	}
+	expectedUpstream := stream.Upstream{
+		Name:     "multiple-endpoints",
+		ZoneSize: plusZoneSize,
+		Servers: []stream.UpstreamServer{
+			{
+				Address: "10.0.0.1:80",
+			},
+		},
+	}
+
+	result := gen.createStreamUpstream(stateUpstream)
 
 	g := NewWithT(t)
 	g.Expect(result).To(Equal(expectedUpstream))

--- a/internal/mode/static/nginx/config/upstreams_test.go
+++ b/internal/mode/static/nginx/config/upstreams_test.go
@@ -372,6 +372,10 @@ func TestCreateStreamUpstreams(t *testing.T) {
 					Address: "10.0.0.2",
 					Port:    80,
 				},
+				{
+					Address: "2001:db8::1",
+					IPv6:    true,
+				},
 			},
 		},
 		{
@@ -402,6 +406,9 @@ func TestCreateStreamUpstreams(t *testing.T) {
 				},
 				{
 					Address: "10.0.0.2:80",
+				},
+				{
+					Address: "[2001:db8::1]:0",
 				},
 			},
 		},

--- a/internal/mode/static/state/change_processor.go
+++ b/internal/mode/static/state/change_processor.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1alpha3"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -107,6 +108,7 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 		ConfigMaps:         make(map[types.NamespacedName]*apiv1.ConfigMap),
 		NginxProxies:       make(map[types.NamespacedName]*ngfAPI.NginxProxy),
 		GRPCRoutes:         make(map[types.NamespacedName]*v1.GRPCRoute),
+		TLSRoutes:          make(map[types.NamespacedName]*v1alpha2.TLSRoute),
 		NGFPolicies:        make(map[graph.PolicyKey]policies.Policy),
 	}
 
@@ -210,6 +212,11 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 				gvk:       cfg.MustExtractGVK(&ngfAPI.ObservabilityPolicy{}),
 				store:     commonPolicyObjectStore,
 				predicate: funcPredicate{stateChanged: isNGFPolicyRelevant},
+			},
+			{
+				gvk:       cfg.MustExtractGVK(&v1alpha2.TLSRoute{}),
+				store:     newObjectStoreMapAdapter(clusterStore.TLSRoutes),
+				predicate: nil,
 			},
 		},
 	)

--- a/internal/mode/static/state/change_processor_test.go
+++ b/internal/mode/static/state/change_processor_test.go
@@ -199,6 +199,7 @@ func createScheme() *runtime.Scheme {
 
 	utilruntime.Must(v1.Install(scheme))
 	utilruntime.Must(v1beta1.Install(scheme))
+	utilruntime.Must(v1alpha2.Install(scheme))
 	utilruntime.Must(v1alpha3.Install(scheme))
 	utilruntime.Must(apiv1.AddToScheme(scheme))
 	utilruntime.Must(discoveryV1.AddToScheme(scheme))
@@ -528,6 +529,7 @@ var _ = Describe("ChangeProcessor", func() {
 								Valid:      true,
 								Attachable: true,
 								Routes:     map[graph.RouteKey]*graph.L7Route{routeKey1: expRouteHR1},
+								L4Routes:   map[graph.L4RouteKey]*graph.L4Route{},
 								SupportedKinds: []v1.RouteGroupKind{
 									{Kind: v1.Kind(kinds.HTTPRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
 									{Kind: v1.Kind(kinds.GRPCRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
@@ -539,6 +541,7 @@ var _ = Describe("ChangeProcessor", func() {
 								Valid:          true,
 								Attachable:     true,
 								Routes:         map[graph.RouteKey]*graph.L7Route{routeKey1: expRouteHR1},
+								L4Routes:       map[graph.L4RouteKey]*graph.L4Route{},
 								ResolvedSecret: helpers.GetPointer(client.ObjectKeyFromObject(diffNsTLSSecret)),
 								SupportedKinds: []v1.RouteGroupKind{
 									{Kind: v1.Kind(kinds.HTTPRoute), Group: helpers.GetPointer[v1.Group](v1.GroupName)},
@@ -549,6 +552,7 @@ var _ = Describe("ChangeProcessor", func() {
 						Valid: true,
 					},
 					IgnoredGateways:   map[types.NamespacedName]*v1.Gateway{},
+					L4Routes:          map[graph.L4RouteKey]*graph.L4Route{},
 					Routes:            map[graph.RouteKey]*graph.L7Route{routeKey1: expRouteHR1},
 					ReferencedSecrets: map[types.NamespacedName]*graph.Secret{},
 					ReferencedServices: map[types.NamespacedName]struct{}{

--- a/internal/mode/static/state/conditions/conditions.go
+++ b/internal/mode/static/state/conditions/conditions.go
@@ -32,6 +32,10 @@ const (
 	// RouteReasonInvalidListener is used with the "Accepted" condition when the Route references an invalid listener.
 	RouteReasonInvalidListener v1.RouteConditionReason = "InvalidListener"
 
+	// RouteReasonHostnameConflict is used with the "Accepted" condition when a route has the exact same hostname
+	// as another route.
+	RouteReasonHostnameConflict v1.RouteConditionReason = "HostnameConflict"
+
 	// RouteReasonGatewayNotProgrammed is used when the associated Gateway is not programmed.
 	// Used with Accepted (false).
 	RouteReasonGatewayNotProgrammed v1.RouteConditionReason = "GatewayNotProgrammed"
@@ -184,6 +188,17 @@ func NewRouteInvalidListener() conditions.Condition {
 		Status:  metav1.ConditionFalse,
 		Reason:  string(RouteReasonInvalidListener),
 		Message: "Listener is invalid for this parent ref",
+	}
+}
+
+// NewRouteHostnameConflict returns a Condition that indicates that the Route is not accepted because of a
+// conflicting hostname on the same port.
+func NewRouteHostnameConflict() conditions.Condition {
+	return conditions.Condition{
+		Type:    string(v1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(RouteReasonHostnameConflict),
+		Message: "Hostname(s) conflict with another route of the same kind on the same port",
 	}
 }
 
@@ -418,6 +433,26 @@ func NewListenerProtocolConflict(msg string) []conditions.Condition {
 			Type:    string(v1.ListenerConditionConflicted),
 			Status:  metav1.ConditionTrue,
 			Reason:  string(v1.ListenerReasonProtocolConflict),
+			Message: msg,
+		},
+		NewListenerNotProgrammedInvalid(msg),
+	}
+}
+
+// NewListenerHostnameConflict returns Conditions that indicate multiple Listeners are specified with the same
+// Listener port, but are HTTPS and TLS and have overlapping hostnames.
+func NewListenerHostnameConflict(msg string) []conditions.Condition {
+	return []conditions.Condition{
+		{
+			Type:    string(v1.ListenerConditionAccepted),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(v1.ListenerReasonHostnameConflict),
+			Message: msg,
+		},
+		{
+			Type:    string(v1.ListenerConditionConflicted),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(v1.ListenerReasonHostnameConflict),
 			Message: msg,
 		},
 		NewListenerNotProgrammedInvalid(msg),

--- a/internal/mode/static/state/dataplane/types.go
+++ b/internal/mode/static/state/dataplane/types.go
@@ -89,6 +89,8 @@ type Layer4VirtualServer struct {
 	UpstreamName string
 	// Port is the port of the server.
 	Port int32
+	// IsDefault refers to whether this server is created for the default listener hostname.
+	IsDefault bool
 }
 
 // Upstream is a pool of endpoints to be load balanced.

--- a/internal/mode/static/state/dataplane/types.go
+++ b/internal/mode/static/state/dataplane/types.go
@@ -30,8 +30,12 @@ type Configuration struct {
 	HTTPServers []VirtualServer
 	// SSLServers holds all SSLServers.
 	SSLServers []VirtualServer
-	// Upstreams holds all unique Upstreams.
+	// TLSPassthroughServers hold all TLSPassthroughServers
+	TLSPassthroughServers []Layer4VirtualServer
+	// Upstreams holds all unique http Upstreams.
 	Upstreams []Upstream
+	// StreamUpstreams holds all unique stream Upstreams
+	StreamUpstreams []Upstream
 	// BackendGroups holds all unique BackendGroups.
 	BackendGroups []BackendGroup
 	// BaseHTTPConfig holds the configuration options at the http context.
@@ -75,6 +79,16 @@ type VirtualServer struct {
 	Port int32
 	// IsDefault indicates whether the server is the default server.
 	IsDefault bool
+}
+
+// Layer4VirtualServer is a virtual server for Layer 4 traffic.
+type Layer4VirtualServer struct {
+	// Hostname is the hostname of the server.
+	Hostname string
+	// UpstreamName refers to the name of the upstream that is used.
+	UpstreamName string
+	// Port is the port of the server.
+	Port int32
 }
 
 // Upstream is a pool of endpoints to be load balanced.

--- a/internal/mode/static/state/graph/backend_refs.go
+++ b/internal/mode/static/state/graph/backend_refs.go
@@ -19,7 +19,7 @@ import (
 	staticConds "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/conditions"
 )
 
-// BackendRef is an internal representation of a backendRef in an HTTP/GRPCRoute.
+// BackendRef is an internal representation of a backendRef in an HTTP/GRPC/TLSRoute.
 type BackendRef struct {
 	// BackendTLSPolicy is the BackendTLSPolicy of the Service which is referenced by the backendRef.
 	BackendTLSPolicy *BackendTLSPolicy

--- a/internal/mode/static/state/graph/route_common.go
+++ b/internal/mode/static/state/graph/route_common.go
@@ -290,7 +290,7 @@ func bindRouteToListeners(
 			continue
 		}
 
-		// Case 2: Attachment is not possible due to unsupported configuration
+		// Case 2: Attachment is not possible due to unsupported configuration.
 
 		if ref.Port != nil {
 			valErr := field.Forbidden(path.Child("port"), "cannot be set")

--- a/internal/mode/static/state/graph/service.go
+++ b/internal/mode/static/state/graph/service.go
@@ -5,27 +5,27 @@ import (
 )
 
 func buildReferencedServices(
-	routes map[RouteKey]*L7Route,
+	l7routes map[RouteKey]*L7Route,
+	l4Routes map[L4RouteKey]*L4Route,
 ) map[types.NamespacedName]struct{} {
 	svcNames := make(map[types.NamespacedName]struct{})
 
-	getServiceNamesFromRoute := func(parentRefs []ParentRef, routeRules []RouteRule) {
-		// If none of the ParentRefs are attached to the Gateway, we want to skip the route.
-		attached := false
+	attached := func(parentRefs []ParentRef) bool {
 		for _, ref := range parentRefs {
 			if ref.Attachment.Attached {
-				attached = true
-				break
+				return true
 			}
 		}
-		if !attached {
-			return
-		}
 
+		return false
+	}
+
+	// Processes both valid and invalid BackendRefs as invalid ones still have referenced services
+	// we may want to track.
+
+	populateServiceNamesForL7Routes := func(routeRules []RouteRule) {
 		for _, rule := range routeRules {
 			for _, ref := range rule.BackendRefs {
-				// Processes both valid and invalid BackendRefs as invalid ones still have referenced services
-				// we may want to track.
 				if ref.SvcNsName != (types.NamespacedName{}) {
 					svcNames[ref.SvcNsName] = struct{}{}
 				}
@@ -33,15 +33,40 @@ func buildReferencedServices(
 		}
 	}
 
+	populateServiceNamesForL4Routes := func(route *L4Route) {
+		nsname := route.Spec.BackendRef.SvcNsName
+		if nsname != (types.NamespacedName{}) {
+			svcNames[nsname] = struct{}{}
+		}
+	}
+
 	// routes all have populated ParentRefs from when they were created.
 	//
-	// Get all the service names referenced from all the Routes.
-	for _, route := range routes {
+	// Get all the service names referenced from all the l7 and l4 routes.
+	for _, route := range l7routes {
 		if !route.Valid {
 			continue
 		}
 
-		getServiceNamesFromRoute(route.ParentRefs, route.Spec.Rules)
+		// If none of the ParentRefs are attached to the Gateway, we want to skip the route.
+		if !attached(route.ParentRefs) {
+			continue
+		}
+
+		populateServiceNamesForL7Routes(route.Spec.Rules)
+	}
+
+	for _, route := range l4Routes {
+		if !route.Valid {
+			continue
+		}
+
+		// If none of the ParentRefs are attached to the Gateway, we want to skip the route.
+		if !attached(route.ParentRefs) {
+			continue
+		}
+
+		populateServiceNamesForL4Routes(route)
 	}
 
 	if len(svcNames) == 0 {

--- a/internal/mode/static/state/graph/service_test.go
+++ b/internal/mode/static/state/graph/service_test.go
@@ -8,148 +8,126 @@ import (
 )
 
 func TestBuildReferencedServices(t *testing.T) {
-	normalRoute := &L7Route{
-		ParentRefs: []ParentRef{
-			{
-				Attachment: &ParentRefAttachmentStatus{
-					Attached: true,
+	getNormalL7Route := func() *L7Route {
+		return &L7Route{
+			ParentRefs: []ParentRef{
+				{
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: true,
+					},
 				},
 			},
-		},
-		Valid: true,
-		Spec: L7RouteSpec{
-			Rules: []RouteRule{
-				{
-					BackendRefs: []BackendRef{
-						{
-							SvcNsName: types.NamespacedName{Namespace: "banana-ns", Name: "service"},
-							Weight:    1,
+			Valid: true,
+			Spec: L7RouteSpec{
+				Rules: []RouteRule{
+					{
+						BackendRefs: []BackendRef{
+							{
+								SvcNsName: types.NamespacedName{Namespace: "banana-ns", Name: "service"},
+							},
 						},
 					},
-					ValidMatches: true,
-					ValidFilters: true,
 				},
 			},
-		},
-		RouteType: RouteTypeHTTP,
+			RouteType: RouteTypeHTTP,
+		}
 	}
 
-	validRouteTwoServicesOneRule := &L7Route{
-		ParentRefs: []ParentRef{
-			{
-				Attachment: &ParentRefAttachmentStatus{
-					Attached: true,
-				},
-			},
-		},
-		Valid: true,
-		Spec: L7RouteSpec{
-			Rules: []RouteRule{
-				{
-					BackendRefs: []BackendRef{
-						{
-							SvcNsName: types.NamespacedName{Namespace: "service-ns", Name: "service"},
-							Weight:    1,
-						},
-						{
-							SvcNsName: types.NamespacedName{Namespace: "service-ns2", Name: "service2"},
-							Weight:    1,
-						},
-					},
-					ValidMatches: true,
-					ValidFilters: true,
-				},
-			},
-		},
+	getModifiedL7Route := func(mod func(route *L7Route) *L7Route) *L7Route {
+		return mod(getNormalL7Route())
 	}
 
-	validRouteTwoServicesTwoRules := &L7Route{
-		ParentRefs: []ParentRef{
-			{
-				Attachment: &ParentRefAttachmentStatus{
-					Attached: true,
+	getNormalL4Route := func() *L4Route {
+		return &L4Route{
+			Spec: L4RouteSpec{
+				BackendRef: BackendRef{
+					SvcNsName: types.NamespacedName{Namespace: "tlsroute-ns", Name: "service"},
 				},
 			},
-		},
-		Valid: true,
-		Spec: L7RouteSpec{
-			Rules: []RouteRule{
+			Valid: true,
+			ParentRefs: []ParentRef{
 				{
-					BackendRefs: []BackendRef{
-						{
-							SvcNsName: types.NamespacedName{Namespace: "service-ns", Name: "service"},
-							Weight:    1,
-						},
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: true,
 					},
-					ValidMatches: true,
-					ValidFilters: true,
-				},
-				{
-					BackendRefs: []BackendRef{
-						{
-							SvcNsName: types.NamespacedName{Namespace: "service-ns2", Name: "service2"},
-							Weight:    1,
-						},
-					},
-					ValidMatches: true,
-					ValidFilters: true,
 				},
 			},
-		},
+		}
 	}
 
-	invalidRoute := &L7Route{
-		ParentRefs: []ParentRef{
-			{
-				Attachment: &ParentRefAttachmentStatus{
-					Attached: true,
-				},
-			},
-		},
-		Valid: false,
-		Spec: L7RouteSpec{
-			Rules: []RouteRule{
-				{
-					BackendRefs: []BackendRef{
-						{
-							SvcNsName: types.NamespacedName{Namespace: "service-ns", Name: "service"},
-							Weight:    1,
-						},
-					},
-					ValidMatches: true,
-					ValidFilters: true,
-				},
-			},
-		},
+	getModifiedL4Route := func(mod func(route *L4Route) *L4Route) *L4Route {
+		return mod(getNormalL4Route())
 	}
 
-	unattachedRoute := &L7Route{
-		ParentRefs: []ParentRef{
-			{
-				Attachment: &ParentRefAttachmentStatus{
-					Attached: false,
-				},
-			},
-		},
-		Valid: true,
-		Spec: L7RouteSpec{
-			Rules: []RouteRule{
-				{
-					BackendRefs: []BackendRef{
-						{
-							SvcNsName: types.NamespacedName{Namespace: "service-ns", Name: "service"},
-							Weight:    1,
-						},
-					},
-					ValidMatches: true,
-					ValidFilters: true,
-				},
-			},
-		},
-	}
+	normalRoute := getNormalL7Route()
+	normalL4Route := getNormalL4Route()
 
-	attachedRouteWithManyParentRefs := &L7Route{
-		ParentRefs: []ParentRef{
+	validRouteTwoServicesOneRule := getModifiedL7Route(func(route *L7Route) *L7Route {
+		route.Spec.Rules[0].BackendRefs = []BackendRef{
+			{
+				SvcNsName: types.NamespacedName{Namespace: "service-ns", Name: "service"},
+			},
+			{
+				SvcNsName: types.NamespacedName{Namespace: "service-ns2", Name: "service2"},
+			},
+		}
+
+		return route
+	})
+
+	validRouteTwoServicesTwoRules := getModifiedL7Route(func(route *L7Route) *L7Route {
+		route.Spec.Rules = []RouteRule{
+			{
+				BackendRefs: []BackendRef{
+					{
+						SvcNsName: types.NamespacedName{Namespace: "service-ns", Name: "service"},
+					},
+				},
+			},
+			{
+				BackendRefs: []BackendRef{
+					{
+						SvcNsName: types.NamespacedName{Namespace: "service-ns2", Name: "service2"},
+					},
+				},
+			},
+		}
+
+		return route
+	})
+
+	normalL4Route2 := getModifiedL4Route(func(route *L4Route) *L4Route {
+		route.Spec.BackendRef.SvcNsName = types.NamespacedName{Namespace: "tlsroute-ns", Name: "service2"}
+		return route
+	})
+
+	normalL4RouteWithSameSvcAsL7Route := getModifiedL4Route(func(route *L4Route) *L4Route {
+		route.Spec.BackendRef.SvcNsName = types.NamespacedName{Namespace: "service-ns", Name: "service"}
+		return route
+	})
+
+	invalidRoute := getModifiedL7Route(func(route *L7Route) *L7Route {
+		route.Valid = false
+		return route
+	})
+
+	invalidL4Route := getModifiedL4Route(func(route *L4Route) *L4Route {
+		route.Valid = false
+		return route
+	})
+
+	unattachedRoute := getModifiedL7Route(func(route *L7Route) *L7Route {
+		route.ParentRefs[0].Attachment.Attached = false
+		return route
+	})
+
+	unattachedL4Route := getModifiedL4Route(func(route *L4Route) *L4Route {
+		route.ParentRefs[0].Attachment.Attached = false
+		return route
+	})
+
+	attachedRouteWithManyParentRefs := getModifiedL7Route(func(route *L7Route) *L7Route {
+		route.ParentRefs = []ParentRef{
 			{
 				Attachment: &ParentRefAttachmentStatus{
 					Attached: false,
@@ -165,64 +143,65 @@ func TestBuildReferencedServices(t *testing.T) {
 					Attached: true,
 				},
 			},
-		},
-		Valid: true,
-		Spec: L7RouteSpec{
-			Rules: []RouteRule{
-				{
-					BackendRefs: []BackendRef{
-						{
-							SvcNsName: types.NamespacedName{Namespace: "service-ns", Name: "service"},
-							Weight:    1,
-						},
-					},
-					ValidMatches: true,
-					ValidFilters: true,
+		}
+
+		return route
+	})
+
+	attachedL4RoutesWithManyParentRefs := getModifiedL4Route(func(route *L4Route) *L4Route {
+		route.ParentRefs = []ParentRef{
+			{
+				Attachment: &ParentRefAttachmentStatus{
+					Attached: false,
 				},
 			},
-		},
-	}
-	validRouteNoServiceNsName := &L7Route{
-		ParentRefs: []ParentRef{
 			{
 				Attachment: &ParentRefAttachmentStatus{
 					Attached: true,
 				},
 			},
-		},
-		Valid: true,
-		Spec: L7RouteSpec{
-			Rules: []RouteRule{
-				{
-					BackendRefs: []BackendRef{
-						{
-							Weight: 1,
-						},
-					},
-					ValidMatches: true,
-					ValidFilters: true,
+			{
+				Attachment: &ParentRefAttachmentStatus{
+					Attached: false,
 				},
 			},
-		},
-	}
+		}
+
+		return route
+	})
+
+	validRouteNoServiceNsName := getModifiedL7Route(func(route *L7Route) *L7Route {
+		route.Spec.Rules[0].BackendRefs[0].SvcNsName = types.NamespacedName{}
+		return route
+	})
+
+	validL4RouteNoServiceNsName := getModifiedL4Route(func(route *L4Route) *L4Route {
+		route.Spec.BackendRef.SvcNsName = types.NamespacedName{}
+		return route
+	})
 
 	tests := []struct {
-		routes map[RouteKey]*L7Route
-		exp    map[types.NamespacedName]struct{}
-		name   string
+		l7Routes map[RouteKey]*L7Route
+		l4Routes map[L4RouteKey]*L4Route
+		exp      map[types.NamespacedName]struct{}
+		name     string
 	}{
 		{
-			name: "normal route",
-			routes: map[RouteKey]*L7Route{
+			name: "normal routes",
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "normal-route"}}: normalRoute,
 			},
+			l4Routes: map[L4RouteKey]*L4Route{
+				{NamespacedName: types.NamespacedName{Name: "normal-l4-route"}}: normalL4Route,
+			},
 			exp: map[types.NamespacedName]struct{}{
-				{Namespace: "banana-ns", Name: "service"}: {},
+				{Namespace: "banana-ns", Name: "service"}:   {},
+				{Namespace: "tlsroute-ns", Name: "service"}: {},
 			},
 		},
 		{
-			name: "route with two services in one Rule",
-			routes: map[RouteKey]*L7Route{
+			name: "l7 route with two services in one Rule", // l4 routes don't support multiple services right now
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "two-svc-one-rule"}}: validRouteTwoServicesOneRule,
 			},
 			exp: map[types.NamespacedName]struct{}{
@@ -231,8 +210,8 @@ func TestBuildReferencedServices(t *testing.T) {
 			},
 		},
 		{
-			name: "route with one service per rule",
-			routes: map[RouteKey]*L7Route{
+			name: "route with one service per rule", // l4 routes don't support multiple rules right now
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "one-svc-per-rule"}}: validRouteTwoServicesTwoRules,
 			},
 			exp: map[types.NamespacedName]struct{}{
@@ -241,65 +220,94 @@ func TestBuildReferencedServices(t *testing.T) {
 			},
 		},
 		{
-			name: "two valid routes with same services",
-			routes: map[RouteKey]*L7Route{
+			name: "multiple valid routes with same services",
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "one-svc-per-rule"}}: validRouteTwoServicesTwoRules,
 				{NamespacedName: types.NamespacedName{Name: "two-svc-one-rule"}}: validRouteTwoServicesOneRule,
 			},
+			l4Routes: map[L4RouteKey]*L4Route{
+				{NamespacedName: types.NamespacedName{Name: "l4-route-1"}}:                    normalL4Route,
+				{NamespacedName: types.NamespacedName{Name: "l4-route-2"}}:                    normalL4Route2,
+				{NamespacedName: types.NamespacedName{Name: "l4-route-same-svc-as-l7-route"}}: normalL4RouteWithSameSvcAsL7Route,
+			},
 			exp: map[types.NamespacedName]struct{}{
 				{Namespace: "service-ns", Name: "service"}:   {},
 				{Namespace: "service-ns2", Name: "service2"}: {},
+				{Namespace: "tlsroute-ns", Name: "service"}:  {},
+				{Namespace: "tlsroute-ns", Name: "service2"}: {},
 			},
 		},
 		{
-			name: "two valid routes with different services",
-			routes: map[RouteKey]*L7Route{
+			name: "valid routes with different services",
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "one-svc-per-rule"}}: validRouteTwoServicesTwoRules,
 				{NamespacedName: types.NamespacedName{Name: "normal-route"}}:     normalRoute,
+			},
+			l4Routes: map[L4RouteKey]*L4Route{
+				{NamespacedName: types.NamespacedName{Name: "normal-l4-route"}}: normalL4Route,
 			},
 			exp: map[types.NamespacedName]struct{}{
 				{Namespace: "service-ns", Name: "service"}:   {},
 				{Namespace: "service-ns2", Name: "service2"}: {},
 				{Namespace: "banana-ns", Name: "service"}:    {},
+				{Namespace: "tlsroute-ns", Name: "service"}:  {},
 			},
 		},
 		{
 			name: "invalid routes",
-			routes: map[RouteKey]*L7Route{
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "invalid-route"}}: invalidRoute,
+			},
+			l4Routes: map[L4RouteKey]*L4Route{
+				{NamespacedName: types.NamespacedName{Name: "invalid-l4-route"}}: invalidL4Route,
 			},
 			exp: nil,
 		},
 		{
 			name: "unattached route",
-			routes: map[RouteKey]*L7Route{
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "unattached-route"}}: unattachedRoute,
+			},
+			l4Routes: map[L4RouteKey]*L4Route{
+				{NamespacedName: types.NamespacedName{Name: "unattached-l4-route"}}: unattachedL4Route,
 			},
 			exp: nil,
 		},
 		{
 			name: "combination of valid and invalid routes",
-			routes: map[RouteKey]*L7Route{
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "normal-route"}}:  normalRoute,
 				{NamespacedName: types.NamespacedName{Name: "invalid-route"}}: invalidRoute,
 			},
+			l4Routes: map[L4RouteKey]*L4Route{
+				{NamespacedName: types.NamespacedName{Name: "invalid-l4-route"}}: invalidL4Route,
+				{NamespacedName: types.NamespacedName{Name: "normal-l4-route"}}:  normalL4Route,
+			},
 			exp: map[types.NamespacedName]struct{}{
-				{Namespace: "banana-ns", Name: "service"}: {},
+				{Namespace: "banana-ns", Name: "service"}:   {},
+				{Namespace: "tlsroute-ns", Name: "service"}: {},
 			},
 		},
 		{
 			name: "route with many parentRefs and one is attached",
-			routes: map[RouteKey]*L7Route{
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "multiple-parent-ref-route"}}: attachedRouteWithManyParentRefs,
 			},
+			l4Routes: map[L4RouteKey]*L4Route{
+				{NamespacedName: types.NamespacedName{Name: "multiple-parent-ref-l4-route"}}: attachedL4RoutesWithManyParentRefs,
+			},
 			exp: map[types.NamespacedName]struct{}{
-				{Namespace: "service-ns", Name: "service"}: {},
+				{Namespace: "banana-ns", Name: "service"}:   {},
+				{Namespace: "tlsroute-ns", Name: "service"}: {},
 			},
 		},
 		{
 			name: "valid route no service nsname",
-			routes: map[RouteKey]*L7Route{
+			l7Routes: map[RouteKey]*L7Route{
 				{NamespacedName: types.NamespacedName{Name: "no-service-nsname"}}: validRouteNoServiceNsName,
+			},
+			l4Routes: map[L4RouteKey]*L4Route{
+				{NamespacedName: types.NamespacedName{Name: "no-service-nsname-l4"}}: validL4RouteNoServiceNsName,
 			},
 			exp: nil,
 		},
@@ -308,7 +316,7 @@ func TestBuildReferencedServices(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(buildReferencedServices(test.routes)).To(Equal(test.exp))
+			g.Expect(buildReferencedServices(test.l7Routes, test.l4Routes)).To(Equal(test.exp))
 		})
 	}
 }

--- a/internal/mode/static/state/graph/tlsroute.go
+++ b/internal/mode/static/state/graph/tlsroute.go
@@ -1,0 +1,133 @@
+package graph
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
+	staticConds "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/conditions"
+)
+
+func buildTLSRoute(
+	gtr *v1alpha2.TLSRoute,
+	gatewayNsNames []types.NamespacedName,
+	services map[types.NamespacedName]*apiv1.Service,
+	npCfg *NginxProxy,
+) *L4Route {
+	r := &L4Route{
+		Source: gtr,
+	}
+
+	sectionNameRefs, err := buildSectionNameRefs(gtr.Spec.ParentRefs, gtr.Namespace, gatewayNsNames)
+	if err != nil {
+		r.Valid = false
+
+		return r
+	}
+	// route doesn't belong to any of the Gateways
+	if len(sectionNameRefs) == 0 {
+		return nil
+	}
+	r.ParentRefs = sectionNameRefs
+
+	if err := validateHostnames(
+		gtr.Spec.Hostnames,
+		field.NewPath("spec").Child("hostnames"),
+	); err != nil {
+		r.Valid = false
+		r.Conditions = append(r.Conditions, staticConds.NewRouteUnsupportedValue(err.Error()))
+		return r
+	}
+
+	r.Spec.Hostnames = gtr.Spec.Hostnames
+
+	if len(gtr.Spec.Rules) != 1 || len(gtr.Spec.Rules[0].BackendRefs) != 1 {
+		r.Valid = false
+		cond := staticConds.NewRouteBackendRefUnsupportedValue(
+			"Must have exactly one Rule and BackendRef",
+		)
+		r.Conditions = append(r.Conditions, cond)
+		return r
+	}
+
+	cond, br := validateBackendRefTLSRoute(gtr, services, npCfg)
+
+	r.Spec.BackendRef = br
+	r.Valid = true
+	r.Attachable = true
+
+	if cond != nil {
+		r.Conditions = append(r.Conditions, *cond)
+		r.Valid = false
+	}
+
+	return r
+}
+
+func validateBackendRefTLSRoute(gtr *v1alpha2.TLSRoute,
+	services map[types.NamespacedName]*apiv1.Service,
+	npCfg *NginxProxy,
+) (*conditions.Condition, BackendRef) {
+	// Length of BackendRefs and Rules is guaranteed to be one due to earlier check in buildTLSRoute
+	refPath := field.NewPath("spec").Child("rules").Index(0).Child("backendRefs").Index(0)
+
+	ref := gtr.Spec.Rules[0].BackendRefs[0]
+
+	ns := gtr.Namespace
+	if ref.Namespace != nil {
+		ns = string(*ref.Namespace)
+	}
+
+	svcNsName := types.NamespacedName{
+		Namespace: ns,
+		Name:      string(gtr.Spec.Rules[0].BackendRefs[0].Name),
+	}
+
+	backendRef := BackendRef{
+		Valid: true,
+	}
+	var cond *conditions.Condition
+
+	if ref.Port == nil {
+		valErr := field.Required(refPath.Child("port"), "port cannot be nil")
+		backendRef.Valid = false
+		cond = helpers.GetPointer(staticConds.NewRouteBackendRefUnsupportedValue(valErr.Error()))
+
+		return cond, backendRef
+	}
+
+	svcIPFamily, svcPort, err := getIPFamilyAndPortFromRef(
+		ref,
+		svcNsName,
+		services,
+		refPath,
+	)
+
+	backendRef.ServicePort = svcPort
+	backendRef.SvcNsName = svcNsName
+
+	if err != nil {
+		backendRef.Valid = false
+		cond = helpers.GetPointer(staticConds.NewRouteBackendRefRefBackendNotFound(err.Error()))
+	} else if err := verifyIPFamily(npCfg, svcIPFamily); err != nil {
+		backendRef.Valid = false
+		cond = helpers.GetPointer(staticConds.NewRouteInvalidIPFamily(err.Error()))
+	} else if ref.Group != nil && !(*ref.Group == "core" || *ref.Group == "") {
+		valErr := field.NotSupported(refPath.Child("group"), *ref.Group, []string{"core", ""})
+		backendRef.Valid = false
+		cond = helpers.GetPointer(staticConds.NewRouteBackendRefInvalidKind(valErr.Error()))
+	} else if ref.Kind != nil && *ref.Kind != "Service" {
+		valErr := field.NotSupported(refPath.Child("kind"), *ref.Kind, []string{"Service"})
+		backendRef.Valid = false
+		cond = helpers.GetPointer(staticConds.NewRouteBackendRefInvalidKind(valErr.Error()))
+	} else if ref.Namespace != nil && string(*ref.Namespace) != gtr.Namespace {
+		msg := "Cross-namespace routing is not supported"
+		backendRef.Valid = false
+		cond = helpers.GetPointer(staticConds.NewRouteBackendRefUnsupportedValue(msg))
+	}
+	// FIXME(sarthyparty): Add check for invalid weights, we removed checks to pass the conformance test
+	return cond, backendRef
+}

--- a/internal/mode/static/state/graph/tlsroute_test.go
+++ b/internal/mode/static/state/graph/tlsroute_test.go
@@ -1,0 +1,468 @@
+package graph
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	ngfAPI "github.com/nginxinc/nginx-gateway-fabric/apis/v1alpha1"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/conditions"
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
+	staticConds "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/state/conditions"
+)
+
+func createTLSRoute(
+	hostname gatewayv1.Hostname,
+	rules []v1alpha2.TLSRouteRule,
+	parentRefs []gatewayv1.ParentReference,
+) *v1alpha2.TLSRoute {
+	return &v1alpha2.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "tr",
+		},
+		Spec: v1alpha2.TLSRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: parentRefs,
+			},
+			Hostnames: []gatewayv1.Hostname{hostname},
+			Rules:     rules,
+		},
+	}
+}
+
+func TestBuildTLSRoute(t *testing.T) {
+	parentRef := gatewayv1.ParentReference{
+		Namespace:   helpers.GetPointer[gatewayv1.Namespace]("test"),
+		Name:        "gateway",
+		SectionName: helpers.GetPointer[gatewayv1.SectionName]("l1"),
+	}
+	gatewayNsName := types.NamespacedName{
+		Namespace: "test",
+		Name:      "gateway",
+	}
+	parentRefGraph := ParentRef{
+		SectionName: helpers.GetPointer[gatewayv1.SectionName]("l1"),
+		Gateway:     gatewayNsName,
+	}
+	duplicateParentRefsGtr := createTLSRoute(
+		"hi.example.com",
+		nil,
+		[]gatewayv1.ParentReference{
+			parentRef,
+			parentRef,
+		},
+	)
+	noParentRefsGtr := createTLSRoute(
+		"hi.example.com",
+		nil,
+		[]gatewayv1.ParentReference{},
+	)
+	invalidHostnameGtr := createTLSRoute(
+		"hi....com",
+		nil,
+		[]gatewayv1.ParentReference{
+			parentRef,
+		},
+	)
+	noRulesGtr := createTLSRoute(
+		"app.example.com",
+		nil,
+		[]gatewayv1.ParentReference{
+			parentRef,
+		},
+	)
+	backedRefDNEGtr := createTLSRoute(
+		"app.example.com",
+		[]v1alpha2.TLSRouteRule{
+			{
+				BackendRefs: []gatewayv1.BackendRef{
+					{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: "hi",
+							Port: helpers.GetPointer[gatewayv1.PortNumber](80),
+						},
+					},
+				},
+			},
+		},
+		[]gatewayv1.ParentReference{
+			parentRef,
+		},
+	)
+
+	wrongBackendRefGroupGtr := createTLSRoute(
+		"app.example.com",
+		[]v1alpha2.TLSRouteRule{
+			{
+				BackendRefs: []gatewayv1.BackendRef{
+					{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name:  "hi",
+							Port:  helpers.GetPointer[gatewayv1.PortNumber](80),
+							Group: helpers.GetPointer[gatewayv1.Group]("wrong"),
+						},
+					},
+				},
+			},
+		},
+		[]gatewayv1.ParentReference{
+			parentRef,
+		},
+	)
+
+	wrongBackendRefKindGtr := createTLSRoute(
+		"app.example.com",
+		[]v1alpha2.TLSRouteRule{
+			{
+				BackendRefs: []gatewayv1.BackendRef{
+					{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: "hi",
+							Port: helpers.GetPointer[gatewayv1.PortNumber](80),
+							Kind: helpers.GetPointer[gatewayv1.Kind]("not service"),
+						},
+					},
+				},
+			},
+		},
+		[]gatewayv1.ParentReference{
+			parentRef,
+		},
+	)
+
+	wrongBackendRefNamespaceGtr8 := createTLSRoute("app.example.com",
+		[]v1alpha2.TLSRouteRule{
+			{
+				BackendRefs: []gatewayv1.BackendRef{
+					{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name:      "hi",
+							Port:      helpers.GetPointer[gatewayv1.PortNumber](80),
+							Namespace: helpers.GetPointer[gatewayv1.Namespace]("wrong"),
+						},
+					},
+				},
+			},
+		},
+		[]gatewayv1.ParentReference{
+			parentRef,
+		},
+	)
+
+	portNilBackendRefGtr := createTLSRoute("app.example.com",
+		[]v1alpha2.TLSRouteRule{
+			{
+				BackendRefs: []gatewayv1.BackendRef{
+					{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: "hi",
+						},
+					},
+				},
+			},
+		},
+		[]gatewayv1.ParentReference{
+			parentRef,
+		},
+	)
+
+	ipFamilyMismatchGtr := createTLSRoute(
+		"app.example.com",
+		[]v1alpha2.TLSRouteRule{
+			{
+				BackendRefs: []gatewayv1.BackendRef{
+					{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: "hi",
+							Port: helpers.GetPointer[gatewayv1.PortNumber](80),
+						},
+					},
+				},
+			},
+		},
+		[]gatewayv1.ParentReference{
+			parentRef,
+		},
+	)
+	svcNsName := types.NamespacedName{
+		Namespace: "test",
+		Name:      "hi",
+	}
+
+	svcNsNameWrong := types.NamespacedName{
+		Namespace: "wrong",
+		Name:      "hi",
+	}
+
+	createSvc := func(name string, port int32) *apiv1.Service {
+		return &apiv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+				Name:      name,
+			},
+			Spec: apiv1.ServiceSpec{
+				Ports: []apiv1.ServicePort{
+					{Port: port},
+				},
+			},
+		}
+	}
+
+	badNsSvc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "wrong",
+			Name:      "hi",
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{Port: 80},
+			},
+		},
+	}
+
+	ipv4Svc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "hi",
+		},
+		Spec: apiv1.ServiceSpec{
+			IPFamilies: []apiv1.IPFamily{
+				apiv1.IPv4Protocol,
+			},
+			Ports: []apiv1.ServicePort{
+				{Port: 80},
+			},
+		},
+	}
+
+	tests := []struct {
+		expected       *L4Route
+		gtr            *v1alpha2.TLSRoute
+		services       map[types.NamespacedName]*apiv1.Service
+		name           string
+		gatewayNsNames []types.NamespacedName
+		npCfg          NginxProxy
+	}{
+		{
+			gtr:            duplicateParentRefsGtr,
+			expected:       &L4Route{Source: duplicateParentRefsGtr},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services:       map[types.NamespacedName]*apiv1.Service{},
+			name:           "duplicate parent refs",
+		},
+		{
+			gtr:            noParentRefsGtr,
+			expected:       nil,
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services:       map[types.NamespacedName]*apiv1.Service{},
+			name:           "no parent refs",
+		},
+		{
+			gtr: invalidHostnameGtr,
+			expected: &L4Route{
+				Source:     invalidHostnameGtr,
+				ParentRefs: []ParentRef{parentRefGraph},
+				Conditions: []conditions.Condition{staticConds.NewRouteUnsupportedValue(
+					"spec.hostnames[0]: Invalid value: \"hi....com\": a lowercase RFC 1" +
+						"123 subdomain must consist of lower case alphanumeric characters" +
+						", '-' or '.', and must start and end with an alphanumeric charac" +
+						"ter (e.g. 'example.com', regex used for validation is '[a-z0-9](" +
+						"[-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				)},
+			},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services:       map[types.NamespacedName]*apiv1.Service{},
+			name:           "invalid hostname",
+		},
+		{
+			gtr: noRulesGtr,
+			expected: &L4Route{
+				Source:     noRulesGtr,
+				ParentRefs: []ParentRef{parentRefGraph},
+				Spec: L4RouteSpec{
+					Hostnames: []gatewayv1.Hostname{
+						"app.example.com",
+					},
+				},
+				Conditions: []conditions.Condition{staticConds.NewRouteBackendRefUnsupportedValue(
+					"Must have exactly one Rule and BackendRef",
+				)},
+			},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services:       map[types.NamespacedName]*apiv1.Service{},
+			name:           "invalid rule",
+		},
+		{
+			gtr: backedRefDNEGtr,
+			expected: &L4Route{
+				Source:     backedRefDNEGtr,
+				ParentRefs: []ParentRef{parentRefGraph},
+				Spec: L4RouteSpec{
+					Hostnames: []gatewayv1.Hostname{
+						"app.example.com",
+					},
+					BackendRef: BackendRef{
+						SvcNsName: types.NamespacedName{
+							Namespace: "test",
+							Name:      "hi",
+						},
+					},
+				},
+				Conditions: []conditions.Condition{staticConds.NewRouteBackendRefRefBackendNotFound(
+					"spec.rules[0].backendRefs[0].name: Not found: \"hi\"",
+				)},
+				Attachable: true,
+			},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services:       map[types.NamespacedName]*apiv1.Service{},
+			name:           "BackendRef not found",
+		},
+		{
+			gtr: wrongBackendRefGroupGtr,
+			expected: &L4Route{
+				Source:     wrongBackendRefGroupGtr,
+				ParentRefs: []ParentRef{parentRefGraph},
+				Spec: L4RouteSpec{
+					Hostnames: []gatewayv1.Hostname{
+						"app.example.com",
+					},
+					BackendRef: BackendRef{
+						SvcNsName:   svcNsName,
+						ServicePort: apiv1.ServicePort{Port: 80},
+					},
+				},
+				Conditions: []conditions.Condition{staticConds.NewRouteBackendRefInvalidKind(
+					"spec.rules[0].backendRefs[0].group:" +
+						" Unsupported value: \"wrong\": supported values: \"core\", \"\"",
+				)},
+				Attachable: true,
+			},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services: map[types.NamespacedName]*apiv1.Service{
+				svcNsName: createSvc("hi", 80),
+			},
+			name: "BackendRef group wrong",
+		},
+		{
+			gtr: wrongBackendRefKindGtr,
+			expected: &L4Route{
+				Source:     wrongBackendRefKindGtr,
+				ParentRefs: []ParentRef{parentRefGraph},
+				Spec: L4RouteSpec{
+					Hostnames: []gatewayv1.Hostname{
+						"app.example.com",
+					},
+					BackendRef: BackendRef{
+						SvcNsName:   svcNsName,
+						ServicePort: apiv1.ServicePort{Port: 80},
+					},
+				},
+				Conditions: []conditions.Condition{staticConds.NewRouteBackendRefInvalidKind(
+					"spec.rules[0].backendRefs[0].kind:" +
+						" Unsupported value: \"not service\": supported values: \"Service\"",
+				)},
+				Attachable: true,
+			},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services: map[types.NamespacedName]*apiv1.Service{
+				svcNsName: createSvc("hi", 80),
+			},
+			name: "BackendRef kind wrong",
+		},
+		{
+			gtr: wrongBackendRefNamespaceGtr8,
+			expected: &L4Route{
+				Source:     wrongBackendRefNamespaceGtr8,
+				ParentRefs: []ParentRef{parentRefGraph},
+				Spec: L4RouteSpec{
+					Hostnames: []gatewayv1.Hostname{
+						"app.example.com",
+					},
+					BackendRef: BackendRef{
+						SvcNsName:   svcNsNameWrong,
+						ServicePort: apiv1.ServicePort{Port: 80},
+					},
+				},
+				Conditions: []conditions.Condition{staticConds.NewRouteBackendRefUnsupportedValue(
+					"Cross-namespace routing is not supported",
+				)},
+				Attachable: true,
+			},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services: map[types.NamespacedName]*apiv1.Service{
+				svcNsNameWrong: badNsSvc,
+			},
+			name: "BackendRef namespace wrong",
+		},
+		{
+			gtr: portNilBackendRefGtr,
+			expected: &L4Route{
+				Source:     portNilBackendRefGtr,
+				ParentRefs: []ParentRef{parentRefGraph},
+				Spec: L4RouteSpec{
+					Hostnames: []gatewayv1.Hostname{
+						"app.example.com",
+					},
+					BackendRef: BackendRef{},
+				},
+				Conditions: []conditions.Condition{staticConds.NewRouteBackendRefUnsupportedValue(
+					"spec.rules[0].backendRefs[0].port: Required value: port cannot be nil",
+				)},
+				Attachable: true,
+			},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services: map[types.NamespacedName]*apiv1.Service{
+				svcNsNameWrong: createSvc("hi", 80),
+			},
+			name: "BackendRef port nil",
+		},
+		{
+			gtr: ipFamilyMismatchGtr,
+			expected: &L4Route{
+				Source:     ipFamilyMismatchGtr,
+				ParentRefs: []ParentRef{parentRefGraph},
+				Spec: L4RouteSpec{
+					Hostnames: []gatewayv1.Hostname{
+						"app.example.com",
+					},
+					BackendRef: BackendRef{
+						SvcNsName:   svcNsName,
+						ServicePort: apiv1.ServicePort{Port: 80},
+					},
+				},
+				Conditions: []conditions.Condition{staticConds.NewRouteInvalidIPFamily(
+					"Service configured with IPv4 family but NginxProxy is configured with IPv6",
+				)},
+				Attachable: true,
+			},
+			gatewayNsNames: []types.NamespacedName{gatewayNsName},
+			services: map[types.NamespacedName]*apiv1.Service{
+				svcNsName: ipv4Svc,
+			},
+			name: "service and npcfg ip family mismatch",
+			npCfg: NginxProxy{
+				Source: &ngfAPI.NginxProxy{Spec: ngfAPI.NginxProxySpec{IPFamily: helpers.GetPointer(ngfAPI.IPv6)}},
+				Valid:  true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := buildTLSRoute(
+				test.gtr,
+				test.gatewayNsNames,
+				test.services,
+				&test.npCfg,
+			)
+			g.Expect(helpers.Diff(test.expected, r)).To(BeEmpty())
+		})
+	}
+}

--- a/internal/mode/static/status/status_setters.go
+++ b/internal/mode/static/status/status_setters.go
@@ -101,6 +101,27 @@ func newHTTPRouteStatusSetter(status gatewayv1.HTTPRouteStatus, gatewayCtlrName 
 	}
 }
 
+func newTLSRouteStatusSetter(status v1alpha2.TLSRouteStatus, gatewayCtlrName string) frameworkStatus.Setter {
+	return func(object client.Object) (wasSet bool) {
+		tr := object.(*v1alpha2.TLSRoute)
+
+		// keep all the parent statuses that belong to other controllers
+		for _, os := range tr.Status.Parents {
+			if string(os.ControllerName) != gatewayCtlrName {
+				status.Parents = append(status.Parents, os)
+			}
+		}
+
+		if routeStatusEqual(gatewayCtlrName, tr.Status.Parents, status.Parents) {
+			return false
+		}
+
+		tr.Status = status
+
+		return true
+	}
+}
+
 func newGRPCRouteStatusSetter(status gatewayv1.GRPCRouteStatus, gatewayCtlrName string) frameworkStatus.Setter {
 	return func(object client.Object) (wasSet bool) {
 		gr := object.(*gatewayv1.GRPCRoute)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,17 @@ GW_SVC_GKE_INTERNAL = false
 NGF_VERSION ?= edge## NGF version to be tested
 PULL_POLICY = Never## Pull policy for the images
 PROVISIONER_MANIFEST = conformance/provisioner/provisioner.yaml
-SUPPORTED_FEATURES = HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,GatewayPort8080,HTTPRouteResponseHeaderModification,GRPCExactMethodMatching,GRPCRouteListenerHostnameMatching,GRPCRouteHeaderMatching
+SUPPORTED_EXTENDED_FEATURES = HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,GatewayPort8080,HTTPRouteResponseHeaderModification
+STANDARD_CONFORMANCE_PROFILES = GATEWAY-HTTP,GATEWAY-GRPC
+EXPERIMENTAL_CONFORMANCE_PROFILES = GATEWAY-TLS
+CONFORMANCE_PROFILES = $(STANDARD_CONFORMANCE_PROFILES) # by default we use the standard conformance profiles. If experimental is enabled we override this and add the experimental profiles.
+SKIP_TESTS = TLSRouteInvalidReferenceGrant
+
+# Check if ENABLE_EXPERIMENTAL is true
+ifeq ($(ENABLE_EXPERIMENTAL),true)
+    # If true, add the experimental conformance profiles
+    CONFORMANCE_PROFILES = $(EXPERIMENTAL_CONFORMANCE_PROFILES),$(STANDARD_CONFORMANCE_PROFILES)
+endif
 
 ifneq ($(GINKGO_LABEL),)
 	override GINKGO_FLAGS += --label-filter "$(GINKGO_LABEL)"
@@ -40,7 +50,7 @@ run-conformance-tests: ## Run conformance tests
 		--image=$(CONFORMANCE_PREFIX):$(CONFORMANCE_TAG) --image-pull-policy=Never \
 		--overrides='{ "spec": { "serviceAccountName": "conformance" }	}' \
 		--restart=Never -- sh -c "go test -v . -tags conformance,experimental -args --gateway-class=$(GATEWAY_CLASS) \
-								--supported-features=$(SUPPORTED_FEATURES) --version=$(NGF_VERSION) \
+						        --supported-features=$(SUPPORTED_EXTENDED_FEATURES) --version=$(NGF_VERSION) --skip-tests=$(SKIP_TESTS) --conformance-profiles=$(CONFORMANCE_PROFILES) \
 								--report-output=output.txt; cat output.txt" | tee output.txt
 	./scripts/check-pod-exit-code.sh
 	sed -e '1,/CONFORMANCE PROFILE/d' output.txt > conformance-profile.yaml

--- a/tests/conformance/conformance-rbac.yaml
+++ b/tests/conformance/conformance-rbac.yaml
@@ -39,6 +39,7 @@ rules:
   - grpcroutes
   - referencegrants
   - gatewayclasses
+  - tlsroutes
   verbs:
   - create
   - delete

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/gateway-api/conformance"
 	conf_v1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
@@ -35,9 +34,12 @@ func TestConformance(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Logf(`Running conformance tests with %s GatewayClass\n cleanup: %t\n`+
-		`debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]`,
+		`debug: %t\n enable all features: %t \n supported extended features: [%v]\n exempt features: [%v]\n`+
+		`conformance profiles: [%v]\n skip tests: [%v]`,
 		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug,
-		*flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures)
+		*flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures,
+		*flags.ConformanceProfiles, *flags.SkipTests,
+	)
 
 	opts := conformance.DefaultOptions(t)
 	opts.Implementation = conf_v1.Implementation{
@@ -49,7 +51,6 @@ func TestConformance(t *testing.T) {
 			"https://github.com/nginxinc/nginx-gateway-fabric/discussions/new/choose",
 		},
 	}
-	opts.ConformanceProfiles = sets.New(suite.GatewayHTTPConformanceProfileName, suite.GatewayGRPCConformanceProfileName)
 
 	testSuite, err := suite.NewConformanceTestSuite(opts)
 	g.Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
### Proposed changes

Problem: As a user of NKG, I want to enable TLS Passthrough for my application's endpoints, so that I can achieve end-to-end encryption for my incoming traffic, and so that I do not have to manage certificates at the Gateway.

Solution: Allow users to configure TLS Passthrough for their apps using TLSRoute. Adds basic support for TLSRoute. Cross-namespace routing via ReferenceGrants, traffic splitting, and TLS termination use case will be added in a future release. 

Note that the stream conf volume are always enabled in the deployment.yaml because our nginx conf reads from it. If the file did not exist then nginx will error.

Closes #686 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Add support for TLS Passthrough using TLSRoutes
```
