### PR TITLE
Add teardown of NGF to start of reconfiguration performance test

### DIFF
--- a/tests/suite/reconfig_test.go
+++ b/tests/suite/reconfig_test.go
@@ -45,6 +45,9 @@ var _ = Describe("Reconfiguration Performance Testing", Ordered, Label("reconfig
 	)
 
 	BeforeAll(func() {
+		// Reconfiguration tests deploy NGF in the test, so we want to tear down any existing instances.
+		teardown(releaseName)
+
 		resultsDir, err := framework.CreateResultsDir("reconfig", version)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Add teardown of NGF to start of reconfiguration performance test.