### PR TITLE
Support IP and Hostname trusted addresses

### DIFF
--- a/apis/v1alpha1/nginxproxy_types.go
+++ b/apis/v1alpha1/nginxproxy_types.go
@@ -27,20 +27,6 @@ type NginxProxyList struct {
 	Items           []NginxProxy `json:"items"`
 }
 
-// IPFamilyType specifies the IP family to be used by NGINX.
-//
-// +kubebuilder:validation:Enum=dual;ipv4;ipv6
-type IPFamilyType string
-
-const (
-	// Dual specifies that NGINX will use both IPv4 and IPv6.
-	Dual IPFamilyType = "dual"
-	// IPv4 specifies that NGINX will use only IPv4.
-	IPv4 IPFamilyType = "ipv4"
-	// IPv6 specifies that NGINX will use only IPv6.
-	IPv6 IPFamilyType = "ipv6"
-)
-
 // NginxProxySpec defines the desired state of the NginxProxy.
 type NginxProxySpec struct {
 	// IPFamily specifies the IP family to be used by the NGINX.
@@ -154,11 +140,11 @@ type RewriteClientIP struct {
 	// If no addresses are provided, NGINX will not rewrite the client IP information.
 	// Sets NGINX directive set_real_ip_from: https://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
 	// This field is required if mode is set.
-	// +kubebuilder:validation:MaxItems=16
-	// +listType=map
-	// +listMapKey=type
 	//
 	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=16
 	TrustedAddresses []Address `json:"trustedAddresses,omitempty"`
 }
 
@@ -179,27 +165,40 @@ const (
 	RewriteClientIPModeXForwardedFor RewriteClientIPModeType = "XForwardedFor"
 )
 
+// IPFamilyType specifies the IP family to be used by NGINX.
+//
+// +kubebuilder:validation:Enum=dual;ipv4;ipv6
+type IPFamilyType string
+
+const (
+	// Dual specifies that NGINX will use both IPv4 and IPv6.
+	Dual IPFamilyType = "dual"
+	// IPv4 specifies that NGINX will use only IPv4.
+	IPv4 IPFamilyType = "ipv4"
+	// IPv6 specifies that NGINX will use only IPv6.
+	IPv6 IPFamilyType = "ipv6"
+)
+
 // Address is a struct that specifies address type and value.
 type Address struct {
 	// Type specifies the type of address.
-	// Default is "cidr" which specifies that the address is a CIDR block.
-	//
-	// +optional
-	// +kubebuilder:default:=cidr
-	Type AddressType `json:"type,omitempty"`
+	Type AddressType `json:"type"`
 
 	// Value specifies the address value.
-	//
-	// +optional
-	Value string `json:"value,omitempty"`
+	Value string `json:"value"`
 }
 
 // AddressType specifies the type of address.
-// +kubebuilder:validation:Enum=cidr
+// +kubebuilder:validation:Enum=CIDR;IPAddress;Hostname
 type AddressType string
 
 const (
-	// AddressTypeCIDR specifies that the address is a CIDR block.
-	// kubebuilder:validation:Pattern=`^[\.a-zA-Z0-9:]*(\/([0-9]?[0-9]?[0-9]))$`
-	AddressTypeCIDR AddressType = "cidr"
+	// CIDRAddressType specifies that the address is a CIDR block.
+	CIDRAddressType AddressType = "CIDR"
+
+	// IPAddressType specifies that the address is an IP address.
+	IPAddressType AddressType = "IPAddress"
+
+	// HostnameAddressType specifies that the address is a Hostname.
+	HostnameAddressType AddressType = "Hostname"
 )

--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -73,6 +73,47 @@
               "required": [],
               "type": "string"
             },
