### PR TITLE
Add loadBalancerSourceRanges to helm parameters

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -300,6 +300,7 @@ The following table lists the configurable parameters of the NGINX Gateway Fabri
 | `service.create` | Creates a service to expose the NGINX Gateway Fabric pods. | bool | `true` |
 | `service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | string | `"Local"` |
 | `service.loadBalancerIP` | The static IP address for the load balancer. Requires service.type set to LoadBalancer. | string | `""` |
+| `service.loadBalancerSourceRanges` | The IP ranges (CIDR) that are allowed to access the load balancer. Requires service.type set to LoadBalancer. | list | `[]` |
 | `service.ports` | A list of ports to expose through the NGINX Gateway Fabric service. Update it to match the listener ports from your Gateway resource. Follows the conventional Kubernetes yaml syntax for service ports. | list | `[{"name":"http","port":80,"protocol":"TCP","targetPort":80},{"name":"https","port":443,"protocol":"TCP","targetPort":443}]` |
 | `service.type` | The type of service to create for the NGINX Gateway Fabric. | string | `"LoadBalancer"` |
 | `serviceAccount.annotations` | Set of custom annotations for the NGINX Gateway Fabric service account. | object | `{}` |

--- a/charts/nginx-gateway-fabric/templates/service.yaml
+++ b/charts/nginx-gateway-fabric/templates/service.yaml
@@ -17,8 +17,14 @@ spec:
   {{- end }}
 {{- end }}
   type: {{ .Values.service.type }}
-{{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+{{- if eq .Values.service.type "LoadBalancer" }}
+  {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end }}
 {{- end}}
   selector:
     {{- include "nginx-gateway.selectorLabels" . | nindent 4 }}

--- a/charts/nginx-gateway-fabric/templates/service.yaml
+++ b/charts/nginx-gateway-fabric/templates/service.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 2 }}
   {{- end }}
 {{- end}}
   selector:

--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -580,6 +580,15 @@
           "title": "loadBalancerIP",
           "type": "string"
         },
+        "loadBalancerSourceRanges": {
+          "description": "The IP ranges (CIDR) that are allowed to access the load balancer. Requires service.type set to LoadBalancer.",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "loadBalancerSourceRanges",
+          "type": "array"
+        },
         "ports": {
           "description": "A list of ports to expose through the NGINX Gateway Fabric service. Update it to match the listener ports from\nyour Gateway resource. Follows the conventional Kubernetes yaml syntax for service ports.",
           "items": {

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -306,6 +306,9 @@ service:
   # -- The static IP address for the load balancer. Requires service.type set to LoadBalancer.
   loadBalancerIP: ""
 
+  # -- The IP ranges (CIDR) that are allowed to access the load balancer. Requires service.type set to LoadBalancer.
+  loadBalancerSourceRanges: []
+
   # @schema
   # type: array
   # items:


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Users need a way to provide the `loadBalancerSourceRanges` to restrict IPs that can access the load balancer.

Solution: Added a helm parameter to specify `loadBalancerSourceRanges` during helm install/upgrade

Testing: Manual testing by adding `loadBalancerSourceRanges` in values.yaml file and doing a helm install. Verified the service specifications for changes to be reflected correctly.

```
k get svc -n nginx-gateway ngf-nginx-gateway-fabric -o yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    meta.helm.sh/release-name: ngf
    meta.helm.sh/release-namespace: nginx-gateway
  creationTimestamp: "2024-11-14T21:43:25Z"
  labels:
    app.kubernetes.io/instance: ngf
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: nginx-gateway-fabric
    app.kubernetes.io/version: edge
    helm.sh/chart: nginx-gateway-fabric-1.4.0
  name: ngf-nginx-gateway-fabric
  namespace: nginx-gateway
  resourceVersion: "8048"
  uid: ad7e9b3e-4421-4e74-8487-c93aed59561f
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: 10.96.145.154
  clusterIPs:
  - 10.96.145.154
  externalTrafficPolicy: Local
  healthCheckNodePort: 30737
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  loadBalancerSourceRanges:
  - 192.168.0.0/24
  - 10.0.0.0/16
  ports:
```

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #1865 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Adds `loadBalancerSourceRanges` as a helm parameter to be configured during install/upgrade.
```
