### PR TITLE
Fix duplicate ancestors on UpstreamSettingsPolicy status

### DIFF
--- a/internal/mode/static/state/graph/policies.go
+++ b/internal/mode/static/state/graph/policies.go
@@ -112,11 +112,18 @@ func attachPolicyToService(
 
 	if !gw.Valid {
 		ancestor.Conditions = []conditions.Condition{staticConds.NewPolicyTargetNotFound("Parent Gateway is invalid")}
+		if ancestorsContainsAncestorRef(policy.Ancestors, ancestor.Ancestor) {
+			return
+		}
+
 		policy.Ancestors = append(policy.Ancestors, ancestor)
 		return
 	}
 
-	policy.Ancestors = append(policy.Ancestors, ancestor)
+	if !ancestorsContainsAncestorRef(policy.Ancestors, ancestor.Ancestor) {
+		policy.Ancestors = append(policy.Ancestors, ancestor)
+	}
+
 	svc.Policies = append(svc.Policies, policy)
 }
 

--- a/internal/mode/static/state/graph/policy_ancestor.go
+++ b/internal/mode/static/state/graph/policy_ancestor.go
@@ -4,6 +4,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/nginxinc/nginx-gateway-fabric/internal/framework/helpers"
 )
 
 const maxAncestors = 16
@@ -60,4 +62,36 @@ func createParentReference(
 		Namespace: (*v1.Namespace)(&nsname.Namespace),
 		Name:      v1.ObjectName(nsname.Name),
 	}
+}
+
+func ancestorsContainsAncestorRef(ancestors []PolicyAncestor, ref v1.ParentReference) bool {
+	for _, an := range ancestors {
+		if parentRefEqual(an.Ancestor, ref) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parentRefEqual(ref1, ref2 v1.ParentReference) bool {
+	if !helpers.EqualPointers(ref1.Kind, ref2.Kind) {
+		return false
+	}
+
+	if !helpers.EqualPointers(ref1.Group, ref2.Group) {
+		return false
+	}
+
+	if !helpers.EqualPointers(ref1.Namespace, ref2.Namespace) {
+		return false
+	}
+
+	// we don't check the other fields in ParentRef because we don't set them
+
+	if ref1.Name != ref2.Name {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
### Proposed changes

Problem: When an UpstreamSettingsPolicy targeted multiple Services, NGF would write duplicate ancestors to its status.

Solution: Only add unique ancestors to policy ancestors list.

Testing: Added unit tests and manually verified that only one ancestor is written to the status.

Closes #2935 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
None
```
