### PR TITLE
Fix longevity results filenames

### DIFF
--- a/tests/scripts/run-tests-gcp-vm.sh
+++ b/tests/scripts/run-tests-gcp-vm.sh
@@ -35,7 +35,12 @@ if [ "${STOP_LONGEVITY}" = "true" ]; then
         version=${TAG}
     fi
 
-    results="${SCRIPT_DIR}/../results/longevity/$version/$version.md"
+    runType=oss
+    if [ "${PLUS_ENABLED}" = "true" ]; then
+        runType=plus
+    fi
+
+    results="${SCRIPT_DIR}/../results/longevity/$version/$version-$runType.md"
     printf "\n## Error Logs\n\n" >>"${results}"
 
     ## ngf error logs


### PR DESCRIPTION
Problem: Running the longevity tests would result in two different files being written.

Solution: For consistency with other tests, and to compile into one file, update the script to use the same filename.
