### PR TITLE
Fix relative link in docs (#2596)

### DIFF
--- a/site/content/overview/resource-validation.md
+++ b/site/content/overview/resource-validation.md
@@ -52,7 +52,7 @@ More information on CEL in Kubernetes can be found [here](https://kubernetes.io/
 
 This step catches the following cases of invalid values:
 
-- Valid values from the Gateway API perspective but not supported by NGINX Gateway Fabric yet. For example, a feature in an HTTPRoute routing rule. For the list of supported features see [Gateway API Compatibility]({{< relref "/gateway-api-compatibility.md" >}}) doc.
+- Valid values from the Gateway API perspective but not supported by NGINX Gateway Fabric yet. For example, a feature in an HTTPRoute routing rule. For the list of supported features see [Gateway API Compatibility]({{< relref "gateway-api-compatibility.md" >}}) doc.
 - Valid values from the Gateway API perspective, but invalid for NGINX, because NGINX has stricter validation requirements for certain fields. These values will cause NGINX to fail to reload or operate erroneously.
 - Invalid values (both from the Gateway API and NGINX perspectives) that were not rejected because Step 1 was bypassed. Similar to the previous case, these values will cause NGINX to fail to reload or operate erroneously.
 - Malicious values that inject unrestricted NGINX config into the NGINX configuration (similar to an SQL injection attack).


### PR DESCRIPTION
Problem: One of our relative links was incorrect and causing docs to fail to build.

Solution: Fix link.
