### PR TITLE
Remove the email support section from the NGF README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For troubleshooting help, see the [Troubleshooting](https://docs.nginx.com/nginx
 
 We’d like to hear your feedback! If you experience issues with our Gateway Controller, please [open a bug][bug] in
 GitHub. If you have any suggestions or enhancement requests, please [open an idea][idea] on GitHub discussions. You can
-contact us directly via kubernetes@nginx.com or on the [NGINX Community Slack][slack] in
+contact us directly on the [NGINX Community Slack][slack] in
 the `#nginx-gateway-fabric`
 channel.
 


### PR DESCRIPTION
### Proposed changes

Problem: Email support for users was provided through [kubernetes@nginx.com](mailto:kubernetes@nginx.com) in NGF.

Solution: Removed email support from NGF and updated the README file accordingly.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated the necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
