### PR TITLE
Fix failing image build workflow

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           base-image: ${{ needs.variables.outputs.nginx_version }}
           image: ghcr.io/nginxinc/nginx-gateway-fabric/nginx:${{ needs.variables.outputs.ngf_tag }}
-          platforms: "linux/arm64, linux/amd64"
+          platforms: "linux/arm64,linux/amd64"
 
       - id: needs
         run: echo "needs-updating=${{ steps.update.outputs.needs-updating }}" >> $GITHUB_OUTPUT
@@ -70,7 +70,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       image: nginx
-      platforms: "linux/arm64, linux/amd64"
+      platforms: "linux/arm64,linux/amd64"
       tag: ${{ needs.variables.outputs.ngf_tag }}
     permissions:
       contents: read # for docker/build-push-action to read repo content


### PR DESCRIPTION
Problem: The nightly image build workflow that would update the nginx image was failing.

Solution: Remove whitespace that caused the platform to be evaluated as a command instead of as a parameter.

Issue to fix the action to allow whitespace: https://github.com/lucacome/docker-image-update-checker/issues/39

Testing: Used a local script to verify how the inputs work.

Closes #2279

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
