### PR TITLE
Add init container for setting up base config

### DIFF
--- a/charts/nginx-gateway-fabric/templates/deployment.yaml
+++ b/charts/nginx-gateway-fabric/templates/deployment.yaml
@@ -29,6 +29,33 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      initContainers:
+      - name: copy-nginx-config
+        image: {{ .Values.nginxGateway.image.repository }}:{{ default .Chart.AppVersion .Values.nginxGateway.image.tag }}
+        imagePullPolicy: {{ .Values.nginxGateway.image.pullPolicy }}
+        command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            add:
+            - KILL # Set because the binary has CAP_KILL for the main controller process. Not used by init.
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsUser: 102
+          runAsGroup: 1001
+        volumeMounts:
+        - name: nginx-includes-configmap
+          mountPath: /includes
+        - name: nginx-main-includes
+          mountPath: /etc/nginx/main-includes
       containers:
       - args:
         - static-mode
@@ -223,6 +250,9 @@ spec:
         emptyDir: {}
       - name: nginx-includes
         emptyDir: {}
+      - name: nginx-includes-configmap
+        configMap:
+          name: nginx-includes
       {{- with .Values.extraVolumes -}}
       {{ toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/nginx-gateway-fabric/templates/include-configmap.yaml
+++ b/charts/nginx-gateway-fabric/templates/include-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-includes
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "nginx-gateway.labels" . | nindent 4 }}
+data:
+  main.conf: |
+    {{- if and .Values.nginx.config .Values.nginx.config.logging .Values.nginx.config.logging.errorLevel }}
+    error_log stderr {{ .Values.nginx.config.logging.errorLevel }};
+    {{ else }}
+    error_log stderr info;
+    {{- end }}

--- a/charts/nginx-gateway-fabric/templates/scc.yaml
+++ b/charts/nginx-gateway-fabric/templates/scc.yaml
@@ -32,6 +32,7 @@ seccompProfiles:
 volumes:
 - emptyDir
 - secret
+- configMap
 users:
 - {{ printf "system:serviceaccount:%s:%s" .Release.Namespace (include "nginx-gateway.serviceAccountName" .) }}
 allowedCapabilities:

--- a/cmd/gateway/commands_test.go
+++ b/cmd/gateway/commands_test.go
@@ -437,6 +437,51 @@ func TestSleepCmdFlagValidation(t *testing.T) {
 	}
 }
 