+            "rewriteClientIP": {
+              "description": "RewriteClientIP defines configuration for rewriting the client IP to the original client's IP.",
+              "properties": {
+                "mode": {
+                  "enum": [
+                    "ProxyProtocol",
+                    "XForwardedFor"
+                  ],
+                  "required": [],
+                  "type": "string"
+                },
+                "setIPRecursively": {
+                  "required": [],
+                  "type": "boolean"
+                },
+                "trustedAddresses": {
+                  "items": {
+                    "properties": {
+                      "type": {
+                        "enum": [
+                          "CIDR",
+                          "IPAddress",
+                          "Hostname"
+                        ],
+                        "required": [],
+                        "type": "string"
+                      },
+                      "value": {
+                        "required": [],
+                        "type": "string"
+                      }
+                    },
+                    "required": []
+                  },
+                  "required": [],
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
             "telemetry": {
               "description": "Telemetry specifies the OpenTelemetry configuration.",
               "properties": {

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -142,6 +142,29 @@ nginx:
   #       - ipv4
   #       - ipv6
   #       - dual
+  #   rewriteClientIP:
+  #     type: object
+  #     description: RewriteClientIP defines configuration for rewriting the client IP to the original client's IP.
+  #     properties:
+  #       mode:
+  #         type: string
+  #         enum:
+  #           - ProxyProtocol
+  #           - XForwardedFor
+  #       setIPRecursively:
+  #         type: boolean
+  #       trustedAddresses:
+  #         type: array
+  #         items:
+  #           properties:
+  #             type:
+  #               type: string
+  #               enum:
+  #                 - CIDR
+  #                 - IPAddress
+  #                 - Hostname
+  #             value:
+  #               type: string
   #   telemetry:
   #     type: object
   #     description: Telemetry specifies the OpenTelemetry configuration.

--- a/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
+++ b/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
@@ -105,16 +105,18 @@ spec:
                         and value.
                       properties:
                         type:
-                          default: cidr
-                          description: |-
-                            Type specifies the type of address.
-                            Default is "cidr" which specifies that the address is a CIDR block.
+                          description: Type specifies the type of address.
                           enum:
-                          - cidr
+                          - CIDR
+                          - IPAddress
+                          - Hostname
                           type: string
                         value:
                           description: Value specifies the address value.
                           type: string
+                      required:
+                      - type
+                      - value
                       type: object
                     maxItems: 16
                     type: array

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -690,16 +690,18 @@ spec:
                         and value.
                       properties:
                         type:
-                          default: cidr
-                          description: |-
-                            Type specifies the type of address.
-                            Default is "cidr" which specifies that the address is a CIDR block.
+                          description: Type specifies the type of address.
                           enum:
-                          - cidr
+                          - CIDR
+                          - IPAddress
+                          - Hostname
                           type: string
                         value:
                           description: Value specifies the address value.
                           type: string
+                      required:
+                      - type
+                      - value
                       type: object
                     maxItems: 16
                     type: array

--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -2201,7 +2201,7 @@ func TestBuildConfiguration(t *testing.T) {
 								SetIPRecursively: helpers.GetPointer(true),
 								TrustedAddresses: []ngfAPI.Address{
 									{
-										Type:  ngfAPI.AddressTypeCIDR,
+										Type:  ngfAPI.CIDRAddressType,
 										Value: "1.1.1.1/32",
 									},
 								},
@@ -3651,7 +3651,7 @@ func TestBuildRewriteIPSettings(t *testing.T) {
 								Mode: helpers.GetPointer(ngfAPI.RewriteClientIPModeProxyProtocol),
 								TrustedAddresses: []ngfAPI.Address{
 									{
-										Type:  ngfAPI.AddressTypeCIDR,
+										Type:  ngfAPI.CIDRAddressType,
 										Value: "10.9.9.4/32",
 									},
 								},
@@ -3678,7 +3678,7 @@ func TestBuildRewriteIPSettings(t *testing.T) {
 								Mode: helpers.GetPointer(ngfAPI.RewriteClientIPModeXForwardedFor),
 								TrustedAddresses: []ngfAPI.Address{
 									{
-										Type:  ngfAPI.AddressTypeCIDR,
+										Type:  ngfAPI.CIDRAddressType,
 										Value: "76.89.90.11/24",
 									},
 								},
@@ -3705,19 +3705,19 @@ func TestBuildRewriteIPSettings(t *testing.T) {
 								Mode: helpers.GetPointer(ngfAPI.RewriteClientIPModeXForwardedFor),
 								TrustedAddresses: []ngfAPI.Address{
 									{
-										Type:  ngfAPI.AddressTypeCIDR,
+										Type:  ngfAPI.CIDRAddressType,
 										Value: "5.5.5.5/12",
 									},
 									{
-										Type:  ngfAPI.AddressTypeCIDR,
+										Type:  ngfAPI.CIDRAddressType,
 										Value: "1.1.1.1/26",
 									},
 									{
-										Type:  ngfAPI.AddressTypeCIDR,
+										Type:  ngfAPI.CIDRAddressType,
 										Value: "2.2.2.2/32",
 									},
 									{
-										Type:  ngfAPI.AddressTypeCIDR,
+										Type:  ngfAPI.CIDRAddressType,
 										Value: "3.3.3.3/24",
 									},
 								},

--- a/site/content/reference/api.md
+++ b/site/content/reference/api.md
@@ -495,9 +495,7 @@ AddressType
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>Type specifies the type of address.
-Default is &ldquo;cidr&rdquo; which specifies that the address is a CIDR block.</p>
+<p>Type specifies the type of address.</p>
 </td>
 </tr>
 <tr>
@@ -508,7 +506,6 @@ string
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Value specifies the address value.</p>
 </td>
 </tr>
@@ -531,9 +528,14 @@ string
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;cidr&#34;</p></td>
-<td><p>AddressTypeCIDR specifies that the address is a CIDR block.
-kubebuilder:validation:Pattern=<code>^[\.a-zA-Z0-9:]*(\/([0-9]?[0-9]?[0-9]))$</code></p>
+<tbody><tr><td><p>&#34;CIDR&#34;</p></td>
+<td><p>CIDRAddressType specifies that the address is a CIDR block.</p>
+</td>
+</tr><tr><td><p>&#34;Hostname&#34;</p></td>
+<td><p>HostnameAddressType specifies that the address is a Hostname.</p>
+</td>
+</tr><tr><td><p>&#34;IPAddress&#34;</p></td>
+<td><p>IPAddressType specifies that the address is an IP address.</p>
 </td>
 </tr></tbody>
 </table>


### PR DESCRIPTION
Problem: Our initial implementation of rewriting client IP only supported CIDRs for the trusted addresses field.

Solution: Add support for IP addresses and hostnames

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
