### PR TITLE
Use NGF logger in client-go library

### DIFF
--- a/cmd/gateway/commands.go
+++ b/cmd/gateway/commands.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	ctlrZap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -125,6 +126,8 @@ func createStaticModeCommand() *cobra.Command {
 			atom := zap.NewAtomicLevel()
 
 			logger := ctlrZap.New(ctlrZap.Level(atom))
+			klog.SetLogger(logger)
+
 			commit, date, dirty := getBuildInfo()
 			logger.Info(
 				"Starting NGINX Gateway Fabric in static mode",

--- a/docs/developer/logging-guidelines.md
+++ b/docs/developer/logging-guidelines.md
@@ -383,6 +383,7 @@ There are two critical libraries for NGF that log:
       of that project.
 - [client-go](https://github.com/kubernetes/client-go).
   - It uses [klog](https://github.com/kubernetes/klog) for logging.
+  - We inject the above logger into klog to ensure it uses the same formatting.
   - Most of the logging is done at increased klog-specific
       verbosity. However, errors are logged at the default verbosity like
       in [this line](https://github.com/kubernetes/client-go/blob/c5b1c13ccbedeb03c00ba162ef27566b0dfb512d/tools/record/event.go#L240).

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
+	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/gateway-api v1.1.0
 )
@@ -89,7 +90,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240423202451-8948a665c108 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect


### PR DESCRIPTION
Problem: The klog logger used by client-go has different formatting than the NGF loggers.

Solution: Set the klog logger to wrap the NGF logger and therefore use the same formatting.

Testing: Verified that client-go log messages now fit our formatting.

Closes #1101

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
