### PR TITLE
Skip plus tests on a fork (#2784)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -24,6 +24,7 @@ jobs:
   conformance-tests:
     name: Run Tests
     runs-on: ubuntu-24.04
+    if: ${{ !github.event.pull_request.head.repo.fork || inputs.image != 'plus' }}
     permissions:
       contents: write # needed for uploading release artifacts
     env:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -21,6 +21,7 @@ jobs:
   functional-tests:
     name: Run Tests
     runs-on: ubuntu-24.04
+    if: ${{ !github.event.pull_request.head.repo.fork || inputs.image != 'plus' }}
     env:
       DOCKER_BUILD_SUMMARY: false
     steps:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -17,7 +17,7 @@ jobs:
   helm-tests-local:
     name: Helm Tests Local
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name != 'schedule' }}
+    if: ${{ github.event_name != 'schedule' && (!github.event.pull_request.head.repo.fork || inputs.image != 'plus') }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Cherry-pick #2784 to skip NGINX Plus tests on a fork.