+func TestCopyCmdFlagValidation(t *testing.T) {
+	t.Parallel()
+	tests := []flagTestCase{
+		{
+			name: "valid flags",
+			args: []string{
+				"--source=/my/file",
+				"--destination=dest/file",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "omitted flags",
+			args:    nil,
+			wantErr: false,
+		},
+		{
+			name: "source set without destination",
+			args: []string{
+				"--source=/my/file",
+			},
+			wantErr: true,
+			expectedErrPrefix: "if any flags in the group [source destination] are set they must all be set; " +
+				"missing [destination]",
+		},
+		{
+			name: "destination set without source",
+			args: []string{
+				"--destination=/dest/file",
+			},
+			wantErr: true,
+			expectedErrPrefix: "if any flags in the group [source destination] are set they must all be set; " +
+				"missing [source]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := createCopyCommand()
+			testFlag(t, cmd, test)
+		})
+	}
+}
+
 func TestParseFlags(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -23,6 +23,7 @@ func main() {
 	rootCmd.AddCommand(
 		createStaticModeCommand(),
 		createProvisionerModeCommand(),
+		createCopyCommand(),
 		createSleepCommand(),
 	)
 

--- a/config/tests/static-deployment.yaml
+++ b/config/tests/static-deployment.yaml
@@ -21,6 +21,33 @@ spec:
         app.kubernetes.io/name: nginx-gateway
         app.kubernetes.io/instance: nginx-gateway
     spec:
+      initContainers:
+      - name: copy-nginx-config
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            add:
+            - KILL # Set because the binary has CAP_KILL for the main controller process. Not used by init.
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsUser: 102
+          runAsGroup: 1001
+        volumeMounts:
+        - name: nginx-includes-configmap
+          mountPath: /includes
+        - name: nginx-main-includes
+          mountPath: /etc/nginx/main-includes
       containers:
       - args:
         - static-mode
@@ -137,3 +164,6 @@ spec:
         emptyDir: {}
       - name: nginx-includes
         emptyDir: {}
+      - name: nginx-includes-configmap
+        configMap:
+          name: nginx-includes

--- a/deploy/aws-nlb/deploy.yaml
+++ b/deploy/aws-nlb/deploy.yaml
@@ -143,6 +143,19 @@ subjects:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+data:
+  main.conf: |
+    error_log stderr info;
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: nginx-gateway
+    app.kubernetes.io/name: nginx-gateway
+    app.kubernetes.io/version: edge
+  name: nginx-includes
+  namespace: nginx-gateway
+---
+apiVersion: v1
 kind: Service
 metadata:
   annotations:
@@ -290,6 +303,33 @@ spec:
           name: nginx-cache
         - mountPath: /etc/nginx/includes
           name: nginx-includes
+      initContainers:
+      - command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        name: copy-nginx-config
+        securityContext:
+          capabilities:
+            add:
+            - KILL
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsUser: 102
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /includes
+          name: nginx-includes-configmap
+        - mountPath: /etc/nginx/main-includes
+          name: nginx-main-includes
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true
@@ -311,6 +351,9 @@ spec:
         name: nginx-cache
       - emptyDir: {}
         name: nginx-includes
+      - configMap:
+          name: nginx-includes
+        name: nginx-includes-configmap
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/azure/deploy.yaml
+++ b/deploy/azure/deploy.yaml
@@ -143,6 +143,19 @@ subjects:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+data:
+  main.conf: |
+    error_log stderr info;
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: nginx-gateway
+    app.kubernetes.io/name: nginx-gateway
+    app.kubernetes.io/version: edge
+  name: nginx-includes
+  namespace: nginx-gateway
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -287,6 +300,33 @@ spec:
           name: nginx-cache
         - mountPath: /etc/nginx/includes
           name: nginx-includes
+      initContainers:
+      - command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        name: copy-nginx-config
+        securityContext:
+          capabilities:
+            add:
+            - KILL
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsUser: 102
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /includes
+          name: nginx-includes-configmap
+        - mountPath: /etc/nginx/main-includes
+          name: nginx-main-includes
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -310,6 +350,9 @@ spec:
         name: nginx-cache
       - emptyDir: {}
         name: nginx-includes
+      - configMap:
+          name: nginx-includes
+        name: nginx-includes-configmap
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/default/deploy.yaml
+++ b/deploy/default/deploy.yaml
@@ -143,6 +143,19 @@ subjects:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+data:
+  main.conf: |
+    error_log stderr info;
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: nginx-gateway
+    app.kubernetes.io/name: nginx-gateway
+    app.kubernetes.io/version: edge
+  name: nginx-includes
+  namespace: nginx-gateway
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -287,6 +300,33 @@ spec:
           name: nginx-cache
         - mountPath: /etc/nginx/includes
           name: nginx-includes
+      initContainers:
+      - command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        name: copy-nginx-config
+        securityContext:
+          capabilities:
+            add:
+            - KILL
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsUser: 102
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /includes
+          name: nginx-includes-configmap
+        - mountPath: /etc/nginx/main-includes
+          name: nginx-main-includes
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true
@@ -308,6 +348,9 @@ spec:
         name: nginx-cache
       - emptyDir: {}
         name: nginx-includes
+      - configMap:
+          name: nginx-includes
+        name: nginx-includes-configmap
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/experimental-nginx-plus/deploy.yaml
+++ b/deploy/experimental-nginx-plus/deploy.yaml
@@ -156,6 +156,19 @@ subjects:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+data:
+  main.conf: |
+    error_log stderr info;
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: nginx-gateway
+    app.kubernetes.io/name: nginx-gateway
+    app.kubernetes.io/version: edge
+  name: nginx-includes
+  namespace: nginx-gateway
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -302,6 +315,33 @@ spec:
           name: nginx-cache
         - mountPath: /etc/nginx/includes
           name: nginx-includes
+      initContainers:
+      - command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        name: copy-nginx-config
+        securityContext:
+          capabilities:
+            add:
+            - KILL
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsUser: 102
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /includes
+          name: nginx-includes-configmap
+        - mountPath: /etc/nginx/main-includes
+          name: nginx-main-includes
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true
@@ -323,6 +363,9 @@ spec:
         name: nginx-cache
       - emptyDir: {}
         name: nginx-includes
+      - configMap:
+          name: nginx-includes
+        name: nginx-includes-configmap
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/experimental/deploy.yaml
+++ b/deploy/experimental/deploy.yaml
@@ -148,6 +148,19 @@ subjects:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+data:
+  main.conf: |
+    error_log stderr info;
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: nginx-gateway
+    app.kubernetes.io/name: nginx-gateway
+    app.kubernetes.io/version: edge
+  name: nginx-includes
+  namespace: nginx-gateway
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -293,6 +306,33 @@ spec:
           name: nginx-cache
         - mountPath: /etc/nginx/includes
           name: nginx-includes
+      initContainers:
+      - command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        name: copy-nginx-config
+        securityContext:
+          capabilities:
+            add:
+            - KILL
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsUser: 102
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /includes
+          name: nginx-includes-configmap
+        - mountPath: /etc/nginx/main-includes
+          name: nginx-main-includes
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true
@@ -314,6 +354,9 @@ spec:
         name: nginx-cache
       - emptyDir: {}
         name: nginx-includes
+      - configMap:
+          name: nginx-includes
+        name: nginx-includes-configmap
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/nginx-plus/deploy.yaml
+++ b/deploy/nginx-plus/deploy.yaml
@@ -151,6 +151,19 @@ subjects:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+data:
+  main.conf: |
+    error_log stderr info;
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: nginx-gateway
+    app.kubernetes.io/name: nginx-gateway
+    app.kubernetes.io/version: edge
+  name: nginx-includes
+  namespace: nginx-gateway
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -298,6 +311,33 @@ spec:
           name: nginx-cache
         - mountPath: /etc/nginx/includes
           name: nginx-includes
+      initContainers:
+      - command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        name: copy-nginx-config
+        securityContext:
+          capabilities:
+            add:
+            - KILL
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsUser: 102
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /includes
+          name: nginx-includes-configmap
+        - mountPath: /etc/nginx/main-includes
+          name: nginx-main-includes
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true
@@ -319,6 +359,9 @@ spec:
         name: nginx-cache
       - emptyDir: {}
         name: nginx-includes
+      - configMap:
+          name: nginx-includes
+        name: nginx-includes-configmap
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/nodeport/deploy.yaml
+++ b/deploy/nodeport/deploy.yaml
@@ -143,6 +143,19 @@ subjects:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+data:
+  main.conf: |
+    error_log stderr info;
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: nginx-gateway
+    app.kubernetes.io/name: nginx-gateway
+    app.kubernetes.io/version: edge
+  name: nginx-includes
+  namespace: nginx-gateway
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -287,6 +300,33 @@ spec:
           name: nginx-cache
         - mountPath: /etc/nginx/includes
           name: nginx-includes
+      initContainers:
+      - command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        name: copy-nginx-config
+        securityContext:
+          capabilities:
+            add:
+            - KILL
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsUser: 102
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /includes
+          name: nginx-includes-configmap
+        - mountPath: /etc/nginx/main-includes
+          name: nginx-main-includes
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true
@@ -308,6 +348,9 @@ spec:
         name: nginx-cache
       - emptyDir: {}
         name: nginx-includes
+      - configMap:
+          name: nginx-includes
+        name: nginx-includes-configmap
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -151,6 +151,19 @@ subjects:
   namespace: nginx-gateway
 ---
 apiVersion: v1
+data:
+  main.conf: |
+    error_log stderr info;
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: nginx-gateway
+    app.kubernetes.io/name: nginx-gateway
+    app.kubernetes.io/version: edge
+  name: nginx-includes
+  namespace: nginx-gateway
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -295,6 +308,33 @@ spec:
           name: nginx-cache
         - mountPath: /etc/nginx/includes
           name: nginx-includes
+      initContainers:
+      - command:
+        - /usr/bin/gateway
+        - copy
+        - --source
+        - /includes/main.conf
+        - --destination
+        - /etc/nginx/main-includes/main.conf
+        image: ghcr.io/nginxinc/nginx-gateway-fabric:edge
+        imagePullPolicy: Always
+        name: copy-nginx-config
+        securityContext:
+          capabilities:
+            add:
+            - KILL
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsUser: 102
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /includes
+          name: nginx-includes-configmap
+        - mountPath: /etc/nginx/main-includes
+          name: nginx-main-includes
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true
@@ -316,6 +356,9 @@ spec:
         name: nginx-cache
       - emptyDir: {}
         name: nginx-includes
+      - configMap:
+          name: nginx-includes
+        name: nginx-includes-configmap
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
@@ -381,3 +424,4 @@ users:
 volumes:
 - emptyDir
 - secret
+- configMap

--- a/internal/mode/static/handler_test.go
+++ b/internal/mode/static/handler_test.go
@@ -155,7 +155,7 @@ var _ = Describe("eventHandler", func() {
 
 				handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
 
-				dcfg := dataplane.GetDefaultConfiguration(1)
+				dcfg := dataplane.GetDefaultConfiguration(&graph.Graph{}, 1)
 
 				checkUpsertEventExpectations(e)
 				expectReconfig(dcfg, fakeCfgFiles)
@@ -171,7 +171,7 @@ var _ = Describe("eventHandler", func() {
 
 				handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
 
-				dcfg := dataplane.GetDefaultConfiguration(1)
+				dcfg := dataplane.GetDefaultConfiguration(&graph.Graph{}, 1)
 
 				checkDeleteEventExpectations(e)
 				expectReconfig(dcfg, fakeCfgFiles)
@@ -195,7 +195,7 @@ var _ = Describe("eventHandler", func() {
 
 				handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
 
-				dcfg := dataplane.GetDefaultConfiguration(2)
+				dcfg := dataplane.GetDefaultConfiguration(&graph.Graph{}, 2)
 				Expect(helpers.Diff(handler.GetLatestConfiguration(), &dcfg)).To(BeEmpty())
 			})
 		})
@@ -520,7 +520,7 @@ var _ = Describe("eventHandler", func() {
 
 				handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
 
-				dcfg := dataplane.GetDefaultConfiguration(1)
+				dcfg := dataplane.GetDefaultConfiguration(&graph.Graph{}, 1)
 				Expect(helpers.Diff(handler.GetLatestConfiguration(), &dcfg)).To(BeEmpty())
 
 				Expect(fakeGenerator.GenerateCallCount()).To(Equal(1))
@@ -533,7 +533,7 @@ var _ = Describe("eventHandler", func() {
 			It("should not call the NGINX Plus API", func() {
 				handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
 
-				dcfg := dataplane.GetDefaultConfiguration(1)
+				dcfg := dataplane.GetDefaultConfiguration(&graph.Graph{}, 1)
 				Expect(helpers.Diff(handler.GetLatestConfiguration(), &dcfg)).To(BeEmpty())
 
 				Expect(fakeGenerator.GenerateCallCount()).To(Equal(1))
@@ -629,7 +629,7 @@ var _ = Describe("eventHandler", func() {
 		Expect(handler.cfg.nginxConfiguredOnStartChecker.readyCheck(nil)).ToNot(Succeed())
 		handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
 
-		dcfg := dataplane.GetDefaultConfiguration(1)
+		dcfg := dataplane.GetDefaultConfiguration(&graph.Graph{}, 1)
 		Expect(helpers.Diff(handler.GetLatestConfiguration(), &dcfg)).To(BeEmpty())
 
 		Expect(readyChannel).To(BeClosed())
@@ -677,7 +677,7 @@ var _ = Describe("eventHandler", func() {
 
 		handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
 
-		dcfg := dataplane.GetDefaultConfiguration(2)
+		dcfg := dataplane.GetDefaultConfiguration(&graph.Graph{}, 2)
 		Expect(helpers.Diff(handler.GetLatestConfiguration(), &dcfg)).To(BeEmpty())
 
 		Expect(readyChannel).To(BeClosed())

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -137,16 +137,6 @@ func StartManager(cfg config.Config) error {
 		ProtectedPorts: protectedPorts,
 	})
 
-	// Clear the configuration folders to ensure that no files are left over in case the control plane was restarted
-	// (this assumes the folders are in a shared volume).
-	removedPaths, err := file.ClearFolders(file.NewStdLibOSFileManager(), ngxcfg.ConfigFolders)
-	for _, path := range removedPaths {
-		cfg.Logger.Info("removed configuration file", "path", path)
-	}
-	if err != nil {
-		return fmt.Errorf("cannot clear NGINX configuration folders: %w", err)
-	}
-
 	processHandler := ngxruntime.NewProcessHandlerImpl(os.ReadFile, os.Stat)
 
 	// Ensure NGINX is running before registering metrics & starting the manager.

--- a/internal/mode/static/state/dataplane/configuration.go
+++ b/internal/mode/static/state/dataplane/configuration.go
@@ -34,7 +34,7 @@ func BuildConfiguration(
 	configVersion int,
 ) Configuration {
 	if g.GatewayClass == nil || !g.GatewayClass.Valid || g.Gateway == nil {
-		return GetDefaultConfiguration(configVersion)
+		return GetDefaultConfiguration(g, configVersion)
 	}
 
 	baseHTTPConfig := buildBaseHTTPConfig(g)
@@ -907,9 +907,9 @@ func buildLogging(g *graph.Graph) Logging {
 	return logSettings
 }
 
-func GetDefaultConfiguration(configVersion int) Configuration {
+func GetDefaultConfiguration(g *graph.Graph, configVersion int) Configuration {
 	return Configuration{
 		Version: configVersion,
-		Logging: Logging{ErrorLevel: defaultErrorLogLevel},
+		Logging: buildLogging(g),
 	}
 }


### PR DESCRIPTION
Problem: We are starting to introduce configuration options that exist in the main context. However, that configuration won't be written until the control plane writes it to nginx, meaning it doesn't exist on nginx startup. Therefore nginx uses its default configuration for a brief time, which is incorrect.

We want to be able to provide this configuration on startup.

Solution: Using an init container, we can mount a ConfigMap containing the dynamic base config, and copy it to the proper location in the filesystem before nginx starts. We can't mount the ConfigMap directly to the proper location because it would be read-only, preventing our control plane from writing to it.

This allows us to bootstrap the user config into nginx on startup, while also allowing our control plane to overwrite it if the user ever changes the config after the fact.

Removed logic that cleared out nginx files on startup because it would erase this bootstrap config, and it wasn't really needed since we delete nginx files when we write config anyway.

Also fixed an issue where the log level was not honored when no Gateway resources existed.

Testing: Verified that the log level is set properly on startup.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Added an init container to bootstrap nginx config on startup.
```
