### PR TITLE
Add patch version to site/go.mod

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -1,5 +1,5 @@
 module github.com/nginxinc/nginx-gateway-fabric/site
 
-go 1.21
+go 1.21.0
 
 require github.com/nginxinc/nginx-hugo-theme v0.41.23 // indirect


### PR DESCRIPTION
Problem: As of Go 1.21, toolchain versions must use the 1.N.P syntax. This is causing a warning from CodeQL in our pipelines.

Solution: Add the minimum patch version.
