### PR TITLE
Fix docs docker failing without git context

### DIFF
--- a/site/config/docker/config.toml
+++ b/site/config/docker/config.toml
@@ -1,0 +1,1 @@
+enableGitInfo = false

--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/nginx-gateway-fabric/site
 
 go 1.21
 
-require github.com/nginxinc/nginx-hugo-theme v0.41.19 // indirect
+require github.com/nginxinc/nginx-hugo-theme v0.41.20 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,6 +1,2 @@
-github.com/nginxinc/nginx-hugo-theme v0.41.14 h1:OraNB01CdMJXufPddvIVt6qn6Mj38Z/XCVIWBgVtuY0=
-github.com/nginxinc/nginx-hugo-theme v0.41.14/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
-github.com/nginxinc/nginx-hugo-theme v0.41.18 h1:4weO2h6L56lebyX7G+iqHd481RCXQQParhb1lARwdLQ=
-github.com/nginxinc/nginx-hugo-theme v0.41.18/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
-github.com/nginxinc/nginx-hugo-theme v0.41.19 h1:CyZOhU8q0p3nQ+ZTFRx7c/Dq9rxV1mShADIHz0vDoHo=
-github.com/nginxinc/nginx-hugo-theme v0.41.19/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.41.20 h1:6BJGRGdHW17OpkC4qbcHARo9TRrJPFrALBjFltwedf8=
+github.com/nginxinc/nginx-hugo-theme v0.41.20/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=

--- a/site/hugo-entrypoint.sh
+++ b/site/hugo-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 hugo mod get -u github.com/nginxinc/nginx-hugo-theme
-hugo $*
+hugo --environment docker $*


### PR DESCRIPTION
### Proposed changes
Fix docs docker failing without git context. Since adding LastMod, a proper git history is required during hugo build time. The mount point in docker doesn't pull in the .git directory, so it would always fail.




### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
