### PR TITLE
Add server zone metrics

### DIFF
--- a/internal/mode/static/nginx/config/generator.go
+++ b/internal/mode/static/nginx/config/generator.go
@@ -169,12 +169,12 @@ func (g GeneratorImpl) generateHTTPConfig(
 func (g GeneratorImpl) getExecuteFuncs(generator policies.Generator) []executeFunc {
 	return []executeFunc{
 		executeBaseHTTPConfig,
-		newExecuteServersFunc(generator),
+		g.newExecuteServersFunc(generator),
 		g.executeUpstreams,
 		executeSplitClients,
 		executeMaps,
 		executeTelemetry,
-		executeStreamServers,
+		g.executeStreamServers,
 		g.executeStreamUpstreams,
 		executeStreamMaps,
 	}

--- a/internal/mode/static/nginx/config/http/config.go
+++ b/internal/mode/static/nginx/config/http/config.go
@@ -111,6 +111,7 @@ type ProxySSLVerify struct {
 type ServerConfig struct {
 	Servers  []Server
 	IPFamily shared.IPFamily
+	Plus     bool
 }
 
 // Include defines a file that's included via the include directive.

--- a/internal/mode/static/nginx/config/servers.go
+++ b/internal/mode/static/nginx/config/servers.go
@@ -59,18 +59,19 @@ var grpcBaseHeaders = []http.Header{
 	},
 }
 
-func newExecuteServersFunc(generator policies.Generator) executeFunc {
+func (g GeneratorImpl) newExecuteServersFunc(generator policies.Generator) executeFunc {
 	return func(configuration dataplane.Configuration) []executeResult {
-		return executeServers(configuration, generator)
+		return g.executeServers(configuration, generator)
 	}
 }
 
-func executeServers(conf dataplane.Configuration, generator policies.Generator) []executeResult {
+func (g GeneratorImpl) executeServers(conf dataplane.Configuration, generator policies.Generator) []executeResult {
 	servers, httpMatchPairs := createServers(conf.HTTPServers, conf.SSLServers, conf.TLSPassthroughServers, generator)
 
 	serverConfig := http.ServerConfig{
 		Servers:  servers,
 		IPFamily: getIPFamily(conf.BaseHTTPConfig),
+		Plus:     g.plus,
 	}
 
 	serverResult := executeResult{

--- a/internal/mode/static/nginx/config/stream/config.go
+++ b/internal/mode/static/nginx/config/stream/config.go
@@ -5,6 +5,7 @@ import "github.com/nginxinc/nginx-gateway-fabric/internal/mode/static/nginx/conf
 // Server holds all configuration for a stream server.
 type Server struct {
 	Listen     string
+	StatusZone string
 	ProxyPass  string
 	Pass       string
 	SSLPreread bool
@@ -27,4 +28,5 @@ type UpstreamServer struct {
 type ServerConfig struct {
 	Servers  []Server
 	IPFamily shared.IPFamily
+	Plus     bool
 }

--- a/internal/mode/static/nginx/config/stream_servers_template.go
+++ b/internal/mode/static/nginx/config/stream_servers_template.go
@@ -9,6 +9,11 @@ server {
 	{{- if and ($.IPFamily.IPv6) (not $s.IsSocket) }}
     listen [::]:{{ $s.Listen }};
 	{{- end }}
+
+	{{- if $.Plus }}
+    status_zone {{ $s.StatusZone }};
+    {{- end }}
+
 	{{- if $s.ProxyPass }}
     proxy_pass {{ $s.ProxyPass }};
 	{{- end }}


### PR DESCRIPTION
Problem: server_zone metrics were not being emitted for NGINX Plus users

Solution: Add these metrics to the server blocks when running NGINX Plus

Testing: Verified that server_zone metrics show up in Prometheus

Closes #2220 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Added server_zone metrics for NGINX Plus users.
```
