### PR TITLE
Fix graceful recovery tests

### DIFF
--- a/tests/framework/timeout.go
+++ b/tests/framework/timeout.go
@@ -32,6 +32,9 @@ type TimeoutConfig struct {
 
 	// GetStatusTimeout represents the maximum time for NGF to update the status of a resource.
 	GetStatusTimeout time.Duration
+
+	// TestForTrafficTimeout represents the maximum time for NGF to test for passing or failing traffic.
+	TestForTrafficTimeout time.Duration
 }
 
 // DefaultTimeoutConfig populates a TimeoutConfig with the default values.
@@ -47,5 +50,6 @@ func DefaultTimeoutConfig() TimeoutConfig {
 		ContainerRestartTimeout: 10 * time.Second,
 		GetLeaderLeaseTimeout:   60 * time.Second,
 		GetStatusTimeout:        60 * time.Second,
+		TestForTrafficTimeout:   60 * time.Second,
 	}
 }

--- a/tests/suite/graceful_recovery_test.go
+++ b/tests/suite/graceful_recovery_test.go
@@ -138,7 +138,7 @@ func runRestartNodeTest(teaURL, coffeeURL string, files []string, ns *core.Names
 			"drain",
 			kindNodeName,
 			"--ignore-daemonsets",
-			"--delete-local-data",
+			"--delete-emptydir-data",
 		).CombinedOutput()
 
 		Expect(err).ToNot(HaveOccurred(), string(output))

--- a/tests/suite/graceful_recovery_test.go
+++ b/tests/suite/graceful_recovery_test.go
@@ -133,17 +133,18 @@ func runRestartNodeTest(teaURL, coffeeURL string, files []string, ns *core.Names
 	}
 
 	if drain {
-		_, err := exec.Command(
+		output, err := exec.Command(
 			"kubectl",
 			"drain",
 			kindNodeName,
 			"--ignore-daemonsets",
 			"--delete-local-data",
 		).CombinedOutput()
-		Expect(err).ToNot(HaveOccurred())
 
-		_, err = exec.Command("kubectl", "delete", "node", kindNodeName).CombinedOutput()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), string(output))
+
+		output, err = exec.Command("kubectl", "delete", "node", kindNodeName).CombinedOutput()
+		Expect(err).ToNot(HaveOccurred(), string(output))
 	}
 
 	_, err = exec.Command("docker", "restart", containerName).CombinedOutput()

--- a/tests/suite/graceful_recovery_test.go
+++ b/tests/suite/graceful_recovery_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Graceful Recovery test", Ordered, Label("graceful-recovery"), 
 			func() error {
 				return checkForWorkingTraffic(teaURL, coffeeURL)
 			}).
-			WithTimeout(timeoutConfig.RequestTimeout * 2).
+			WithTimeout(timeoutConfig.TestForTrafficTimeout).
 			WithPolling(500 * time.Millisecond).
 			Should(Succeed())
 	})
@@ -287,6 +287,7 @@ func checkForFailingTraffic(teaURL, coffeeURL string) error {
 
 func expectRequestToSucceed(appURL, address string, responseBodyMessage string) error {
 	status, body, err := framework.Get(appURL, address, timeoutConfig.RequestTimeout)
+
 	if status != http.StatusOK {
 		return errors.New("http status was not 200")
 	}
@@ -320,7 +321,7 @@ func checkNGFFunctionality(teaURL, coffeeURL, ngfPodName, containerName string, 
 		func() error {
 			return checkForWorkingTraffic(teaURL, coffeeURL)
 		}).
-		WithTimeout(timeoutConfig.RequestTimeout * 2).
+		WithTimeout(timeoutConfig.TestForTrafficTimeout).
 		WithPolling(500 * time.Millisecond).
 		Should(Succeed())
 
@@ -330,7 +331,7 @@ func checkNGFFunctionality(teaURL, coffeeURL, ngfPodName, containerName string, 
 		func() error {
 			return checkForFailingTraffic(teaURL, coffeeURL)
 		}).
-		WithTimeout(timeoutConfig.RequestTimeout).
+		WithTimeout(timeoutConfig.TestForTrafficTimeout).
 		WithPolling(500 * time.Millisecond).
 		Should(Succeed())
 
@@ -341,7 +342,7 @@ func checkNGFFunctionality(teaURL, coffeeURL, ngfPodName, containerName string, 
 		func() error {
 			return checkForWorkingTraffic(teaURL, coffeeURL)
 		}).
-		WithTimeout(timeoutConfig.RequestTimeout * 2).
+		WithTimeout(timeoutConfig.TestForTrafficTimeout).
 		WithPolling(500 * time.Millisecond).
 		Should(Succeed())
 


### PR DESCRIPTION
Fix graceful recovery tests

Problem: Graceful recovery tests were failing in the pipeline

Solutions: 
- Increase timeout when testing for passing/failing traffic after a container or pod restart. The timeout was set to 20 seconds, with a polling interval of 500ms, but the per-request timeout was 10 seconds. This means we were only retrying the request twice when a request timed out because it couldn't connect. Increasing the overall timeout to 60 seconds increased the number of retries and eliminated the errors.
- Remove the `kubectl drain` flag	`--delete-local-data` since it no longer exists and replace it with `--delete-emptydir-data.` See: https://github.com/kubernetes/website/issues/29058. 

Fixes #2429 

Testing: 
- Ran locally multiple times without error
- Ran in pipeline multiple times without error

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork