### PR TITLE
Enable and update endpoint for telemetry for longevity tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
           AZURE_BUCKET_NAME: ${{ secrets.AZURE_BUCKET_NAME }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMMUNITY }}
-          TELEMETRY_ENDPOINT: oss.edge.df.f5.com:443
+          TELEMETRY_ENDPOINT: ${{ github.ref_type == 'branch' && github.event_name == 'push' && github.ref == 'refs/heads/release' && 'oss-dev.edge.df.f5.com:443' || 'oss.edge.df.f5.com:443' }}
           TELEMETRY_ENDPOINT_INSECURE: "false"
 
       - name: Cache Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
           AZURE_BUCKET_NAME: ${{ secrets.AZURE_BUCKET_NAME }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMMUNITY }}
-          TELEMETRY_ENDPOINT: ${{ github.ref_type == 'branch' && github.event_name == 'push' && github.ref == 'refs/heads/release' && 'oss-dev.edge.df.f5.com:443' || 'oss.edge.df.f5.com:443' }}
+          TELEMETRY_ENDPOINT: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-') && 'oss-dev.edge.df.f5.com:443' || 'oss.edge.df.f5.com:443' }}
           TELEMETRY_ENDPOINT_INSECURE: "false"
 
       - name: Cache Artifacts

--- a/tests/framework/ngf.go
+++ b/tests/framework/ngf.go
@@ -192,9 +192,10 @@ func UninstallNGF(cfg InstallationConfig, k8sClient client.Client) ([]byte, erro
 func setTelemetryArgs(cfg InstallationConfig) []string {
 	var args []string
 
-	args = append(args, formatValueSet("nginxGateway.productTelemetry.enable", "false")...)
 	if cfg.Telemetry {
 		args = append(args, formatValueSet("nginxGateway.productTelemetry.enable", "true")...)
+	} else {
+		args = append(args, formatValueSet("nginxGateway.productTelemetry.enable", "false")...)
 	}
 	return args
 }

--- a/tests/suite/system_suite_test.go
+++ b/tests/suite/system_suite_test.go
@@ -99,6 +99,7 @@ type setupConfig struct {
 	deploy        bool
 	nfr           bool
 	debugLogLevel bool
+	telemetry     bool
 }
 
 func setup(cfg setupConfig, extraInstallArgs ...string) {
@@ -151,6 +152,10 @@ func setup(cfg setupConfig, extraInstallArgs ...string) {
 		Skip("Graceful Recovery test must be run on Kind")
 	}
 
+	if clusterInfo.IsGKE && strings.Contains(GinkgoLabelFilter(), "longevity") {
+		cfg.telemetry = true
+	}
+
 	switch {
 	case *versionUnderTest != "":
 		version = *versionUnderTest
@@ -196,6 +201,7 @@ func createNGFInstallConfig(cfg setupConfig, extraInstallArgs ...string) framewo
 		ServiceType:     *serviceType,
 		IsGKEInternalLB: *isGKEInternalLB,
 		Plus:            *plusEnabled,
+		Telemetry:       cfg.telemetry,
 	}
 
 	// if we aren't installing from the public charts, then set the custom images


### PR DESCRIPTION
### Proposed changes

We want to report telemetry when running longevity tests to the development endpoint.

Problem: Users want to get telemetry reports when running longevity tests to simulate a live environment.

Solution: To provide live telemetry reports when running longevity tests, we have enabled telemetry for the test when label is `longevity` and updated the workflow that creates the binary for release to update the `TELEMETRY_ENDPOINT` to the dev endpoint. 

Note: I will be updating the binary building workflow to be triggered on a push to release branch. I tested it on the condition of `pull_request` to verify variables are set properly.

Testing: Manual testing using Github [actions](https://github.com/nginxinc/nginx-gateway-fabric/actions/runs/12056510143/job/33619284623?pr=2824#step:7:15) and running longevity tests. 

<img width="959" alt="Screenshot 2024-11-27 at 11 07 16 AM" src="https://github.com/user-attachments/assets/d5eb6ed7-e8c3-4653-abaf-c415a4efb1d4">


Running `make start-longevity-test`

```
make start-longevity-test
CI=false ./scripts/run-tests-gcp-vm.sh
.
.
.
 Installing NGF with command: helm install --debug ngf-longevity /home/username/nginx-gateway-fabric/charts/nginx-gateway-fabric --create-namespace --namespace nginx-gateway --wait --set nginxGateway.snippetsFilters.enable=true --set nginxGateway.image.repository=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/nginx-gateway-fabric --set nginxGateway.image.tag=release-1.5-rc --set nginxGateway.image.pullPolicy=Always --set nginx.image.repository=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/nginx-gateway-fabric/nginx-oss --set nginx.image.tag=release-1.5-rc --set nginx.image.pullPolicy=Always --set nginx.plus=true --set service.type=LoadBalancer --set service.annotations.networking\.gke\.io\/load-balancer-type=Internal --set nginxGateway.productTelemetry.enable=false --set nginxGateway.productTelemetry.enable=true --set nginxGateway.config.logging.level=debug
```

Product Telemetry set to true

```
--set nginxGateway.productTelemetry.enable=true 
```

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #1781 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
