### PR TITLE
Don't cancel in progress runs of CLA bot

### DIFF
--- a/.github/workflows/f5-cla.yml
+++ b/.github/workflows/f5-cla.yml
@@ -8,10 +8,10 @@ on:
     types:
       - opened
       - synchronize
+      - reopened
 
 concurrency:
   group: ${{ github.ref_name }}-cla
-  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
### Proposed changes

We have a bot that adds comments to the community PRs and triggers a second run of the workflow right away. This means that the first run that was actually checking the CLA gets canceled and the check doesn't run.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
