### PR TITLE
(Cherry-pick) docs: enableGitInfo config (#2637) 

### DIFF
--- a/site/config/_default/config.toml
+++ b/site/config/_default/config.toml
@@ -1,5 +1,5 @@
 title = "NGINX Gateway Fabric"
-enableGitInfo = false
+enableGitInfo = true
 baseURL = "/"
 staticDir = ["static"]
 languageCode = "en-us"


### PR DESCRIPTION
Cherry-pick enableGitInfo config and docs-action bump https://github.com/nginxinc/nginx-gateway-fabric/pull/2637

