### PR TITLE
fix(chart-readme): Use correct indentation in lifecyce.preStop examples

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -191,23 +191,23 @@ being performed on NGF), you may need to configure delayed termination on the NG
 
    ```yaml
     nginxGateway:
-    <...>
-    lifecycle:
-        preStop:
-        exec:
-            command:
-            - /usr/bin/gateway
-            - sleep
-            - --duration=40s # This flag is optional, the default is 30s
+        <...>
+        lifecycle:
+            preStop:
+                exec:
+                    command:
+                    - /usr/bin/gateway
+                    - sleep
+                    - --duration=40s # This flag is optional, the default is 30s
 
     nginx:
-    <...>
-    lifecycle:
-        preStop:
-        exec:
-            command:
-            - /bin/sleep
-            - "40"
+        <...>
+        lifecycle:
+            preStop:
+                exec:
+                    command:
+                    - /bin/sleep
+                    - "40"
    ```
 
 2. Ensure the `terminationGracePeriodSeconds` matches or exceeds the `sleep` value from the `preStopHook` (the default

--- a/charts/nginx-gateway-fabric/README.md.gotmpl
+++ b/charts/nginx-gateway-fabric/README.md.gotmpl
@@ -189,23 +189,23 @@ being performed on NGF), you may need to configure delayed termination on the NG
 
    ```yaml
     nginxGateway:
-    <...>
-    lifecycle:
-        preStop:
-        exec:
-            command:
-            - /usr/bin/gateway
-            - sleep
-            - --duration=40s # This flag is optional, the default is 30s
+        <...>
+        lifecycle:
+            preStop:
+                exec:
+                    command:
+                    - /usr/bin/gateway
+                    - sleep
+                    - --duration=40s # This flag is optional, the default is 30s
 
     nginx:
-    <...>
-    lifecycle:
-        preStop:
-        exec:
-            command:
-            - /bin/sleep
-            - "40"
+        <...>
+        lifecycle:
+            preStop:
+                exec:
+                    command:
+                    - /bin/sleep
+                    - "40"
    ```
 
 2. Ensure the `terminationGracePeriodSeconds` matches or exceeds the `sleep` value from the `preStopHook` (the default


### PR DESCRIPTION
### Proposed changes

**Problem:** The Helm chart example configuration for configuring `lifecycle.preStop` uses a misleading indentation that can confuse users.

**Solution:** Updated the Helm chart's README by fixing the indentation of the example code block to showcase the proper JSON paths of `nginxGateway.lifecycle.preStop.exec.command` and `nginx.lifecycle.preStop.exec.command`. The `PreStop` hook is described as having `exec` as a handler in https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution and https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers.

**Testing:** Successfully deployed this chart into my cluster with the updated paths, but still trying to figure out how to confirm they are set.

### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
NONE
```
