### PR TITLE
Fix unit tests to avoid data race in pipelines

### DIFF
--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -36,7 +36,7 @@ the [Counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) tool. Counter
 implementations of internal and public interfaces, allowing us to isolate and control dependencies during testing. It
 simplifies the process of mocking and stubbing, making our tests more robust and flexible.
 
-**Parallelize unit tests**:  We use `t.Parallel()` to parallelize all unit tests and subtests, allowing us faster execution. To avoid race conditions, each test and subtest is designed to be independent. If a test cannot be parallelized due to sequential dependencies, a comment stating the reason must be provided.
+**Parallelize unit tests**: In general, all tests should be designed to run in parallel for faster execution and help uncover bugs. For standard Go tests, this requires adding `t.Parallel()` to every test and subtest. Ginkgo tests, on the other hand, automatically run in parallel without the need for additional configuration. If a component under test requires sequential execution, you can run tests sequentially by using an [ordered container](https://onsi.github.io/ginkgo/#ordered-containers) for Ginkgo tests or by omitting `t.Parallel()` from the go test or subtest. In such cases, it’s essential to include a comment explaining why parallel execution is not possible.
 
 By combining BDD style tests, unit tests, and mock generation, we aim to achieve a comprehensive and maintainable
 testing strategy. This approach enables us to ensure the correctness, reliability, and flexibility of our codebase while

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -36,6 +36,8 @@ the [Counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) tool. Counter
 implementations of internal and public interfaces, allowing us to isolate and control dependencies during testing. It
 simplifies the process of mocking and stubbing, making our tests more robust and flexible.
 
+**Parallelize unit tests**:  We use `t.Parallel()` to parallelize all unit tests and subtests, allowing us faster execution. To avoid race conditions, each test and subtest is designed to be independent. If a test cannot be parallelized due to sequential dependencies, a comment stating the reason must be provided.
+
 By combining BDD style tests, unit tests, and mock generation, we aim to achieve a comprehensive and maintainable
 testing strategy. This approach enables us to ensure the correctness, reliability, and flexibility of our codebase while
 promoting efficient refactoring and continuous development.

--- a/internal/mode/static/state/graph/reference_grant_test.go
+++ b/internal/mode/static/state/graph/reference_grant_test.go
@@ -345,63 +345,57 @@ func TestRefAllowedFrom(t *testing.T) {
 		},
 	}
 
-	resolver := newReferenceGrantResolver(refGrants)
-	refAllowedFromGRPCRoute := resolver.refAllowedFrom(fromGRPCRoute(grNs))
-	refAllowedFromHTTPRoute := resolver.refAllowedFrom(fromHTTPRoute(hrNs))
-	refAllowedFromTLSRoute := resolver.refAllowedFrom(fromTLSRoute(trNs))
-	refAllowedFromGateway := resolver.refAllowedFrom(fromGateway(gwNs))
-
 	tests := []struct {
 		name           string
-		refAllowedFrom func(resource toResource) bool
+		refAllowedFrom fromResource
 		toResource     toResource
 		expAllowed     bool
 	}{
 		{
 			name:           "ref allowed from gateway to secret",
-			refAllowedFrom: refAllowedFromGateway,
+			refAllowedFrom: fromGateway(gwNs),
 			toResource:     toSecret(allowedGatewayNsName),
 			expAllowed:     true,
 		},
 		{
 			name:           "ref not allowed from gateway to secret",
-			refAllowedFrom: refAllowedFromGateway,
+			refAllowedFrom: fromGateway(gwNs),
 			toResource:     toSecret(notAllowedNsName),
 			expAllowed:     false,
 		},
 		{
 			name:           "ref allowed from httproute to service",
-			refAllowedFrom: refAllowedFromHTTPRoute,
+			refAllowedFrom: fromHTTPRoute(hrNs),
 			toResource:     toService(allowedHTTPRouteNsName),
 			expAllowed:     true,
 		},
 		{
 			name:           "ref not allowed from httproute to service",
-			refAllowedFrom: refAllowedFromHTTPRoute,
+			refAllowedFrom: fromHTTPRoute(hrNs),
 			toResource:     toService(notAllowedNsName),
 			expAllowed:     false,
 		},
 		{
 			name:           "ref allowed from grpcroute to service",
-			refAllowedFrom: refAllowedFromGRPCRoute,
+			refAllowedFrom: fromGRPCRoute(grNs),
 			toResource:     toService(allowedGRPCRouteNsName),
 			expAllowed:     true,
 		},
 		{
 			name:           "ref not allowed from grpcroute to service",
-			refAllowedFrom: refAllowedFromGRPCRoute,
+			refAllowedFrom: fromGRPCRoute(grNs),
 			toResource:     toService(notAllowedNsName),
 			expAllowed:     false,
 		},
 		{
 			name:           "ref allowed from tlsroute to service",
-			refAllowedFrom: refAllowedFromTLSRoute,
+			refAllowedFrom: fromTLSRoute(trNs),
 			toResource:     toService(allowedTLSRouteNsName),
 			expAllowed:     true,
 		},
 		{
 			name:           "ref not allowed from tlsroute to service",
-			refAllowedFrom: refAllowedFromTLSRoute,
+			refAllowedFrom: fromTLSRoute(trNs),
 			toResource:     toService(notAllowedNsName),
 			expAllowed:     false,
 		},
@@ -411,8 +405,11 @@ func TestRefAllowedFrom(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
+			resolver := newReferenceGrantResolver(refGrants)
+			refAllowed := resolver.refAllowedFrom(test.refAllowedFrom)
+
 			g := NewWithT(t)
-			g.Expect(test.refAllowedFrom(test.toResource)).To(Equal(test.expAllowed))
+			g.Expect(refAllowed(test.toResource)).To(Equal(test.expAllowed))
 		})
 	}
 }


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Users want to parallelize unit tests without having data race issues

Solution: Modify unit tests to be independent of variables, maps/structs to avoid data race when tests run in parallel.

Testing: Manual Testing
1. run `make unit-test` 10-12 times. Passes all the time
2.  run tests 10-12 times in the folder `https://github.com/nginxinc/nginx-gateway-fabric/tree/main/internal/mode/static/state/graph` , where most of the data race failures were happening.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #2569 
Closes #2578 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
