### PR TITLE
Move check for plus usage endpoint to test-with-plus target

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -133,7 +133,7 @@ stop-longevity-test: nfr-test ## Stop the longevity test and collects results
 		--plus-license-file-name=$(PLUS_LICENSE_FILE) --plus-usage-endpoint=$(PLUS_USAGE_ENDPOINT)
 
 .PHONY: test
-test: check-for-plus-usage-endpoint build-crossplane-image ## Runs the functional tests on your kind k8s cluster
+test: build-crossplane-image ## Runs the functional tests on your kind k8s cluster
 	kind load docker-image nginx-crossplane:latest --name $(CLUSTER_NAME)
 	go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --randomize-suites --keep-going --fail-on-pending \
 		--trace -r -v --buildvcs --force-newlines $(GITHUB_OUTPUT) \
@@ -146,7 +146,7 @@ test: check-for-plus-usage-endpoint build-crossplane-image ## Runs the functiona
 		--plus-license-file-name=$(PLUS_LICENSE_FILE) --plus-usage-endpoint=$(PLUS_USAGE_ENDPOINT)
 
 .PHONY: test-with-plus
-test-with-plus: PLUS_ENABLED=true
+test-with-plus: check-for-plus-usage-endpoint PLUS_ENABLED=true
 test-with-plus: test ## Runs the functional tests for NGF with NGINX Plus on your default k8s cluster
 
 .PHONY: cleanup-gcp


### PR DESCRIPTION
### Proposed changes

Problem: Functional tests for OSS on forks are failing because the PLUS_USAGE_ENDPOINT isn't set.

Solution: Move check for PLUS_USAGE_ENDPOINT to the `test-with-plus` target.

Testing: testing in pipeline on fork

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
