### PR TITLE
Docs: remove () typo from troubleshooting doc

### DIFF
--- a/site/content/how-to/monitoring/troubleshooting.md
+++ b/site/content/how-to/monitoring/troubleshooting.md
@@ -469,7 +469,7 @@ If you check your _nginx_ container logs and see the following error:
 
 It indicates that `proxy_protocol` is enabled for the gateway listeners, but the request sent to the application endpoint does not contain proxy information. To **resolve** this, you can do one of the following:
 
-- Unassign the field [`rewriteClientIP.mode`](({{< relref "reference/api.md" >}})) in the NginxProxy configuration.
+- Unassign the field [`rewriteClientIP.mode`]({{< relref "reference/api.md" >}}) in the NginxProxy configuration.
 
 - Send valid proxy information with requests being handled by your application.
 


### PR DESCRIPTION
### Problem & Proposed changes

An extra set of `()` in this relref is causing a broken link here https://docs.nginx.com/nginx-gateway-fabric/how-to/monitoring/troubleshooting/#broken-header-error.

![image](https://github.com/user-attachments/assets/5ee344d8-add1-4e4f-96c9-92820ebd67fd)


Closes #ISSUE n/a

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
