### PR TITLE
Use state file for updating N+ upstreams

### DIFF
--- a/internal/mode/static/nginx/config/http/config.go
+++ b/internal/mode/static/nginx/config/http/config.go
@@ -82,9 +82,10 @@ const (
 
 // Upstream holds all configuration for an HTTP upstream.
 type Upstream struct {
-	Name     string
-	ZoneSize string // format: 512k, 1m
-	Servers  []UpstreamServer
+	Name      string
+	ZoneSize  string // format: 512k, 1m
+	StateFile string
+	Servers   []UpstreamServer
 }
 
 // UpstreamServer holds all configuration for an HTTP upstream server.

--- a/internal/mode/static/nginx/config/stream/config.go
+++ b/internal/mode/static/nginx/config/stream/config.go
@@ -15,9 +15,10 @@ type Server struct {
 
 // Upstream holds all configuration for a stream upstream.
 type Upstream struct {
-	Name     string
-	ZoneSize string // format: 512k, 1m
-	Servers  []UpstreamServer
+	Name      string
+	ZoneSize  string // format: 512k, 1m
+	StateFile string // FIXME(sberman): temporary until stream upstreams template is split in UpstreamSettingsPolicy work.
+	Servers   []UpstreamServer
 }
 
 // UpstreamServer holds all configuration for a stream upstream server.

--- a/internal/mode/static/nginx/config/upstreams.go
+++ b/internal/mode/static/nginx/config/upstreams.go
@@ -27,6 +27,8 @@ const (
 	ossZoneSizeStream = "512k"
 	// plusZoneSize is the upstream zone size for nginx plus.
 	plusZoneSizeStream = "1m"
+	// stateDir is the directory for storing state files.
+	stateDir = "/var/lib/nginx/state"
 )
 
 func (g GeneratorImpl) executeUpstreams(conf dataplane.Configuration) []executeResult {
@@ -101,15 +103,18 @@ func (g GeneratorImpl) createUpstreams(upstreams []dataplane.Upstream) []http.Up
 }
 
 func (g GeneratorImpl) createUpstream(up dataplane.Upstream) http.Upstream {
+	var stateFile string
 	zoneSize := ossZoneSize
 	if g.plus {
 		zoneSize = plusZoneSize
+		stateFile = fmt.Sprintf("%s/%s.conf", stateDir, up.Name)
 	}
 
 	if len(up.Endpoints) == 0 {
 		return http.Upstream{
-			Name:     up.Name,
-			ZoneSize: zoneSize,
+			Name:      up.Name,
+			ZoneSize:  zoneSize,
+			StateFile: stateFile,
 			Servers: []http.UpstreamServer{
 				{
 					Address: nginx503Server,
@@ -130,9 +135,10 @@ func (g GeneratorImpl) createUpstream(up dataplane.Upstream) http.Upstream {
 	}
 
 	return http.Upstream{
-		Name:     up.Name,
-		ZoneSize: zoneSize,
-		Servers:  upstreamServers,
+		Name:      up.Name,
+		ZoneSize:  zoneSize,
+		StateFile: stateFile,
+		Servers:   upstreamServers,
 	}
 }
 

--- a/internal/mode/static/nginx/config/upstreams_template.go
+++ b/internal/mode/static/nginx/config/upstreams_template.go
@@ -12,8 +12,13 @@ upstream {{ $u.Name }} {
     {{ if $u.ZoneSize -}}
     zone {{ $u.Name }} {{ $u.ZoneSize }};
     {{ end -}}
-    {{ range $server := $u.Servers }}
+
+    {{- if $u.StateFile }}
+    state {{ $u.StateFile }};
+    {{- else }}
+        {{ range $server := $u.Servers }}
     server {{ $server.Address }};
+        {{- end }}
     {{- end }}
 }
 {{ end -}}

--- a/internal/mode/static/nginx/config/upstreams_test.go
+++ b/internal/mode/static/nginx/config/upstreams_test.go
@@ -289,29 +289,60 @@ func TestCreateUpstreamPlus(t *testing.T) {
 	t.Parallel()
 	gen := GeneratorImpl{plus: true}
 
-	stateUpstream := dataplane.Upstream{
-		Name: "multiple-endpoints",
-		Endpoints: []resolver.Endpoint{
-			{
-				Address: "10.0.0.1",
-				Port:    80,
+	tests := []struct {
+		msg              string
+		stateUpstream    dataplane.Upstream
+		expectedUpstream http.Upstream
+	}{
+		{
+			msg: "with endpoints",
+			stateUpstream: dataplane.Upstream{
+				Name: "endpoints",
+				Endpoints: []resolver.Endpoint{
+					{
+						Address: "10.0.0.1",
+						Port:    80,
+					},
+				},
+			},
+			expectedUpstream: http.Upstream{
+				Name:      "endpoints",
+				ZoneSize:  plusZoneSize,
+				StateFile: stateDir + "/endpoints.conf",
+				Servers: []http.UpstreamServer{
+					{
+						Address: "10.0.0.1:80",
+					},
+				},
 			},
 		},
-	}
-	expectedUpstream := http.Upstream{
-		Name:     "multiple-endpoints",
-		ZoneSize: plusZoneSize,
-		Servers: []http.UpstreamServer{
-			{
-				Address: "10.0.0.1:80",
+		{
+			msg: "no endpoints",
+			stateUpstream: dataplane.Upstream{
+				Name:      "no-endpoints",
+				Endpoints: []resolver.Endpoint{},
+			},
+			expectedUpstream: http.Upstream{
+				Name:      "no-endpoints",
+				ZoneSize:  plusZoneSize,
+				StateFile: stateDir + "/no-endpoints.conf",
+				Servers: []http.UpstreamServer{
+					{
+						Address: nginx503Server,
+					},
+				},
 			},
 		},
 	}
 
-	result := gen.createUpstream(stateUpstream)
-
-	g := NewWithT(t)
-	g.Expect(result).To(Equal(expectedUpstream))
+	for _, test := range tests {
+		t.Run(test.msg, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			result := gen.createUpstream(test.stateUpstream)
+			g.Expect(result).To(Equal(test.expectedUpstream))
+		})
+	}
 }
 
 func TestExecuteStreamUpstreams(t *testing.T) {


### PR DESCRIPTION
Problem: When splitting the data and control plane, we want to be able to maintain the ability to dynamically update upstreams without a reload if using NGINX Plus. With the current process, we write the upstreams into the nginx conf but don't reload, then call the API to actually do the update. Writing into the conf will trigger a reload from the agent once we split, however.

Solution: Don't write the upstream servers into the nginx conf anymore when using NGINX Plus. Instead, utilize the `state` file option that the NGINX Plus API will populate with the upstream servers. This way we can just call the API and don't unintentionally reload by writing servers into the conf.

Testing: Verified that the state file is set and populated when using NGINX Plus. With OSS, servers are still written to the config.


Closes #2841

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
