### PR TITLE
Reorder release notes labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,12 +15,12 @@ changelog:
     - title: 📦 Helm Chart
       labels:
         - helm-chart
-    - title: 📝 Documentation
-      labels:
-        - documentation
     - title: 🧪 Tests
       labels:
         - tests
+    - title: 📝 Documentation
+      labels:
+        - documentation
     - title: 🧹 Tech debt
       labels:
         - tech-debt


### PR DESCRIPTION
Problem: Many of our test changes also include markdown file changes, and the docs label is prioritized in our release notes over tests. This means that the docs sections of the notes often contained many tests changes.

Solution: Prioritize the test label first over docs to hopefully better organize release notes.
