### PR TITLE
Collect UpstreamSettingsPolicyCount in telemetry

### DIFF
--- a/internal/mode/static/telemetry/collector.go
+++ b/internal/mode/static/telemetry/collector.go
@@ -97,6 +97,8 @@ type NGFResourceCounts struct {
 	NginxProxyCount int64
 	// SnippetsFilterCount is the number of SnippetsFilters.
 	SnippetsFilterCount int64
+	// UpstreamSettingsPolicyCount is the number of UpstreamSettingsPolicies.
+	UpstreamSettingsPolicyCount int64
 }
 
 // DataCollectorConfig holds configuration parameters for DataCollectorImpl.
@@ -239,6 +241,8 @@ func collectGraphResourceCount(
 			}
 		case kinds.ObservabilityPolicy:
 			ngfResourceCounts.ObservabilityPolicyCount++
+		case kinds.UpstreamSettingsPolicy:
+			ngfResourceCounts.UpstreamSettingsPolicyCount++
 		}
 	}
 

--- a/internal/mode/static/telemetry/collector_test.go
+++ b/internal/mode/static/telemetry/collector_test.go
@@ -329,6 +329,10 @@ var _ = Describe("Collector", Ordered, func() {
 							NsName: types.NamespacedName{Namespace: "test", Name: "ObservabilityPolicy-1"},
 							GVK:    schema.GroupVersionKind{Kind: kinds.ObservabilityPolicy},
 						}: {},
+						{
+							NsName: types.NamespacedName{Namespace: "test", Name: "UpstreamSettingsPolicy-1"},
+							GVK:    schema.GroupVersionKind{Kind: kinds.UpstreamSettingsPolicy},
+						}: {},
 					},
 					NginxProxy: &graph.NginxProxy{},
 					SnippetsFilters: map[types.NamespacedName]*graph.SnippetsFilter{
@@ -412,6 +416,7 @@ var _ = Describe("Collector", Ordered, func() {
 					ObservabilityPolicyCount:                 1,
 					NginxProxyCount:                          1,
 					SnippetsFilterCount:                      3,
+					UpstreamSettingsPolicyCount:              1,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"
@@ -603,6 +608,10 @@ var _ = Describe("Collector", Ordered, func() {
 						NsName: types.NamespacedName{Namespace: "test", Name: "ObservabilityPolicy-1"},
 						GVK:    schema.GroupVersionKind{Kind: kinds.ObservabilityPolicy},
 					}: {},
+					{
+						NsName: types.NamespacedName{Namespace: "test", Name: "UpstreamSettingsPolicy-1"},
+						GVK:    schema.GroupVersionKind{Kind: kinds.UpstreamSettingsPolicy},
+					}: {},
 				},
 				NginxProxy: &graph.NginxProxy{},
 				SnippetsFilters: map[types.NamespacedName]*graph.SnippetsFilter{
@@ -682,6 +691,7 @@ var _ = Describe("Collector", Ordered, func() {
 					ObservabilityPolicyCount:                 1,
 					NginxProxyCount:                          1,
 					SnippetsFilterCount:                      1,
+					UpstreamSettingsPolicyCount:              1,
 				}
 
 				data, err := dataCollector.Collect(ctx)
@@ -693,22 +703,7 @@ var _ = Describe("Collector", Ordered, func() {
 			It("ignores invalid and empty upstreams", func(ctx SpecContext) {
 				fakeGraphGetter.GetLatestGraphReturns(&graph.Graph{})
 				fakeConfigurationGetter.GetLatestConfigurationReturns(invalidUpstreamsConfig)
-				expData.NGFResourceCounts = telemetry.NGFResourceCounts{
-					GatewayCount:                             0,
-					GatewayClassCount:                        0,
-					HTTPRouteCount:                           0,
-					TLSRouteCount:                            0,
-					SecretCount:                              0,
-					ServiceCount:                             0,
-					EndpointCount:                            0,
-					GRPCRouteCount:                           0,
-					BackendTLSPolicyCount:                    0,
-					GatewayAttachedClientSettingsPolicyCount: 0,
-					RouteAttachedClientSettingsPolicyCount:   0,
-					ObservabilityPolicyCount:                 0,
-					NginxProxyCount:                          0,
-					SnippetsFilterCount:                      0,
-				}
+				expData.NGFResourceCounts = telemetry.NGFResourceCounts{}
 
 				data, err := dataCollector.Collect(ctx)
 

--- a/internal/mode/static/telemetry/data.avdl
+++ b/internal/mode/static/telemetry/data.avdl
@@ -99,6 +99,9 @@ attached at the Gateway level. */
 		/** SnippetsFilterCount is the number of SnippetsFilters. */
 		long? SnippetsFilterCount = null;
 		
+		/** UpstreamSettingsPolicyCount is the number of UpstreamSettingsPolicies. */
+		long? UpstreamSettingsPolicyCount = null;
+		
 		/** NGFReplicaCount is the number of replicas of the NGF Pod. */
 		long? NGFReplicaCount = null;
 		

--- a/internal/mode/static/telemetry/data_test.go
+++ b/internal/mode/static/telemetry/data_test.go
@@ -39,6 +39,7 @@ func TestDataAttributes(t *testing.T) {
 			ObservabilityPolicyCount:                 11,
 			NginxProxyCount:                          12,
 			SnippetsFilterCount:                      13,
+			UpstreamSettingsPolicyCount:              14,
 		},
 		NGFReplicaCount:                3,
 		SnippetsFiltersDirectives:      []string{"main-three-count", "http-two-count", "server-one-count"},
@@ -77,6 +78,7 @@ func TestDataAttributes(t *testing.T) {
 		attribute.Int64("ObservabilityPolicyCount", 11),
 		attribute.Int64("NginxProxyCount", 12),
 		attribute.Int64("SnippetsFilterCount", 13),
+		attribute.Int64("UpstreamSettingsPolicyCount", 14),
 		attribute.Int64("NGFReplicaCount", 3),
 	}
 
@@ -119,6 +121,7 @@ func TestDataAttributesWithEmptyData(t *testing.T) {
 		attribute.Int64("ObservabilityPolicyCount", 0),
 		attribute.Int64("NginxProxyCount", 0),
 		attribute.Int64("SnippetsFilterCount", 0),
+		attribute.Int64("UpstreamSettingsPolicyCount", 0),
 		attribute.Int64("NGFReplicaCount", 0),
 	}
 

--- a/internal/mode/static/telemetry/ngfresourcecounts_attributes_generated.go
+++ b/internal/mode/static/telemetry/ngfresourcecounts_attributes_generated.go
@@ -26,6 +26,7 @@ func (d *NGFResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("ObservabilityPolicyCount", d.ObservabilityPolicyCount))
 	attrs = append(attrs, attribute.Int64("NginxProxyCount", d.NginxProxyCount))
 	attrs = append(attrs, attribute.Int64("SnippetsFilterCount", d.SnippetsFilterCount))
+	attrs = append(attrs, attribute.Int64("UpstreamSettingsPolicyCount", d.UpstreamSettingsPolicyCount))
 
 	return attrs
 }

--- a/site/content/overview/product-telemetry.md
+++ b/site/content/overview/product-telemetry.md
@@ -27,7 +27,7 @@ Telemetry data is collected once every 24 hours and sent to a service managed by
 - **Deployment Replica Count:** the count of NGINX Gateway Fabric Pods.
 - **Image Build Source:** whether the image was built by GitHub or locally (values are `gha`, `local`, or `unknown`). The source repository of the images is **not** collected.
 - **Deployment Flags:** a list of NGINX Gateway Fabric Deployment flags that are specified by a user. The actual values of non-boolean flags are **not** collected; we only record that they are either `true` or `false` for boolean flags and `default` or `user-defined` for the rest.
-- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `TLSRoutes`, `Secrets`, `Services`, `BackendTLSPolicies`, `ClientSettingsPolicies`, `NginxProxies`, `ObservabilityPolicies`, `SnippetsFilters`, and `Endpoints`. The data within these resources is **not** collected.
+- **Count of Resources:** the total count of resources related to NGINX Gateway Fabric. This includes `GatewayClasses`, `Gateways`, `HTTPRoutes`,`GRPCRoutes`, `TLSRoutes`, `Secrets`, `Services`, `BackendTLSPolicies`, `ClientSettingsPolicies`, `NginxProxies`, `ObservabilityPolicies`, `UpstreamSettingsPolicies`, `SnippetsFilters`, and `Endpoints`. The data within these resources is **not** collected.
 - **SnippetsFilters Info**a list of directive-context strings from applied SnippetFilters and a total count per strings. The actual value of any NGINX directive is **not** collected.
 This data is used to identify the following information:
 

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -88,6 +88,7 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 				"ObservabilityPolicyCount: Int(0)",
 				"NginxProxyCount: Int(0)",
 				"SnippetsFilterCount: Int(0)",
+				"UpstreamSettingsPolicyCount: Int(0)",
 				"NGFReplicaCount: Int(1)",
 			},
 		)


### PR DESCRIPTION
### Proposed changes

Problem: Want to collect number of UpstreamSettingsPolicies in cluster.

Solution: Collect the count of UpstreamSettingsPolicies in cluster.

Testing: Unit tests and manually verified collection via debug logs

Closes #2370 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Collect UpstreamSettingsPolicy count for data telemetry
```
