### PR TITLE
Fix failing unit test

### DIFF
--- a/internal/mode/static/config_updater_test.go
+++ b/internal/mode/static/config_updater_test.go
@@ -34,7 +34,6 @@ func TestUpdateControlPlane(t *testing.T) {
 	}
 
 	logger := zap.New()
-	fakeEventRecorder := record.NewFakeRecorder(1)
 	nsname := types.NamespacedName{Namespace: "test", Name: "test"}
 
 	tests := []struct {
@@ -81,6 +80,8 @@ func TestUpdateControlPlane(t *testing.T) {
 					return test.setLevelErr
 				},
 			}
+
+			fakeEventRecorder := record.NewFakeRecorder(1)
 
 			err := updateControlPlane(test.nginxGateway, logger, fakeEventRecorder, nsname, fakeLogSetter)
 


### PR DESCRIPTION
Problem: Intermittently one of our unit tests was failing.

Solution: My hunch as to why it was failing is because of the parallel nature would occasionally cause an object to be in the wrong state for a specific test. So that object is now being defined for every test instead of globally.

Closes #2625

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
