### PR TITLE
feat: Update documentation action, bump version for local testing

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -1,4 +1,4 @@
-name: Build and deploy docs
+name: Build and deploy documentation
 on:
   workflow_dispatch:
     inputs:
@@ -12,6 +12,11 @@ on:
         - dev
         - staging
         - prod
+      hugo_theme_override:
+        description: "Hugo theme version (Leave blank for latest)"
+        required: false
+        default: ""
+        type: string
   pull_request:
     branches:
     - "*"
@@ -43,7 +48,7 @@ jobs:
     if: ${{ github.event.repository.fork == false && needs.vars.outputs.azure_creds == 'true' }}
     uses: nginxinc/docs-actions/.github/workflows/docs-build-push.yml@9c59fab05a8131f4d691ba6ea2b6a119f3ef832a # v1.0.7
     permissions:
-      pull-requests: write # needed to write preview url comment to PR
+      pull-requests: write
       contents: read
     with:
       production_url_path: "/nginx-gateway-fabric"
@@ -52,6 +57,7 @@ jobs:
       docs_build_path: "./site"
       doc_type: "hugo"
       environment: ${{ inputs.environment }}
+      force_hugo_theme_version: ${{inputs.hugo_theme_override}}
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS_DOCS }}
       AZURE_KEY_VAULT: ${{ secrets.AZURE_KEY_VAULT_DOCS }}

--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -57,7 +57,7 @@ jobs:
       docs_build_path: "./site"
       doc_type: "hugo"
       environment: ${{ inputs.environment }}
-      force_hugo_theme_version: ${{inputs.hugo_theme_override}}
+      force_hugo_theme_version: ${{ inputs.hugo_theme_override }}
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS_DOCS }}
       AZURE_KEY_VAULT: ${{ secrets.AZURE_KEY_VAULT_DOCS }}

--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -48,7 +48,7 @@ jobs:
     if: ${{ github.event.repository.fork == false && needs.vars.outputs.azure_creds == 'true' }}
     uses: nginxinc/docs-actions/.github/workflows/docs-build-push.yml@9c59fab05a8131f4d691ba6ea2b6a119f3ef832a # v1.0.7
     permissions:
-      pull-requests: write
+      pull-requests: write # Required to add the preview URL comment
       contents: read
     with:
       production_url_path: "/nginx-gateway-fabric"

--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/nginx-gateway-fabric/site
 
 go 1.21
 
-require github.com/nginxinc/nginx-hugo-theme v0.41.22 // indirect
+require github.com/nginxinc/nginx-hugo-theme v0.41.23 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,2 +1,2 @@
-github.com/nginxinc/nginx-hugo-theme v0.41.22 h1:Gb/OLbpumNqp8vOPkZzO2GmgPDRd1yr2tWHWUBHg8BA=
-github.com/nginxinc/nginx-hugo-theme v0.41.22/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.41.23 h1:ddIfLF7BFd78qyIn3z5aReeC4BO/m9FH81d5S+al/6s=
+github.com/nginxinc/nginx-hugo-theme v0.41.23/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=


### PR DESCRIPTION
### Proposed changes

This commit bumps the theme version for the documentation website, and updates the GitHub action used for deploying the website. The update allows you to specify what version of the theme to use for a deployment, which reduces the drift compared to relying on the local version.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
