### PR TITLE
Remove deprecated linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,11 +53,11 @@ linters:
   enable:
     - asasalint
     - asciicheck
+    - copyloopvar
     - dupword
     - errcheck
     - errname
     - errorlint
-    - exportloopref
     - fatcontext
     - ginkgolinter
     - gocheckcompilerdirectives

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
           - javascript
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.59.1
+    rev: v1.60.2
     hooks:
       - id: golangci-lint-full
         name: golangci-lint-root

--- a/cmd/gateway/commands_test.go
+++ b/cmd/gateway/commands_test.go
@@ -133,7 +133,6 @@ func TestCommonFlagsValidation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name+"_static_mode", func(t *testing.T) {
 			t.Parallel()
 			testFlag(t, createStaticModeCommand(), test)
@@ -387,7 +386,6 @@ func TestStaticModeCmdFlagValidation(t *testing.T) {
 	// common flags validation is tested separately
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			cmd := createStaticModeCommand()
@@ -461,7 +459,6 @@ func TestSleepCmdFlagValidation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			cmd := createSleepCommand()

--- a/cmd/gateway/validation_test.go
+++ b/cmd/gateway/validation_test.go
@@ -52,7 +52,6 @@ func TestValidateGatewayControllerName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -118,7 +117,6 @@ func TestValidateResourceName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -184,7 +182,6 @@ func TestValidateNamespaceName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -249,7 +246,6 @@ func TestParseNamespacedResourceName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -317,7 +313,6 @@ func TestValidateQualifiedName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -382,7 +377,6 @@ func TestValidateURL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -425,7 +419,6 @@ func TestValidateIP(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -495,7 +488,6 @@ func TestValidateEndpoint(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -535,7 +527,6 @@ func TestValidatePort(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/controller/filter/filter_test.go
+++ b/internal/framework/controller/filter/filter_test.go
@@ -51,7 +51,6 @@ func TestCreateSingleResourceFilter(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/controller/index/endpointslice_test.go
+++ b/internal/framework/controller/index/endpointslice_test.go
@@ -43,7 +43,6 @@ func TestServiceNameIndexFunc(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.msg, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/controller/predicate/annotation_test.go
+++ b/internal/framework/controller/predicate/annotation_test.go
@@ -59,7 +59,6 @@ func TestAnnotationPredicate_Create(t *testing.T) {
 	p := AnnotationPredicate{Annotation: annotation}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -215,7 +214,6 @@ func TestAnnotationPredicate_Update(t *testing.T) {
 	p := AnnotationPredicate{Annotation: annotation}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/controller/predicate/service_test.go
+++ b/internal/framework/controller/predicate/service_test.go
@@ -228,7 +228,6 @@ func TestServicePortsChangedPredicate_Update(t *testing.T) {
 	p := ServicePortsChangedPredicate{}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.msg, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -445,7 +444,6 @@ func TestGatewayServicePredicate_Update(t *testing.T) {
 	p := GatewayServicePredicate{NSName: types.NamespacedName{Namespace: "nginx-gateway", Name: "nginx"}}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.msg, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/controller/register_test.go
+++ b/internal/framework/controller/register_test.go
@@ -121,7 +121,6 @@ func TestRegister(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.msg, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/gatewayclass/validate_test.go
+++ b/internal/framework/gatewayclass/validate_test.go
@@ -114,7 +114,6 @@ func TestValidateCRDVersions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/helpers/helpers_test.go
+++ b/internal/framework/helpers/helpers_test.go
@@ -80,7 +80,6 @@ func TestEqualPointers(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/status/conditions_test.go
+++ b/internal/framework/status/conditions_test.go
@@ -111,7 +111,6 @@ func TestConditionsEqual(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/framework/status/updater_retry_test.go
+++ b/internal/framework/status/updater_retry_test.go
@@ -71,7 +71,6 @@ func TestNewRetryUpdateFunc(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -113,8 +113,8 @@ func StartManager(cfg config.Config) error {
 
 	// protectedPorts is the map of ports that may not be configured by a listener, and the name of what it is used for
 	protectedPorts := map[int32]string{
-		int32(cfg.MetricsConfig.Port): "MetricsPort",
-		int32(cfg.HealthConfig.Port):  "HealthPort",
+		int32(cfg.MetricsConfig.Port): "MetricsPort", //nolint:gosec // port will not overflow int32
+		int32(cfg.HealthConfig.Port):  "HealthPort",  //nolint:gosec // port will not overflow int32
 	}
 
 	mustExtractGVK := kinds.NewMustExtractGKV(scheme)

--- a/internal/mode/static/state/graph/gateway_test.go
+++ b/internal/mode/static/state/graph/gateway_test.go
@@ -239,7 +239,7 @@ func TestBuildGateway(t *testing.T) {
 		return v1.Listener{
 			Name:     v1.SectionName(name),
 			Hostname: (*v1.Hostname)(helpers.GetPointer(hostname)),
-			Port:     v1.PortNumber(port),
+			Port:     v1.PortNumber(port), //nolint:gosec // port number will not overflow int32
 			Protocol: protocol,
 			TLS:      tls,
 		}

--- a/internal/mode/static/state/graph/reference_grant_test.go
+++ b/internal/mode/static/state/graph/reference_grant_test.go
@@ -162,7 +162,6 @@ func TestReferenceGrantResolver(t *testing.T) {
 	resolver := newReferenceGrantResolver(refGrants)
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.msg, func(t *testing.T) {
 			t.Parallel()
 
@@ -415,7 +414,6 @@ func TestRefAllowedFrom(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/mode/static/state/graph/tlsroute_test.go
+++ b/internal/mode/static/state/graph/tlsroute_test.go
@@ -551,7 +551,6 @@ func TestBuildTLSRoute(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()

--- a/internal/mode/static/status/prepare_requests.go
+++ b/internal/mode/static/status/prepare_requests.go
@@ -284,7 +284,7 @@ func prepareGatewayRequest(
 		listenerStatuses = append(listenerStatuses, v1.ListenerStatus{
 			Name:           v1.SectionName(l.Name),
 			SupportedKinds: l.SupportedKinds,
-			AttachedRoutes: int32(len(l.Routes)) + int32(len(l.L4Routes)),
+			AttachedRoutes: int32(len(l.Routes)) + int32(len(l.L4Routes)), //nolint:gosec // num routes will not overflow
 			Conditions:     apiConds,
 		})
 	}

--- a/tests/suite/scale_test.go
+++ b/tests/suite/scale_test.go
@@ -736,7 +736,6 @@ var _ = Describe("Zero downtime scale test", Ordered, Label("nfr", "zero-downtim
 		buf := new(bytes.Buffer)
 		encoder := framework.NewVegetaCSVEncoder(buf)
 		for _, res := range results {
-			res := res
 			Expect(encoder.Encode(&res)).To(Succeed())
 		}
 

--- a/tests/suite/upgrade_test.go
+++ b/tests/suite/upgrade_test.go
@@ -162,7 +162,6 @@ var _ = Describe("Upgrade testing", Label("nfr", "upgrade"), func() {
 				buf := new(bytes.Buffer)
 				encoder := framework.NewVegetaCSVEncoder(buf)
 				for _, res := range results {
-					res := res
 					Expect(encoder.Encode(&res)).To(Succeed())
 				}
 


### PR DESCRIPTION
Lint workflow action uses latest golangci-lint version, so we need to fix issues.