### PR TITLE
docs-fix-broken-url

### DIFF
--- a/site/content/includes/installation/expose-nginx-gateway-fabric.md
+++ b/site/content/includes/installation/expose-nginx-gateway-fabric.md
@@ -50,4 +50,4 @@ There are two options for accessing NGINX Gateway Fabric depending on the type o
 
 NGINX Gateway Fabric uses the created service to update the **Addresses** field in the **Gateway Status** resource. Using a **LoadBalancer** service sets this field to the IP address and/or hostname of that service. Without a service, the pod IP address is used.
 
-This gateway is associated with the NGINX Gateway Fabric through the **gatewayClassName** field. The default installation of NGINX Gateway Fabric creates a **GatewayClass** with the name **nginx**. NGINX Gateway Fabric will only configure gateways with a **gatewayClassName** of **nginx** unless you change the name via the `--gatewayclass` [command-line flag](/docs/cli-help.md#static-mode).
+This gateway is associated with the NGINX Gateway Fabric through the **gatewayClassName** field. The default installation of NGINX Gateway Fabric creates a **GatewayClass** with the name **nginx**. NGINX Gateway Fabric will only configure gateways with a **gatewayClassName** of **nginx** unless you change the name via the `--gatewayclass` [command-line flag]({{< relref "reference/cli-help.md#static-mode">}}).


### PR DESCRIPTION
### Proposed changes

Fixing a broken URL in the Documentation. https://docs.nginx.com/nginx-gateway-fabric/installation/installing-ngf/helm/

Problem: The link `command-line flag` in the Nginx Gateway Fabric Docs in here https://docs.nginx.com/nginx-gateway-fabric/installation/installing-ngf/helm/#access-nginx-gateway-fabric is broken. User is returned a 404 page.

Solution: I have updated the link to use the correct path `reference/cli-help.md#static-mode`

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
