### PR TITLE
Use correct indentation in lifecyce examples

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -191,23 +191,23 @@ being performed on NGF), you may need to configure delayed termination on the NG
 
    ```yaml
     nginxGateway:
-    <...>
-    lifecycle:
-        preStop:
-        exec:
-            command:
-            - /usr/bin/gateway
-            - sleep
-            - --duration=40s # This flag is optional, the default is 30s
+        <...>
+        lifecycle:
+            preStop:
+                exec:
+                    command:
+                    - /usr/bin/gateway
+                    - sleep
+                    - --duration=40s # This flag is optional, the default is 30s
 
     nginx:
-    <...>
-    lifecycle:
-        preStop:
-        exec:
-            command:
-            - /bin/sleep
-            - "40"
+        <...>
+        lifecycle:
+            preStop:
+                exec:
+                    command:
+                    - /bin/sleep
+                    - "40"
    ```
 
 2. Ensure the `terminationGracePeriodSeconds` matches or exceeds the `sleep` value from the `preStopHook` (the default

--- a/charts/nginx-gateway-fabric/README.md.gotmpl
+++ b/charts/nginx-gateway-fabric/README.md.gotmpl
@@ -189,23 +189,23 @@ being performed on NGF), you may need to configure delayed termination on the NG
 
    ```yaml
     nginxGateway:
-    <...>
-    lifecycle:
-        preStop:
-        exec:
-            command:
-            - /usr/bin/gateway
-            - sleep
-            - --duration=40s # This flag is optional, the default is 30s
+        <...>
+        lifecycle:
+            preStop:
+                exec:
+                    command:
+                    - /usr/bin/gateway
+                    - sleep
+                    - --duration=40s # This flag is optional, the default is 30s
 
     nginx:
-    <...>
-    lifecycle:
-        preStop:
-        exec:
-            command:
-            - /bin/sleep
-            - "40"
+        <...>
+        lifecycle:
+            preStop:
+                exec:
+                    command:
+                    - /bin/sleep
+                    - "40"
    ```
 
 2. Ensure the `terminationGracePeriodSeconds` matches or exceeds the `sleep` value from the `preStopHook` (the default


### PR DESCRIPTION
### Proposed changes

**Problem:** The Helm chart example configuration for configuring `lifecycle.preStop` uses a misleading indentation that can confuse users.

**Solution:** Updated the Helm chart's README by fixing the indentation of the example code block to showcase the proper JSON paths of `nginxGateway.lifecycle.preStop.exec.command` and `nginx.lifecycle.preStop.exec.command`. The `PreStop` hook is described as having `exec` as a handler in https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution and https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers.

**Testing:**

Successfully deployed this chart into my cluster with the updated paths:

```
› kubectl -n nginx-gateway get pod -o json | jq '.items[].spec.containers[] | {name, lifecycle}'
{
  "name": "nginx-gateway",
  "lifecycle": {
    "preStop": {
      "exec": {
        "command": [
          "/usr/bin/gateway",
          "sleep",
          "--duration=30s"
        ]
      }
    }
  }
}
{
  "name": "nginx",
  "lifecycle": {
    "preStop": {
      "exec": {
        "command": [
          "/bin/sh",
          "-c",
          "/bin/sleep 30"
        ]
      }
    }
  }
}
```

- [ ] `make unit-test`
- [x] `make lint`
- [x] `make lint-helm`
- [x] `make generate-all`
- [x] `kubectl -n nginx-gateway exec deployment/gateway-nginx-gateway-fabric -c nginx -- nginx -T`

`make unit-test` looks like everything passed except this single failure at the end:

```
PASS
coverage: 57.7% of statements
composite coverage: 93.6% of statements

Ginkgo ran 27 suites in 56.33843625s

There were failures detected in the following suites:
  static ./internal/mode/static

Test Suite Failed
exit status 1
gmake: *** [Makefile:196: unit-test] Error 1
```

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
NONE
```
