### PR TITLE
Update SnippetFilter validation rules in enhancement proposal

### DIFF
--- a/docs/proposals/advanced-nginx-extensions.md
+++ b/docs/proposals/advanced-nginx-extensions.md
@@ -460,6 +460,8 @@ In addition, the `ResolvedRefs` condition should be set to `False` with one of t
 These reasons are not defined in the Gateway API library, so they will need to be added and documented.
 In addition, the `Accepted` route condition should be set to `True`.
 
+Refer to [HTTPRouteFilter API](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteFilter) for more implementation details.
+
 #### NGINX Values
 
 An invalid snippet can break NGINX config. When this happens, NGINX will continue to use the last valid configuration.

--- a/docs/proposals/advanced-nginx-extensions.md
+++ b/docs/proposals/advanced-nginx-extensions.md
@@ -445,6 +445,21 @@ one `http` snippet with multiple `http` snippets scattered around in the spec.
 
 NGF will not validate the values of snippets. See the next section.
 
+When a SnippetsFilter is specified in a routing rule and one of the following is true:
+
+- the SnippetsFilter does not exist
+- the SnippetsFilter referenced is invalid
+- the same SnippetsFilter is referenced multiple times
+
+the filter MUST NOT be skipped. Instead, requests that would have been processed by that filter MUST receive a 500 HTTP error code response.
+In addition, the `ResolvedRefs` condition should be set to `False` with one of the following reasons:
+
+- `FilterNotFound`
+- `InvalidFilter`
+
+These reasons are not defined in the Gateway API library, so they will need to be added and documented.
+In addition, the `Accepted` route condition should be set to `True`.
+
 #### NGINX Values
 
 An invalid snippet can break NGINX config. When this happens, NGINX will continue to use the last valid configuration.


### PR DESCRIPTION
### Proposed changes

Problem: The advanced nginx extensions proposal doesn't provide guidance on handling routes that reference invalid or nonexistent SnippetFilters.

Solution: Add guidance on handling these cases to the enhancement proposal. The guidance is based off the Gateway API spec documentation.

Closes #2468 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
None
```
