### PR TITLE
Only set stream status zone if hostname exists

### DIFF
--- a/internal/mode/static/nginx/config/stream_servers_template.go
+++ b/internal/mode/static/nginx/config/stream_servers_template.go
@@ -13,7 +13,7 @@ server {
     {{- range $address := $s.RewriteClientIP.RealIPFrom }}
     set_real_ip_from {{ $address }};
     {{- end}}
-	{{- if $.Plus }}
+	{{- if and $.Plus $s.StatusZone }}
     status_zone {{ $s.StatusZone }};
     {{- end }}
 


### PR DESCRIPTION
Problem: Noticed during conformance tests, the stream server blocks did not have a hostname, and therefore the status_zone value was empty and invalid.

Solution: Only set the status_zone directive if it has a value.

Closes #2683 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Stream status_zone directive is no longer set if its value is empty.
```
