### PR TITLE
Use go test as unit test runner

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,5 @@ coverage:
         informational: true
 comment:
   require_changes: true
+ignore:
+  - "**/fake_*.go"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
             .github/.cache/buster-for-unit-tests
 
       - name: Run Tests
-        run: make unit-test CI=true
+        run: make unit-test
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,6 @@ ifneq (,$(findstring plus,$(MAKECMDGOALS)))
    PLUS_ENABLED = true
 endif
 
-ifeq ($(CI),true)
-	GITHUB_OUTPUT := --github-output
-endif
-
 .PHONY: help
 help: Makefile ## Display this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "; printf "Usage:\n\n	make \033[36m<target>\033[0m [VARIABLE=value...]\n\nTargets:\n\n"}; {printf "	 \033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -191,11 +187,8 @@ lint: ## Run golangci-lint against code
 
 .PHONY: unit-test
 unit-test: ## Run unit tests for the go code
-	# We have to run the tests in the cmd package using `go test` because of a bug with the CLI library cobra. See https://github.com/spf13/cobra/issues/2104.
-	go test -buildvcs ./cmd/... -race -shuffle=on -coverprofile=cmd-coverage.out -covermode=atomic
-	go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --randomize-suites --race --keep-going --fail-on-pending --fail-fast --trace --covermode=atomic --coverprofile=coverage.out --force-newlines $(GITHUB_OUTPUT) -p -v -r internal
+	go test ./cmd/... ./internal/... -buildvcs -race -shuffle=on -coverprofile=coverage.out -covermode=atomic
 	go tool cover -html=coverage.out -o cover.html
-	go tool cover -html=cmd-coverage.out -o cmd-cover.html
 
 .PHONY: njs-unit-test
 njs-unit-test: ## Run unit tests for the njs httpmatches module

--- a/cmd/gateway/commands_test.go
+++ b/cmd/gateway/commands_test.go
@@ -40,21 +40,6 @@ func testFlag(t *testing.T, cmd *cobra.Command, test flagTestCase) {
 	}
 }
 
-/*
-This test cannot be run with ginkgo. Ginkgo reports the following error:
-* Unexpected error:
-*       <*errors.errorString | 0xc0004746b0>:
-*       unknown flag: --test.v
-*       {
-*           s: "unknown flag: --test.v",
-*       }
-*   occurred
-*
-* This is because cobra sets the args of the command to the OS args when args are nil, and adds the testing flags
-* that ginkgo passes to the testing binary as flags on the command. This does not happen with the `go test` flags
-* because those only have one dash (e.g. -test) and are ignored by cobra.
-* See https://github.com/spf13/cobra/issues/2104.
-*/
 func TestRootCmd(t *testing.T) {
 	t.Parallel()
 	testCase := flagTestCase{
@@ -410,21 +395,6 @@ func TestProvisionerModeCmdFlagValidation(t *testing.T) {
 	testFlag(t, createProvisionerModeCommand(), testCase)
 }
 
-/*
-This test cannot be run with ginkgo. Ginkgo reports the following error for the "omitted flag" case:
-* Unexpected error:
-*       <*errors.errorString | 0xc0004746b0>:
-*       unknown flag: --test.v
-*       {
-*           s: "unknown flag: --test.v",
-*       }
-*   occurred
-*
-* This is because cobra sets the args of the command to the OS args when args are nil, and adds the testing flags
-* that ginkgo passes to the testing binary as flags on the command. This does not happen with the `go test` flags
-* because those only have one dash (e.g. -test) and are ignored by cobra.
-* See https://github.com/spf13/cobra/issues/2104.
-*/
 func TestSleepCmdFlagValidation(t *testing.T) {
 	t.Parallel()
 	tests := []flagTestCase{

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,6 +30,10 @@ ifneq ($(GINKGO_LABEL),)
 	override GINKGO_FLAGS += --label-filter "$(GINKGO_LABEL)"
 endif
 
+ifeq ($(CI),true)
+	GITHUB_OUTPUT := --github-output
+endif
+
 .PHONY: update-go-modules
 update-go-modules: ## Update the gateway-api go modules to latest main version
 	go get -u sigs.k8s.io/gateway-api@main


### PR DESCRIPTION
Problem: Switching to using ginkgo as the test runner caused some issues with verbose output and difficulty finding test failures. This could also be exacerbated by the fact that we mix standard go test style with ginkgo framework tests.

Solution: For now, switch back to using go test as the runner, since the output is cleaner and easier to find errors.

Closes #2584

Future work: https://github.com/nginxinc/nginx-gateway-fabric/issues/2612

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
