### PR TITLE
Fix flaky unit tests

### DIFF
--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -3520,15 +3520,21 @@ func TestBuildStreamUpstreams(t *testing.T) {
 	}
 
 	fakeResolver := resolverfakes.FakeServiceResolver{}
-	fakeResolver.ResolveReturnsOnCall(0, nil, errors.New("error"))
 	fakeEndpoints := []resolver.Endpoint{
 		{Address: "1.1.1.1", Port: 80},
 	}
-	fakeResolver.ResolveReturnsOnCall(
-		1,
-		fakeEndpoints,
-		nil,
-	)
+
+	fakeResolver.ResolveStub = func(
+		_ context.Context,
+		nsName types.NamespacedName,
+		_ apiv1.ServicePort,
+		_ []discoveryV1.AddressType,
+	) ([]resolver.Endpoint, error) {
+		if nsName == secureAppKey.NamespacedName {
+			return nil, errors.New("error")
+		}
+		return fakeEndpoints, nil
+	}
 
 	streamUpstreams := buildStreamUpstreams(context.Background(), testGraph.Gateway.Listeners, &fakeResolver, Dual)
 

--- a/internal/mode/static/state/graph/policies_test.go
+++ b/internal/mode/static/state/graph/policies_test.go
@@ -918,7 +918,7 @@ func TestProcessPolicies_RouteOverlap(t *testing.T) {
 
 			for _, pol := range processed {
 				g.Expect(pol.Valid).To(Equal(test.valid))
-				g.Expect(pol.Conditions).To(Equal(test.expConditions))
+				g.Expect(pol.Conditions).To(ConsistOf(test.expConditions))
 			}
 		})
 	}


### PR DESCRIPTION
Problem: A couple unit tests were flaky due to the ordering of maps or lists that were being parsed.

Solution: Eliminate the randomness of the results.
