### PR TITLE
Update backend group name with a prefix

### DIFF
--- a/internal/mode/static/nginx/config/servers_test.go
+++ b/internal/mode/static/nginx/config/servers_test.go
@@ -1150,7 +1150,7 @@ func TestCreateServers(t *testing.T) {
 			},
 			{
 				Path:            "/_ngf-internal-rule1-route0",
-				ProxyPass:       "http://$test__route1_rule1$request_uri",
+				ProxyPass:       "http://$group_test__route1_rule1$request_uri",
 				ProxySetHeaders: httpBaseHeaders,
 				Type:            http.InternalLocationType,
 				Includes:        internalIncludes,
@@ -2810,7 +2810,7 @@ func TestCreateProxyPass(t *testing.T) {
 			},
 		},
 		{
-			expected: "http://$ns1__bg_rule0$request_uri",
+			expected: "http://$group_ns1__bg_rule0$request_uri",
 			grp: dataplane.BackendGroup{
 				Source: types.NamespacedName{Namespace: "ns1", Name: "bg"},
 				Backends: []dataplane.Backend{

--- a/internal/mode/static/nginx/config/split_clients_test.go
+++ b/internal/mode/static/nginx/config/split_clients_test.go
@@ -52,8 +52,8 @@ func TestExecuteSplitClients(t *testing.T) {
 				bg3,
 			},
 			expStrings: []string{
-				"split_clients $request_id $test__hr_rule0",
-				"split_clients $request_id $test__hr_rule1",
+				"split_clients $request_id $group_test__hr_rule0",
+				"split_clients $request_id $group_test__hr_rule1",
 				"50.00% test1;",
 				"50.00% test2;",
 				"50.00% test3;",
@@ -74,7 +74,7 @@ func TestExecuteSplitClients(t *testing.T) {
 				},
 			},
 			expStrings: []string{
-				"split_clients $request_id $test__zero_percent_rule0",
+				"split_clients $request_id $group_test__zero_percent_rule0",
 				"100.00% non-zero;",
 				"# 0.00% zero;",
 			},
@@ -188,7 +188,7 @@ func TestCreateSplitClients(t *testing.T) {
 			},
 			expSplitClients: []http.SplitClient{
 				{
-					VariableName: "test__hr_one_split_rule0",
+					VariableName: "group_test__hr_one_split_rule0",
 					Distributions: []http.SplitClientDistribution{
 						{
 							Percent: "50.00",
@@ -201,7 +201,7 @@ func TestCreateSplitClients(t *testing.T) {
 					},
 				},
 				{
-					VariableName: "test__hr_two_splits_rule0",
+					VariableName: "group_test__hr_two_splits_rule0",
 					Distributions: []http.SplitClientDistribution{
 						{
 							Percent: "50.00",
@@ -214,7 +214,7 @@ func TestCreateSplitClients(t *testing.T) {
 					},
 				},
 				{
-					VariableName: "test__hr_two_splits_rule1",
+					VariableName: "group_test__hr_two_splits_rule1",
 					Distributions: []http.SplitClientDistribution{
 						{
 							Percent: "33.33",
@@ -661,7 +661,7 @@ func TestBackendGroupName(t *testing.T) {
 					Weight:       1,
 				},
 			},
-			expName: "test__hr_rule0",
+			expName: "group_test__hr_rule0",
 		},
 		{
 			msg: "multiple invalid backends",
@@ -677,7 +677,7 @@ func TestBackendGroupName(t *testing.T) {
 					Weight:       1,
 				},
 			},
-			expName: "test__hr_rule0",
+			expName: "group_test__hr_rule0",
 		},
 	}
 

--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -2992,20 +2992,21 @@ func TestBuildUpstreams(t *testing.T) {
 	g.Expect(upstreams).To(ConsistOf(expUpstreams))
 }
 
+func createBackendGroup(name string, ruleIdx int, backendNames ...string) BackendGroup {
+	backends := make([]Backend, len(backendNames))
+	for i, name := range backendNames {
+		backends[i] = Backend{UpstreamName: name}
+	}
+
+	return BackendGroup{
+		Source:   types.NamespacedName{Namespace: "test", Name: name},
+		RuleIdx:  ruleIdx,
+		Backends: backends,
+	}
+}
+
 func TestBuildBackendGroups(t *testing.T) {
 	t.Parallel()
-	createBackendGroup := func(name string, ruleIdx int, backendNames ...string) BackendGroup {
-		backends := make([]Backend, len(backendNames))
-		for i, name := range backendNames {
-			backends[i] = Backend{UpstreamName: name}
-		}
-
-		return BackendGroup{
-			Source:   types.NamespacedName{Namespace: "test", Name: name},
-			RuleIdx:  ruleIdx,
-			Backends: backends,
-		}
-	}
 
 	hr1Group0 := createBackendGroup("hr1", 0, "foo", "bar")
 
@@ -3061,8 +3062,16 @@ func TestBuildBackendGroups(t *testing.T) {
 	g := NewWithT(t)
 
 	result := buildBackendGroups(servers)
-
 	g.Expect(result).To(ConsistOf(expGroups))
+}
+
+func TestBackendGroupName(t *testing.T) {
+	backendGroup := createBackendGroup("route1", 2, "foo", "bar")
+
+	expectedGroupName := "group_test__route1_rule2"
+
+	g := NewWithT(t)
+	g.Expect(backendGroup.Name()).To(Equal(expectedGroupName))
 }
 
 func TestHostnameMoreSpecific(t *testing.T) {

--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -3066,6 +3066,7 @@ func TestBuildBackendGroups(t *testing.T) {
 }
 
 func TestBackendGroupName(t *testing.T) {
+	t.Parallel()
 	backendGroup := createBackendGroup("route1", 2, "foo", "bar")
 
 	expectedGroupName := "group_test__route1_rule2"

--- a/internal/mode/static/state/dataplane/types.go
+++ b/internal/mode/static/state/dataplane/types.go
@@ -267,11 +267,13 @@ type BackendGroup struct {
 
 // Name returns the name of the backend group.
 // This name must be unique across all HTTPRoutes and all rules within the same HTTPRoute.
+// It is prefixed with `group_` for cases when namespace name starts with a digit. Variable names
+// in nginx configuration cannot start with a digit.
 // The RuleIdx is used to make the name unique across all rules within the same HTTPRoute.
 // The RuleIdx may change for a given rule if an update is made to the HTTPRoute, but it will always match the index
 // of the rule in the stored HTTPRoute.
 func (bg *BackendGroup) Name() string {
-	return fmt.Sprintf("%s__%s_rule%d", bg.Source.Namespace, bg.Source.Name, bg.RuleIdx)
+	return fmt.Sprintf("group_%s__%s_rule%d", bg.Source.Namespace, bg.Source.Name, bg.RuleIdx)
 }
 
 // Backend represents a Backend for a routing rule.

--- a/site/content/how-to/monitoring/troubleshooting.md
+++ b/site/content/how-to/monitoring/troubleshooting.md
@@ -203,7 +203,7 @@ server {
         proxy_set_header Upgrade "$http_upgrade";
         proxy_set_header Connection "$connection_upgrade";
         proxy_http_version 1.1;
-        proxy_pass http://group_default_coffee_80$request_uri;
+        proxy_pass http://default_coffee_80$request_uri;
     }
 
     location = /coffee {
@@ -212,7 +212,7 @@ server {
         proxy_set_header Upgrade "$http_upgrade";
         proxy_set_header Connection "$connection_upgrade";
         proxy_http_version 1.1;
-        proxy_pass http://group_default_coffee_80$request_uri;
+        proxy_pass http://default_coffee_80$request_uri;
     }
 
     location / {
@@ -220,9 +220,9 @@ server {
     }
 
 }
-upstream group_default_coffee_80 {
+upstream default_coffee_80 {
     random two least_conn;
-    zone group_default_coffee_80 512k;
+    zone default_coffee_80 512k;
 
     server 10.244.0.13:8080;
 }

--- a/site/content/how-to/monitoring/troubleshooting.md
+++ b/site/content/how-to/monitoring/troubleshooting.md
@@ -203,7 +203,7 @@ server {
         proxy_set_header Upgrade "$http_upgrade";
         proxy_set_header Connection "$connection_upgrade";
         proxy_http_version 1.1;
-        proxy_pass http://default_coffee_80$request_uri;
+        proxy_pass http://group_default_coffee_80$request_uri;
     }
 
     location = /coffee {
@@ -212,7 +212,7 @@ server {
         proxy_set_header Upgrade "$http_upgrade";
         proxy_set_header Connection "$connection_upgrade";
         proxy_http_version 1.1;
-        proxy_pass http://default_coffee_80$request_uri;
+        proxy_pass http://group_default_coffee_80$request_uri;
     }
 
     location / {
@@ -220,9 +220,9 @@ server {
     }
 
 }
-upstream default_coffee_80 {
+upstream group_default_coffee_80 {
     random two least_conn;
-    zone default_coffee_80 512k;
+    zone group_default_coffee_80 512k;
 
     server 10.244.0.13:8080;
 }
@@ -294,6 +294,7 @@ Verify that the port number (for example, `8080`) matches the port number you ha
 ### Common errors
 
 {{< bootstrap-table "table table-striped table-bordered" >}}
+
 | Problem Area | Symptom | Troubleshooting Method | Common Cause |
 |------------------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | Startup | NGINX Gateway Fabric fails to start. | Check logs for _nginx_ and _nginx-gateway_ containers. | Readiness probe failed. |
@@ -301,6 +302,7 @@ Verify that the port number (for example, `8080`) matches the port number you ha
 | NGINX errors | Reload failures on NGINX | Fix permissions for control plane. | Security context not configured. |
 | Usage reporting | Errors logs related to usage reporting | Enable usage reporting. Refer to [Usage Reporting]({{< relref "installation/usage-reporting.md" >}}) | Usage reporting disabled. |
 | Client Settings | Request entity too large error | Adjust client settings. Refer to [Client Settings Policy]({{< relref "../traffic-management/client-settings.md" >}}) | Payload is greater than the [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) value.|
+
 {{< /bootstrap-table >}}
 
 ##### NGINX fails to reload

--- a/site/content/how-to/traffic-management/routing-traffic-to-your-app.md
+++ b/site/content/how-to/traffic-management/routing-traffic-to-your-app.md
@@ -340,7 +340,7 @@ If you have any issues while testing the configuration, try the following to deb
 
     location / {
         ...
-        proxy_pass http://default_coffee_80$request_uri; # the upstream is named default_coffee_80
+        proxy_pass http://group_default_coffee_80$request_uri; # the upstream is named group_default_coffee_80
         ...
     }
   }
@@ -349,7 +349,7 @@ If you have any issues while testing the configuration, try the following to deb
   There should also be an upstream block with a name that matches the upstream in the **proxy_pass** directive. This upstream block should contain the pod IPs of the **coffee** pods:
 
   ```nginx configuration
-  upstream default_coffee_80 {
+  upstream group_default_coffee_80 {
     ...
     server 10.12.0.18:8080; # these should be the pod IPs of the coffee pods
     server 10.12.0.19:8080;

--- a/site/content/how-to/traffic-management/routing-traffic-to-your-app.md
+++ b/site/content/how-to/traffic-management/routing-traffic-to-your-app.md
@@ -340,7 +340,7 @@ If you have any issues while testing the configuration, try the following to deb
 
     location / {
         ...
-        proxy_pass http://group_default_coffee_80$request_uri; # the upstream is named group_default_coffee_80
+        proxy_pass http://default_coffee_80$request_uri; # the upstream is named default_coffee_80
         ...
     }
   }
@@ -349,7 +349,7 @@ If you have any issues while testing the configuration, try the following to deb
   There should also be an upstream block with a name that matches the upstream in the **proxy_pass** directive. This upstream block should contain the pod IPs of the **coffee** pods:
 
   ```nginx configuration
-  upstream group_default_coffee_80 {
+  upstream default_coffee_80 {
     ...
     server 10.12.0.18:8080; # these should be the pod IPs of the coffee pods
     server 10.12.0.19:8080;


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: User want to configure split client upstream in a namespace starting with a digit without running into any issues.

 When a user was configuring split clients in a namespace starting with a digit, it led to `proxy_pass` variable being `http://$9c_network__some_route_name_rule0$request_uri` , which led to issues with nginx since variable names cannot start with a digit, leading to a 502 Bad Gateway error.  The above problem existed for cases when a variable name is mentioned for using split weightage of upstreams.

Solution:  Updated backend group name with a prefix "group_". Hence, we update split client variable names, distribution names and upstream names. 

Testing: Testing with cafe and traffic splitting example.

**Config with cafe example** 

```
location = /coffee {
       proxy_pass http://9test_coffee_80$request_uri;
    }
    location = /tea {
       proxy_pass http://9test_tea_80$request_uri;
    }


upstream 9test_coffee_80 {
    random two least_conn;
    zone 9test_coffee_80 512k;

    server 10.244.0.40:8080;
}

upstream 9test_tea_80 {
    random two least_conn;
    zone 9test_tea_80 512k;

    server 10.244.0.41:8080;
}

```


**Config with trafic-splitting example**

```
location /coffee/ {
        proxy_pass http://$group_9test__cafe_route_rule0$request_uri;
    }

location = /coffee {
       proxy_pass http://$group_9test__cafe_route_rule0$request_uri;
 }

upstream 9test_coffee-v1_80 {
    random two least_conn;
    zone 9test_coffee-v1_80 512k;

    server 10.244.0.38:8080;
}

upstream 9test_coffee-v2_80 {
    random two least_conn;
    zone 9test_coffee-v2_80 512k;

    server 10.244.0.39:8080;
}

split_clients $request_id $group_9test__cafe_route_rule0 {
    80.00% 9test_coffee-v1_80;
    20.00% 9test_coffee-v2_80;
}
```



Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #2606 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
