### PR TITLE
Use state file for updating N+ upstreams

### DIFF
--- a/internal/mode/static/handler.go
+++ b/internal/mode/static/handler.go
@@ -182,11 +182,11 @@ func (h *eventHandlerImpl) HandleEventBatch(ctx context.Context, logger logr.Log
 
 		h.setLatestConfiguration(&cfg)
 
-		err = h.updateUpstreamServers(
-			ctx,
-			logger,
-			cfg,
-		)
+		if h.cfg.plus {
+			err = h.updateUpstreamServers(logger, cfg)
+		} else {
+			err = h.updateNginxConf(ctx, logger, cfg)
+		}
 	case state.ClusterStateChange:
 		h.version++
 		cfg := dataplane.BuildConfiguration(ctx, gr, h.cfg.serviceResolver, h.version)
@@ -198,10 +198,7 @@ func (h *eventHandlerImpl) HandleEventBatch(ctx context.Context, logger logr.Log
 
 		h.setLatestConfiguration(&cfg)
 
-		err = h.updateNginxConf(
-			ctx,
-			cfg,
-		)
+		err = h.updateNginxConf(ctx, logger, cfg)
 	}
 
 	var nginxReloadRes status.NginxReloadResult
@@ -306,7 +303,11 @@ func (h *eventHandlerImpl) parseAndCaptureEvent(ctx context.Context, logger logr
 }
 
 // updateNginxConf updates nginx conf files and reloads nginx.
-func (h *eventHandlerImpl) updateNginxConf(ctx context.Context, conf dataplane.Configuration) error {
+func (h *eventHandlerImpl) updateNginxConf(
+	ctx context.Context,
+	logger logr.Logger,
+	conf dataplane.Configuration,
+) error {
 	files := h.cfg.generator.Generate(conf)
 	if err := h.cfg.nginxFileMgr.ReplaceFiles(files); err != nil {
 		return fmt.Errorf("failed to replace NGINX configuration files: %w", err)
@@ -316,89 +317,111 @@ func (h *eventHandlerImpl) updateNginxConf(ctx context.Context, conf dataplane.C
 		return fmt.Errorf("failed to reload NGINX: %w", err)
 	}
 
+	// If using NGINX Plus, update upstream servers using the API.
+	if err := h.updateUpstreamServers(logger, conf); err != nil {
+		return fmt.Errorf("failed to update upstream servers: %w", err)
+	}
+
 	return nil
 }
 
-// updateUpstreamServers is called only when endpoints have changed. It updates nginx conf files and then:
-// - if using NGINX Plus, determines which servers have changed and uses the N+ API to update them;
-// - otherwise if not using NGINX Plus, or an error was returned from the API, reloads nginx.
-func (h *eventHandlerImpl) updateUpstreamServers(
-	ctx context.Context,
-	logger logr.Logger,
-	conf dataplane.Configuration,
-) error {
-	isPlus := h.cfg.nginxRuntimeMgr.IsPlus()
-
-	files := h.cfg.generator.Generate(conf)
-	if err := h.cfg.nginxFileMgr.ReplaceFiles(files); err != nil {
-		return fmt.Errorf("failed to replace NGINX configuration files: %w", err)
-	}
-
-	reload := func() error {
-		if err := h.cfg.nginxRuntimeMgr.Reload(ctx, conf.Version); err != nil {
-			return fmt.Errorf("failed to reload NGINX: %w", err)
-		}
-
+// updateUpstreamServers determines which servers have changed and uses the NGINX Plus API to update them.
+// Only applicable when using NGINX Plus.
+func (h *eventHandlerImpl) updateUpstreamServers(logger logr.Logger, conf dataplane.Configuration) error {
+	if !h.cfg.plus {
 		return nil
 	}
 
-	if isPlus {
-		type upstream struct {
-			name    string
-			servers []ngxclient.UpstreamServer
-		}
-		var upstreams []upstream
+	prevUpstreams, prevStreamUpstreams, err := h.cfg.nginxRuntimeMgr.GetUpstreams()
+	if err != nil {
+		return fmt.Errorf("failed to get upstreams from API: %w", err)
+	}
 
-		prevUpstreams, err := h.cfg.nginxRuntimeMgr.GetUpstreams()
-		if err != nil {
-			logger.Error(err, "failed to get upstreams from API, reloading configuration instead")
-			return reload()
+	type upstream struct {
+		name    string
+		servers []ngxclient.UpstreamServer
+	}
+	var upstreams []upstream
+
+	for _, u := range conf.Upstreams {
+		confUpstream := upstream{
+			name:    u.Name,
+			servers: ngxConfig.ConvertEndpoints(u.Endpoints),
 		}
 
-		for _, u := range conf.Upstreams {
-			confUpstream := upstream{
-				name:    u.Name,
-				servers: ngxConfig.ConvertEndpoints(u.Endpoints),
+		if u, ok := prevUpstreams[confUpstream.name]; ok {
+			if !serversEqual(confUpstream.servers, u.Peers) {
+				upstreams = append(upstreams, confUpstream)
 			}
-
-			if u, ok := prevUpstreams[confUpstream.name]; ok {
-				if !serversEqual(confUpstream.servers, u.Peers) {
-					upstreams = append(upstreams, confUpstream)
-				}
-			}
-		}
-
-		var reloadPlus bool
-		for _, upstream := range upstreams {
-			if err := h.cfg.nginxRuntimeMgr.UpdateHTTPServers(upstream.name, upstream.servers); err != nil {
-				logger.Error(
-					err, "couldn't update upstream via the API, reloading configuration instead",
-					"upstreamName", upstream.name,
-				)
-				reloadPlus = true
-			}
-		}
-
-		if !reloadPlus {
-			return nil
 		}
 	}
 
-	return reload()
+	type streamUpstream struct {
+		name    string
+		servers []ngxclient.StreamUpstreamServer
+	}
+	var streamUpstreams []streamUpstream
+
+	for _, u := range conf.StreamUpstreams {
+		confUpstream := streamUpstream{
+			name:    u.Name,
+			servers: ngxConfig.ConvertStreamEndpoints(u.Endpoints),
+		}
+
+		if u, ok := prevStreamUpstreams[confUpstream.name]; ok {
+			if !serversEqual(confUpstream.servers, u.Peers) {
+				streamUpstreams = append(streamUpstreams, confUpstream)
+			}
+		}
+	}
+
+	for _, upstream := range upstreams {
+		if err := h.cfg.nginxRuntimeMgr.UpdateHTTPServers(upstream.name, upstream.servers); err != nil {
+			logger.Error(err, "couldn't update upstream via the API", "upstreamName", upstream.name)
+		}
+	}
+
+	for _, upstream := range streamUpstreams {
+		if err := h.cfg.nginxRuntimeMgr.UpdateStreamServers(upstream.name, upstream.servers); err != nil {
+			logger.Error(err, "couldn't update stream upstream via the API", "upstreamName", upstream.name)
+		}
+	}
+
+	return nil
 }
 
-func serversEqual(newServers []ngxclient.UpstreamServer, oldServers []ngxclient.Peer) bool {
+// serversEqual accepts lists of either UpstreamServer/Peer or StreamUpstreamServer/StreamPeer and determines
+// if the server names within these lists are equal.
+func serversEqual[
+	upstreamServer ngxclient.UpstreamServer | ngxclient.StreamUpstreamServer,
+	peer ngxclient.Peer | ngxclient.StreamPeer,
+](newServers []upstreamServer, oldServers []peer) bool {
 	if len(newServers) != len(oldServers) {
 		return false
 	}
 
+	getServerVal := func(T any) string {
+		var server string
+		switch t := T.(type) {
+		case ngxclient.UpstreamServer:
+			server = t.Server
+		case ngxclient.StreamUpstreamServer:
+			server = t.Server
+		case ngxclient.Peer:
+			server = t.Server
+		case ngxclient.StreamPeer:
+			server = t.Server
+		}
+		return server
+	}
+
 	diff := make(map[string]struct{}, len(newServers))
 	for _, s := range newServers {
-		diff[s.Server] = struct{}{}
+		diff[getServerVal(s)] = struct{}{}
 	}
 
 	for _, s := range oldServers {
-		if _, ok := diff[s.Server]; !ok {
+		if _, ok := diff[getServerVal(s)]; !ok {
 			return false
 		}
 	}

--- a/internal/mode/static/handler_test.go
+++ b/internal/mode/static/handler_test.go
@@ -423,20 +423,29 @@ var _ = Describe("eventHandler", func() {
 					},
 				},
 			}
-			fakeNginxRuntimeMgr.GetUpstreamsReturns(upstreams, nil)
+
+			streamUpstreams := ngxclient.StreamUpstreams{
+				"two": ngxclient.StreamUpstream{
+					Peers: []ngxclient.StreamPeer{
+						{Server: "server2"},
+					},
+				},
+			}
+
+			fakeNginxRuntimeMgr.GetUpstreamsReturns(upstreams, streamUpstreams, nil)
 		})
 
 		When("running NGINX Plus", func() {
 			It("should call the NGINX Plus API", func() {
-				fakeNginxRuntimeMgr.IsPlusReturns(true)
+				handler.cfg.plus = true
 
 				handler.HandleEventBatch(context.Background(), ctlrZap.New(), batch)
 
 				dcfg := dataplane.GetDefaultConfiguration(&graph.Graph{}, 1)
 				Expect(helpers.Diff(handler.GetLatestConfiguration(), &dcfg)).To(BeEmpty())
 
-				Expect(fakeGenerator.GenerateCallCount()).To(Equal(1))
-				Expect(fakeNginxFileMgr.ReplaceFilesCallCount()).To(Equal(1))
+				Expect(fakeGenerator.GenerateCallCount()).To(Equal(0))
+				Expect(fakeNginxFileMgr.ReplaceFilesCallCount()).To(Equal(0))
 				Expect(fakeNginxRuntimeMgr.GetUpstreamsCallCount()).To(Equal(1))
 			})
 		})
@@ -463,19 +472,11 @@ var _ = Describe("eventHandler", func() {
 					Name: "one",
 				},
 			},
-		}
-
-		type callCounts struct {
-			generate int
-			update   int
-			reload   int
-		}
-
-		assertCallCounts := func(cc callCounts) {
-			Expect(fakeGenerator.GenerateCallCount()).To(Equal(cc.generate))
-			Expect(fakeNginxFileMgr.ReplaceFilesCallCount()).To(Equal(cc.generate))
-			Expect(fakeNginxRuntimeMgr.UpdateHTTPServersCallCount()).To(Equal(cc.update))
-			Expect(fakeNginxRuntimeMgr.ReloadCallCount()).To(Equal(cc.reload))
+			StreamUpstreams: []dataplane.Upstream{
+				{
+					Name: "two",
+				},
+			},
 		}
 
 		BeforeEach(func() {
@@ -486,47 +487,39 @@ var _ = Describe("eventHandler", func() {
 					},
 				},
 			}
-			fakeNginxRuntimeMgr.GetUpstreamsReturns(upstreams, nil)
+
+			streamUpstreams := ngxclient.StreamUpstreams{
+				"two": ngxclient.StreamUpstream{
+					Peers: []ngxclient.StreamPeer{
+						{Server: "server2"},
+					},
+				},
+			}
+
+			fakeNginxRuntimeMgr.GetUpstreamsReturns(upstreams, streamUpstreams, nil)
 		})
 
 		When("running NGINX Plus", func() {
 			BeforeEach(func() {
-				fakeNginxRuntimeMgr.IsPlusReturns(true)
+				handler.cfg.plus = true
 			})
 
 			It("should update servers using the NGINX Plus API", func() {
-				Expect(handler.updateUpstreamServers(context.Background(), ctlrZap.New(), conf)).To(Succeed())
-
-				assertCallCounts(callCounts{generate: 1, update: 1, reload: 0})
+				Expect(handler.updateUpstreamServers(ctlrZap.New(), conf)).To(Succeed())
+				Expect(fakeNginxRuntimeMgr.UpdateHTTPServersCallCount()).To(Equal(1))
 			})
 
-			It("should reload when GET API returns an error", func() {
-				fakeNginxRuntimeMgr.GetUpstreamsReturns(nil, errors.New("error"))
-				Expect(handler.updateUpstreamServers(context.Background(), ctlrZap.New(), conf)).To(Succeed())
-
-				assertCallCounts(callCounts{generate: 1, update: 0, reload: 1})
-			})
-
-			It("should reload when POST API returns an error", func() {
-				fakeNginxRuntimeMgr.UpdateHTTPServersReturns(errors.New("error"))
-				Expect(handler.updateUpstreamServers(context.Background(), ctlrZap.New(), conf)).To(Succeed())
-
-				assertCallCounts(callCounts{generate: 1, update: 1, reload: 1})
+			It("should return error when GET API returns an error", func() {
+				fakeNginxRuntimeMgr.GetUpstreamsReturns(nil, nil, errors.New("error"))
+				Expect(handler.updateUpstreamServers(ctlrZap.New(), conf)).ToNot(Succeed())
 			})
 		})
 
 		When("not running NGINX Plus", func() {
-			It("should update servers by reloading", func() {
-				Expect(handler.updateUpstreamServers(context.Background(), ctlrZap.New(), conf)).To(Succeed())
+			It("should not do anything", func() {
+				Expect(handler.updateUpstreamServers(ctlrZap.New(), conf)).To(Succeed())
 
-				assertCallCounts(callCounts{generate: 1, update: 0, reload: 1})
-			})
-
-			It("should return an error when reloading fails", func() {
-				fakeNginxRuntimeMgr.ReloadReturns(errors.New("error"))
-				Expect(handler.updateUpstreamServers(context.Background(), ctlrZap.New(), conf)).ToNot(Succeed())
-
-				assertCallCounts(callCounts{generate: 1, update: 0, reload: 1})
+				Expect(fakeNginxRuntimeMgr.UpdateHTTPServersCallCount()).To(Equal(0))
 			})
 		})
 	})
@@ -612,7 +605,7 @@ var _ = Describe("eventHandler", func() {
 })
 
 var _ = Describe("serversEqual", func() {
-	DescribeTable("determines if server lists are equal",
+	DescribeTable("determines if HTTP server lists are equal",
 		func(newServers []ngxclient.UpstreamServer, oldServers []ngxclient.Peer, equal bool) {
 			Expect(serversEqual(newServers, oldServers)).To(Equal(equal))
 		},
@@ -643,6 +636,43 @@ var _ = Describe("serversEqual", func() {
 				{Server: "server2"},
 			},
 			[]ngxclient.Peer{
+				{Server: "server1"},
+				{Server: "server2"},
+			},
+			true,
+		),
+	)
+	DescribeTable("determines if stream server lists are equal",
+		func(newServers []ngxclient.StreamUpstreamServer, oldServers []ngxclient.StreamPeer, equal bool) {
+			Expect(serversEqual(newServers, oldServers)).To(Equal(equal))
+		},
+		Entry("different length",
+			[]ngxclient.StreamUpstreamServer{
+				{Server: "server1"},
+			},
+			[]ngxclient.StreamPeer{
+				{Server: "server1"},
+				{Server: "server2"},
+			},
+			false,
+		),
+		Entry("differing elements",
+			[]ngxclient.StreamUpstreamServer{
+				{Server: "server1"},
+				{Server: "server2"},
+			},
+			[]ngxclient.StreamPeer{
+				{Server: "server1"},
+				{Server: "server3"},
+			},
+			false,
+		),
+		Entry("same elements",
+			[]ngxclient.StreamUpstreamServer{
+				{Server: "server1"},
+				{Server: "server2"},
+			},
+			[]ngxclient.StreamPeer{
 				{Server: "server1"},
 				{Server: "server2"},
 			},

--- a/internal/mode/static/handler_test.go
+++ b/internal/mode/static/handler_test.go
@@ -505,19 +505,29 @@ var _ = Describe("eventHandler", func() {
 			})
 
 			It("should update servers using the NGINX Plus API", func() {
-				Expect(handler.updateUpstreamServers(ctlrZap.New(), conf)).To(Succeed())
+				Expect(handler.updateUpstreamServers(conf)).To(Succeed())
 				Expect(fakeNginxRuntimeMgr.UpdateHTTPServersCallCount()).To(Equal(1))
 			})
 
 			It("should return error when GET API returns an error", func() {
 				fakeNginxRuntimeMgr.GetUpstreamsReturns(nil, nil, errors.New("error"))
-				Expect(handler.updateUpstreamServers(ctlrZap.New(), conf)).ToNot(Succeed())
+				Expect(handler.updateUpstreamServers(conf)).ToNot(Succeed())
+			})
+
+			It("should return error when UpdateHTTPServers API returns an error", func() {
+				fakeNginxRuntimeMgr.UpdateHTTPServersReturns(errors.New("error"))
+				Expect(handler.updateUpstreamServers(conf)).ToNot(Succeed())
+			})
+
+			It("should return error when UpdateStreamServers API returns an error", func() {
+				fakeNginxRuntimeMgr.UpdateStreamServersReturns(errors.New("error"))
+				Expect(handler.updateUpstreamServers(conf)).ToNot(Succeed())
 			})
 		})
 
 		When("not running NGINX Plus", func() {
 			It("should not do anything", func() {
-				Expect(handler.updateUpstreamServers(ctlrZap.New(), conf)).To(Succeed())
+				Expect(handler.updateUpstreamServers(conf)).To(Succeed())
 
 				Expect(fakeNginxRuntimeMgr.UpdateHTTPServersCallCount()).To(Equal(0))
 			})

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -172,15 +172,17 @@ func StartManager(cfg config.Config) error {
 	)
 
 	var ngxPlusClient ngxruntime.NginxPlusClient
+	if cfg.Plus {
+		ngxPlusClient, err = ngxruntime.CreatePlusClient()
+		if err != nil {
+			return fmt.Errorf("error creating NGINX plus client: %w", err)
+		}
+	}
 
 	if cfg.MetricsConfig.Enabled {
 		constLabels := map[string]string{"class": cfg.GatewayClassName}
 		var ngxCollector prometheus.Collector
 		if cfg.Plus {
-			ngxPlusClient, err = ngxruntime.CreatePlusClient()
-			if err != nil {
-				return fmt.Errorf("error creating NGINX plus client: %w", err)
-			}
 			ngxCollector, err = collectors.NewNginxPlusMetricsCollector(ngxPlusClient, constLabels, promLogger)
 		} else {
 			ngxCollector = collectors.NewNginxMetricsCollector(constLabels, promLogger)

--- a/internal/mode/static/nginx/config/convert.go
+++ b/internal/mode/static/nginx/config/convert.go
@@ -13,15 +13,7 @@ func ConvertEndpoints(eps []resolver.Endpoint) []ngxclient.UpstreamServer {
 	servers := make([]ngxclient.UpstreamServer, 0, len(eps))
 
 	for _, ep := range eps {
-		var port string
-		if ep.Port != 0 {
-			port = fmt.Sprintf(":%d", ep.Port)
-		}
-
-		format := "%s%s"
-		if ep.IPv6 {
-			format = "[%s]%s"
-		}
+		port, format := getPortAndIPFormat(ep)
 
 		server := ngxclient.UpstreamServer{
 			Server: fmt.Sprintf(format, ep.Address, port),
@@ -31,4 +23,36 @@ func ConvertEndpoints(eps []resolver.Endpoint) []ngxclient.UpstreamServer {
 	}
 
 	return servers
+}
+
+// ConvertStreamEndpoints converts a list of Endpoints into a list of NGINX Plus SDK StreamUpstreamServers.
+func ConvertStreamEndpoints(eps []resolver.Endpoint) []ngxclient.StreamUpstreamServer {
+	servers := make([]ngxclient.StreamUpstreamServer, 0, len(eps))
+
+	for _, ep := range eps {
+		port, format := getPortAndIPFormat(ep)
+
+		server := ngxclient.StreamUpstreamServer{
+			Server: fmt.Sprintf(format, ep.Address, port),
+		}
+
+		servers = append(servers, server)
+	}
+
+	return servers
+}
+
+func getPortAndIPFormat(ep resolver.Endpoint) (string, string) {
+	var port string
+
+	if ep.Port != 0 {
+		port = fmt.Sprintf(":%d", ep.Port)
+	}
+
+	format := "%s%s"
+	if ep.IPv6 {
+		format = "[%s]%s"
+	}
+
+	return port, format
 }

--- a/internal/mode/static/nginx/config/convert_test.go
+++ b/internal/mode/static/nginx/config/convert_test.go
@@ -42,3 +42,37 @@ func TestConvertEndpoints(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(ConvertEndpoints(endpoints)).To(Equal(expUpstreams))
 }
+
+func TestConvertStreamEndpoints(t *testing.T) {
+	t.Parallel()
+	endpoints := []resolver.Endpoint{
+		{
+			Address: "1.2.3.4",
+			Port:    80,
+		},
+		{
+			Address: "5.6.7.8",
+			Port:    0,
+		},
+		{
+			Address: "2001:db8::1",
+			Port:    443,
+			IPv6:    true,
+		},
+	}
+
+	expUpstreams := []ngxclient.StreamUpstreamServer{
+		{
+			Server: "1.2.3.4:80",
+		},
+		{
+			Server: "5.6.7.8",
+		},
+		{
+			Server: "[2001:db8::1]:443",
+		},
+	}
+
+	g := NewWithT(t)
+	g.Expect(ConvertStreamEndpoints(endpoints)).To(Equal(expUpstreams))
+}

--- a/internal/mode/static/nginx/config/http/config.go
+++ b/internal/mode/static/nginx/config/http/config.go
@@ -82,9 +82,10 @@ const (
 
 // Upstream holds all configuration for an HTTP upstream.
 type Upstream struct {
-	Name     string
-	ZoneSize string // format: 512k, 1m
-	Servers  []UpstreamServer
+	Name      string
+	ZoneSize  string // format: 512k, 1m
+	StateFile string
+	Servers   []UpstreamServer
 }
 
 // UpstreamServer holds all configuration for an HTTP upstream server.

--- a/internal/mode/static/nginx/config/stream/config.go
+++ b/internal/mode/static/nginx/config/stream/config.go
@@ -15,9 +15,10 @@ type Server struct {
 
 // Upstream holds all configuration for a stream upstream.
 type Upstream struct {
-	Name     string
-	ZoneSize string // format: 512k, 1m
-	Servers  []UpstreamServer
+	Name      string
+	ZoneSize  string // format: 512k, 1m
+	StateFile string
+	Servers   []UpstreamServer
 }
 
 // UpstreamServer holds all configuration for a stream upstream server.

--- a/internal/mode/static/nginx/config/upstreams_template.go
+++ b/internal/mode/static/nginx/config/upstreams_template.go
@@ -12,8 +12,13 @@ upstream {{ $u.Name }} {
     {{ if $u.ZoneSize -}}
     zone {{ $u.Name }} {{ $u.ZoneSize }};
     {{ end -}}
-    {{ range $server := $u.Servers }}
+
+    {{- if $u.StateFile }}
+    state {{ $u.StateFile }};
+    {{- else }}
+        {{ range $server := $u.Servers }}
     server {{ $server.Address }};
+        {{- end }}
     {{- end }}
 }
 {{ end -}}

--- a/internal/mode/static/nginx/runtime/manager_test.go
+++ b/internal/mode/static/nginx/runtime/manager_test.go
@@ -224,6 +224,17 @@ var _ = Describe("NGINX Runtime Manager", func() {
 			Expect(streamUpstreams).To(BeNil())
 		})
 
+		It("returns an error when GetUpstreams returns nil", func() {
+			ngxPlusClient.GetUpstreamsReturns(nil, nil)
+
+			upstreams, streamUpstreams, err := manager.GetUpstreams()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("GET upstreams returned nil value"))
+			Expect(upstreams).To(BeNil())
+			Expect(streamUpstreams).To(BeNil())
+		})
+
 		It("returns an error when GetStreamUpstreams fails", func() {
 			ngxPlusClient.GetUpstreamsReturns(&ngxclient.Upstreams{}, nil)
 			ngxPlusClient.GetStreamUpstreamsReturns(nil, errors.New("failed to get upstreams"))
@@ -232,6 +243,18 @@ var _ = Describe("NGINX Runtime Manager", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("failed to get upstreams"))
+			Expect(upstreams).To(BeNil())
+			Expect(streamUpstreams).To(BeNil())
+		})
+
+		It("returns an error when GetStreamUpstreams returns nil", func() {
+			ngxPlusClient.GetUpstreamsReturns(&ngxclient.Upstreams{}, nil)
+			ngxPlusClient.GetStreamUpstreamsReturns(nil, nil)
+
+			upstreams, streamUpstreams, err := manager.GetUpstreams()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("GET stream upstreams returned nil value"))
 			Expect(upstreams).To(BeNil())
 			Expect(streamUpstreams).To(BeNil())
 		})

--- a/internal/mode/static/nginx/runtime/runtimefakes/fake_manager.go
+++ b/internal/mode/static/nginx/runtime/runtimefakes/fake_manager.go
@@ -10,17 +10,19 @@ import (
 )
 
 type FakeManager struct {
-	GetUpstreamsStub        func() (client.Upstreams, error)
+	GetUpstreamsStub        func() (client.Upstreams, client.StreamUpstreams, error)
 	getUpstreamsMutex       sync.RWMutex
 	getUpstreamsArgsForCall []struct {
 	}
 	getUpstreamsReturns struct {
 		result1 client.Upstreams
-		result2 error
+		result2 client.StreamUpstreams
+		result3 error
 	}
 	getUpstreamsReturnsOnCall map[int]struct {
 		result1 client.Upstreams
-		result2 error
+		result2 client.StreamUpstreams
+		result3 error
 	}
 	IsPlusStub        func() bool
 	isPlusMutex       sync.RWMutex
@@ -56,11 +58,23 @@ type FakeManager struct {
 	updateHTTPServersReturnsOnCall map[int]struct {
 		result1 error
 	}
+	UpdateStreamServersStub        func(string, []client.StreamUpstreamServer) error
+	updateStreamServersMutex       sync.RWMutex
+	updateStreamServersArgsForCall []struct {
+		arg1 string
+		arg2 []client.StreamUpstreamServer
+	}
+	updateStreamServersReturns struct {
+		result1 error
+	}
+	updateStreamServersReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeManager) GetUpstreams() (client.Upstreams, error) {
+func (fake *FakeManager) GetUpstreams() (client.Upstreams, client.StreamUpstreams, error) {
 	fake.getUpstreamsMutex.Lock()
 	ret, specificReturn := fake.getUpstreamsReturnsOnCall[len(fake.getUpstreamsArgsForCall)]
 	fake.getUpstreamsArgsForCall = append(fake.getUpstreamsArgsForCall, struct {
@@ -73,9 +87,9 @@ func (fake *FakeManager) GetUpstreams() (client.Upstreams, error) {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeManager) GetUpstreamsCallCount() int {
@@ -84,36 +98,39 @@ func (fake *FakeManager) GetUpstreamsCallCount() int {
 	return len(fake.getUpstreamsArgsForCall)
 }
 
-func (fake *FakeManager) GetUpstreamsCalls(stub func() (client.Upstreams, error)) {
+func (fake *FakeManager) GetUpstreamsCalls(stub func() (client.Upstreams, client.StreamUpstreams, error)) {
 	fake.getUpstreamsMutex.Lock()
 	defer fake.getUpstreamsMutex.Unlock()
 	fake.GetUpstreamsStub = stub
 }
 
-func (fake *FakeManager) GetUpstreamsReturns(result1 client.Upstreams, result2 error) {
+func (fake *FakeManager) GetUpstreamsReturns(result1 client.Upstreams, result2 client.StreamUpstreams, result3 error) {
 	fake.getUpstreamsMutex.Lock()
 	defer fake.getUpstreamsMutex.Unlock()
 	fake.GetUpstreamsStub = nil
 	fake.getUpstreamsReturns = struct {
 		result1 client.Upstreams
-		result2 error
-	}{result1, result2}
+		result2 client.StreamUpstreams
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeManager) GetUpstreamsReturnsOnCall(i int, result1 client.Upstreams, result2 error) {
+func (fake *FakeManager) GetUpstreamsReturnsOnCall(i int, result1 client.Upstreams, result2 client.StreamUpstreams, result3 error) {
 	fake.getUpstreamsMutex.Lock()
 	defer fake.getUpstreamsMutex.Unlock()
 	fake.GetUpstreamsStub = nil
 	if fake.getUpstreamsReturnsOnCall == nil {
 		fake.getUpstreamsReturnsOnCall = make(map[int]struct {
 			result1 client.Upstreams
-			result2 error
+			result2 client.StreamUpstreams
+			result3 error
 		})
 	}
 	fake.getUpstreamsReturnsOnCall[i] = struct {
 		result1 client.Upstreams
-		result2 error
-	}{result1, result2}
+		result2 client.StreamUpstreams
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeManager) IsPlus() bool {
@@ -298,6 +315,73 @@ func (fake *FakeManager) UpdateHTTPServersReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeManager) UpdateStreamServers(arg1 string, arg2 []client.StreamUpstreamServer) error {
+	var arg2Copy []client.StreamUpstreamServer
+	if arg2 != nil {
+		arg2Copy = make([]client.StreamUpstreamServer, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.updateStreamServersMutex.Lock()
+	ret, specificReturn := fake.updateStreamServersReturnsOnCall[len(fake.updateStreamServersArgsForCall)]
+	fake.updateStreamServersArgsForCall = append(fake.updateStreamServersArgsForCall, struct {
+		arg1 string
+		arg2 []client.StreamUpstreamServer
+	}{arg1, arg2Copy})
+	stub := fake.UpdateStreamServersStub
+	fakeReturns := fake.updateStreamServersReturns
+	fake.recordInvocation("UpdateStreamServers", []interface{}{arg1, arg2Copy})
+	fake.updateStreamServersMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeManager) UpdateStreamServersCallCount() int {
+	fake.updateStreamServersMutex.RLock()
+	defer fake.updateStreamServersMutex.RUnlock()
+	return len(fake.updateStreamServersArgsForCall)
+}
+
+func (fake *FakeManager) UpdateStreamServersCalls(stub func(string, []client.StreamUpstreamServer) error) {
+	fake.updateStreamServersMutex.Lock()
+	defer fake.updateStreamServersMutex.Unlock()
+	fake.UpdateStreamServersStub = stub
+}
+
+func (fake *FakeManager) UpdateStreamServersArgsForCall(i int) (string, []client.StreamUpstreamServer) {
+	fake.updateStreamServersMutex.RLock()
+	defer fake.updateStreamServersMutex.RUnlock()
+	argsForCall := fake.updateStreamServersArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeManager) UpdateStreamServersReturns(result1 error) {
+	fake.updateStreamServersMutex.Lock()
+	defer fake.updateStreamServersMutex.Unlock()
+	fake.UpdateStreamServersStub = nil
+	fake.updateStreamServersReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeManager) UpdateStreamServersReturnsOnCall(i int, result1 error) {
+	fake.updateStreamServersMutex.Lock()
+	defer fake.updateStreamServersMutex.Unlock()
+	fake.UpdateStreamServersStub = nil
+	if fake.updateStreamServersReturnsOnCall == nil {
+		fake.updateStreamServersReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateStreamServersReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeManager) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -309,6 +393,8 @@ func (fake *FakeManager) Invocations() map[string][][]interface{} {
 	defer fake.reloadMutex.RUnlock()
 	fake.updateHTTPServersMutex.RLock()
 	defer fake.updateHTTPServersMutex.RUnlock()
+	fake.updateStreamServersMutex.RLock()
+	defer fake.updateStreamServersMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/internal/mode/static/nginx/runtime/runtimefakes/fake_nginx_plus_client.go
+++ b/internal/mode/static/nginx/runtime/runtimefakes/fake_nginx_plus_client.go
@@ -9,6 +9,18 @@ import (
 )
 
 type FakeNginxPlusClient struct {
+	GetStreamUpstreamsStub        func() (*client.StreamUpstreams, error)
+	getStreamUpstreamsMutex       sync.RWMutex
+	getStreamUpstreamsArgsForCall []struct {
+	}
+	getStreamUpstreamsReturns struct {
+		result1 *client.StreamUpstreams
+		result2 error
+	}
+	getStreamUpstreamsReturnsOnCall map[int]struct {
+		result1 *client.StreamUpstreams
+		result2 error
+	}
 	GetUpstreamsStub        func() (*client.Upstreams, error)
 	getUpstreamsMutex       sync.RWMutex
 	getUpstreamsArgsForCall []struct {
@@ -39,8 +51,82 @@ type FakeNginxPlusClient struct {
 		result3 []client.UpstreamServer
 		result4 error
 	}
+	UpdateStreamServersStub        func(string, []client.StreamUpstreamServer) ([]client.StreamUpstreamServer, []client.StreamUpstreamServer, []client.StreamUpstreamServer, error)
+	updateStreamServersMutex       sync.RWMutex
+	updateStreamServersArgsForCall []struct {
+		arg1 string
+		arg2 []client.StreamUpstreamServer
+	}
+	updateStreamServersReturns struct {
+		result1 []client.StreamUpstreamServer
+		result2 []client.StreamUpstreamServer
+		result3 []client.StreamUpstreamServer
+		result4 error
+	}
+	updateStreamServersReturnsOnCall map[int]struct {
+		result1 []client.StreamUpstreamServer
+		result2 []client.StreamUpstreamServer
+		result3 []client.StreamUpstreamServer
+		result4 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeNginxPlusClient) GetStreamUpstreams() (*client.StreamUpstreams, error) {
+	fake.getStreamUpstreamsMutex.Lock()
+	ret, specificReturn := fake.getStreamUpstreamsReturnsOnCall[len(fake.getStreamUpstreamsArgsForCall)]
+	fake.getStreamUpstreamsArgsForCall = append(fake.getStreamUpstreamsArgsForCall, struct {
+	}{})
+	stub := fake.GetStreamUpstreamsStub
+	fakeReturns := fake.getStreamUpstreamsReturns
+	fake.recordInvocation("GetStreamUpstreams", []interface{}{})
+	fake.getStreamUpstreamsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeNginxPlusClient) GetStreamUpstreamsCallCount() int {
+	fake.getStreamUpstreamsMutex.RLock()
+	defer fake.getStreamUpstreamsMutex.RUnlock()
+	return len(fake.getStreamUpstreamsArgsForCall)
+}
+
+func (fake *FakeNginxPlusClient) GetStreamUpstreamsCalls(stub func() (*client.StreamUpstreams, error)) {
+	fake.getStreamUpstreamsMutex.Lock()
+	defer fake.getStreamUpstreamsMutex.Unlock()
+	fake.GetStreamUpstreamsStub = stub
+}
+
+func (fake *FakeNginxPlusClient) GetStreamUpstreamsReturns(result1 *client.StreamUpstreams, result2 error) {
+	fake.getStreamUpstreamsMutex.Lock()
+	defer fake.getStreamUpstreamsMutex.Unlock()
+	fake.GetStreamUpstreamsStub = nil
+	fake.getStreamUpstreamsReturns = struct {
+		result1 *client.StreamUpstreams
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeNginxPlusClient) GetStreamUpstreamsReturnsOnCall(i int, result1 *client.StreamUpstreams, result2 error) {
+	fake.getStreamUpstreamsMutex.Lock()
+	defer fake.getStreamUpstreamsMutex.Unlock()
+	fake.GetStreamUpstreamsStub = nil
+	if fake.getStreamUpstreamsReturnsOnCall == nil {
+		fake.getStreamUpstreamsReturnsOnCall = make(map[int]struct {
+			result1 *client.StreamUpstreams
+			result2 error
+		})
+	}
+	fake.getStreamUpstreamsReturnsOnCall[i] = struct {
+		result1 *client.StreamUpstreams
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeNginxPlusClient) GetUpstreams() (*client.Upstreams, error) {
@@ -175,13 +261,93 @@ func (fake *FakeNginxPlusClient) UpdateHTTPServersReturnsOnCall(i int, result1 [
 	}{result1, result2, result3, result4}
 }
 
+func (fake *FakeNginxPlusClient) UpdateStreamServers(arg1 string, arg2 []client.StreamUpstreamServer) ([]client.StreamUpstreamServer, []client.StreamUpstreamServer, []client.StreamUpstreamServer, error) {
+	var arg2Copy []client.StreamUpstreamServer
+	if arg2 != nil {
+		arg2Copy = make([]client.StreamUpstreamServer, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.updateStreamServersMutex.Lock()
+	ret, specificReturn := fake.updateStreamServersReturnsOnCall[len(fake.updateStreamServersArgsForCall)]
+	fake.updateStreamServersArgsForCall = append(fake.updateStreamServersArgsForCall, struct {
+		arg1 string
+		arg2 []client.StreamUpstreamServer
+	}{arg1, arg2Copy})
+	stub := fake.UpdateStreamServersStub
+	fakeReturns := fake.updateStreamServersReturns
+	fake.recordInvocation("UpdateStreamServers", []interface{}{arg1, arg2Copy})
+	fake.updateStreamServersMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3, ret.result4
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
+}
+
+func (fake *FakeNginxPlusClient) UpdateStreamServersCallCount() int {
+	fake.updateStreamServersMutex.RLock()
+	defer fake.updateStreamServersMutex.RUnlock()
+	return len(fake.updateStreamServersArgsForCall)
+}
+
+func (fake *FakeNginxPlusClient) UpdateStreamServersCalls(stub func(string, []client.StreamUpstreamServer) ([]client.StreamUpstreamServer, []client.StreamUpstreamServer, []client.StreamUpstreamServer, error)) {
+	fake.updateStreamServersMutex.Lock()
+	defer fake.updateStreamServersMutex.Unlock()
+	fake.UpdateStreamServersStub = stub
+}
+
+func (fake *FakeNginxPlusClient) UpdateStreamServersArgsForCall(i int) (string, []client.StreamUpstreamServer) {
+	fake.updateStreamServersMutex.RLock()
+	defer fake.updateStreamServersMutex.RUnlock()
+	argsForCall := fake.updateStreamServersArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeNginxPlusClient) UpdateStreamServersReturns(result1 []client.StreamUpstreamServer, result2 []client.StreamUpstreamServer, result3 []client.StreamUpstreamServer, result4 error) {
+	fake.updateStreamServersMutex.Lock()
+	defer fake.updateStreamServersMutex.Unlock()
+	fake.UpdateStreamServersStub = nil
+	fake.updateStreamServersReturns = struct {
+		result1 []client.StreamUpstreamServer
+		result2 []client.StreamUpstreamServer
+		result3 []client.StreamUpstreamServer
+		result4 error
+	}{result1, result2, result3, result4}
+}
+
+func (fake *FakeNginxPlusClient) UpdateStreamServersReturnsOnCall(i int, result1 []client.StreamUpstreamServer, result2 []client.StreamUpstreamServer, result3 []client.StreamUpstreamServer, result4 error) {
+	fake.updateStreamServersMutex.Lock()
+	defer fake.updateStreamServersMutex.Unlock()
+	fake.UpdateStreamServersStub = nil
+	if fake.updateStreamServersReturnsOnCall == nil {
+		fake.updateStreamServersReturnsOnCall = make(map[int]struct {
+			result1 []client.StreamUpstreamServer
+			result2 []client.StreamUpstreamServer
+			result3 []client.StreamUpstreamServer
+			result4 error
+		})
+	}
+	fake.updateStreamServersReturnsOnCall[i] = struct {
+		result1 []client.StreamUpstreamServer
+		result2 []client.StreamUpstreamServer
+		result3 []client.StreamUpstreamServer
+		result4 error
+	}{result1, result2, result3, result4}
+}
+
 func (fake *FakeNginxPlusClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.getStreamUpstreamsMutex.RLock()
+	defer fake.getStreamUpstreamsMutex.RUnlock()
 	fake.getUpstreamsMutex.RLock()
 	defer fake.getUpstreamsMutex.RUnlock()
 	fake.updateHTTPServersMutex.RLock()
 	defer fake.updateHTTPServersMutex.RUnlock()
+	fake.updateStreamServersMutex.RLock()
+	defer fake.updateStreamServersMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
Problem: When splitting the data and control plane, we want to be able to maintain the ability to dynamically update upstreams without a reload if using NGINX Plus. With the current process, we write the upstreams into the nginx conf but don't reload, then call the API to actually do the update. Writing into the conf will trigger a reload from the agent once we split, however.

There were also two bugs:
- if metrics were disabled, the nginx plus client was not initialized, preventing API calls from occuring and instead a reload occurred
- stream upstreams were not updated with the API

Solution: Don't write the upstream servers into the nginx conf anymore when using NGINX Plus. Instead, utilize the `state` file option that the NGINX Plus API will populate with the upstream servers. This way we can just call the API and don't unintentionally reload by writing servers into the conf.

Also added support for updating stream upstreams, and fixed the initialization bug.

Testing: Verified that the state file is set and populated when using NGINX Plus. With OSS, servers are still written to the config.

Closes #2841

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix an issue where updating upstreams with the NGINX Plus API would not occur if metrics were disabled.

Support updating stream upstreams with the NGINX Plus API instead of reloading NGINX.

Use state files for NGINX Plus upstream servers instead of the NGINX config.
```
