### PR TITLE
Add loadbalancerIP as a helm parameter

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -299,6 +299,7 @@ The following table lists the configurable parameters of the NGINX Gateway Fabri
 | `service.annotations` | The annotations of the NGINX Gateway Fabric service. | object | `{}` |
 | `service.create` | Creates a service to expose the NGINX Gateway Fabric pods. | bool | `true` |
 | `service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | string | `"Local"` |
+| `service.loadBalancerIP` | The static IP address for the load balancer. Requires service.type set to LoadBalancer. | string | `""` |
 | `service.ports` | A list of ports to expose through the NGINX Gateway Fabric service. Update it to match the listener ports from your Gateway resource. Follows the conventional Kubernetes yaml syntax for service ports. | list | `[{"name":"http","port":80,"protocol":"TCP","targetPort":80},{"name":"https","port":443,"protocol":"TCP","targetPort":443}]` |
 | `service.type` | The type of service to create for the NGINX Gateway Fabric. | string | `"LoadBalancer"` |
 | `serviceAccount.annotations` | Set of custom annotations for the NGINX Gateway Fabric service account. | object | `{}` |

--- a/charts/nginx-gateway-fabric/templates/service.yaml
+++ b/charts/nginx-gateway-fabric/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   {{- end }}
 {{- end }}
   type: {{ .Values.service.type }}
+{{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end}}
   selector:
     {{- include "nginx-gateway.selectorLabels" . | nindent 4 }}
   ports: # Update the following ports to match your Gateway Listener ports

--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -573,6 +573,13 @@
           "required": [],
           "title": "externalTrafficPolicy"
         },
+        "loadBalancerIP": {
+          "default": "",
+          "description": "The static IP address for the load balancer. Requires service.type set to LoadBalancer.",
+          "required": [],
+          "title": "loadBalancerIP",
+          "type": "string"
+        },
         "ports": {
           "description": "A list of ports to expose through the NGINX Gateway Fabric service. Update it to match the listener ports from\nyour Gateway resource. Follows the conventional Kubernetes yaml syntax for service ports.",
           "items": {

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -303,6 +303,9 @@ service:
   # -- The annotations of the NGINX Gateway Fabric service.
   annotations: {}
 
+  # -- The static IP address for the load balancer. Requires service.type set to LoadBalancer.
+  loadBalancerIP: ""
+
   # @schema
   # type: array
   # items:


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Users want to specify load balancer IP when doing a helm install or upgrade.

Solution: Add a parameter `loadBalancerIP` under `service` in values.yaml. 

Testing: Manual testing with specifying `loadBalancerIP` when doing a `helm install` and verify if svc NGF has the correct value

```
helm install ngf charts/nginx-gateway-fabric --values ./charts/nginx-gateway-fabric/values.yaml  --create-namespace -n nginx-gateway  --set nginxGateway.image.repository=nginx-gateway-fabric --set nginxGateway.image.tag=$(whoami) --set nginxGateway.image.pullPolicy=Never --set nginx.image.repository=nginx-gateway-fabric/nginx --set nginx.image.tag=$(whoami) --set nginx.image.pullPolicy=Never --set service.loadBalancerIP=127.0.0.1
NAME: ngf
LAST DEPLOYED: Mon Nov 11 09:55:59 2024
NAMESPACE: nginx-gateway
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

```
k describe service -n nginx-gateway ngf-nginx-gateway-fabric
Name:                     ngf-nginx-gateway-fabric
Namespace:                nginx-gateway
Labels:                   app.kubernetes.io/instance=ngf
                          app.kubernetes.io/managed-by=Helm
                          app.kubernetes.io/name=nginx-gateway-fabric
                          app.kubernetes.io/version=edge
                          helm.sh/chart=nginx-gateway-fabric-1.4.0
Annotations:              meta.helm.sh/release-name: ngf
                          meta.helm.sh/release-namespace: nginx-gateway
Selector:                 app.kubernetes.io/instance=ngf,app.kubernetes.io/name=nginx-gateway-fabric
Type:                     LoadBalancer
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       10.96.252.162
IPs:                      10.96.252.162
IP:                       127.0.0.1
Port:                     http  80/TCP
TargetPort:               80/TCP
NodePort:                 http  31124/TCP
Endpoints:                10.244.0.5:80
Port:                     https  443/TCP
TargetPort:               443/TCP
NodePort:                 https  32155/TCP
Endpoints:                10.244.0.5:443
Session Affinity:         None
External Traffic Policy:  Local
HealthCheck NodePort:     32444
Events:                   <none>
```

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #2290 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Adds `loadBalancerIP` as a helm parameter to use during install/upgrade.
```
