### PR TITLE
Clean up NFR test result formatting

### DIFF
--- a/.github/workflows/nfr.yml
+++ b/.github/workflows/nfr.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       test_label:
-        description: NFR test to run. Choose between performance, upgrade, scale, or all
+        description: NFR test to run. Choose between a specific test or all tests
         required: true
         default: all
         type: choice
-        options: [performance, upgrade, scale, all]
+        options: [performance, upgrade, scale, zero-downtime-scale, reconfiguration, all]
       version:
         description: Version of NGF under test
         required: true

--- a/tests/suite/reconfig_test.go
+++ b/tests/suite/reconfig_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Cluster node size must be greater than or equal to 4 for test to perform correctly.
-var _ = Describe("Reconfiguration Performance Testing", Ordered, Label("reconfiguration", "nfr"), func() {
+var _ = Describe("Reconfiguration Performance Testing", Ordered, Label("nfr", "reconfiguration"), func() {
 	const (
 		// used for cleaning up resources
 		maxResourceCount = 150
@@ -627,7 +627,6 @@ const reconfigResultTemplate = `
 {{- range .EventsBuckets }}
 	- {{ .Le }}ms: {{ .Val }}
 {{- end }}
-
 `
 
 func writeReconfigResults(dest io.Writer, results reconfigTestResults) error {


### PR DESCRIPTION
Problem: Some results files added extra newlines, causing our formatter to fail. Also, error log files were way too large for feasible parsing.

Solution: Remove extra newlines, and only include error logs instead of full log files.
