### PR TITLE
Fix rewrite path for ReplacePrefixMatch to parse request arguments correctly

### DIFF
--- a/internal/mode/static/nginx/config/servers_test.go
+++ b/internal/mode/static/nginx/config/servers_test.go
@@ -1307,7 +1307,7 @@ func TestCreateServers(t *testing.T) {
 			},
 			{
 				Path:            "/_ngf-internal-rule8-route0",
-				Rewrites:        []string{"^ $request_uri", "^/rewrite-with-headers(.*)$ /prefix-replacement$1 break"},
+				Rewrites:        []string{"^ $request_uri", "^/rewrite-with-headers([^?]*)? /prefix-replacement$1?$args? break"},
 				ProxyPass:       "http://test_foo_80",
 				ProxySetHeaders: rewriteProxySetHeaders,
 				Type:            http.InternalLocationType,
@@ -2427,7 +2427,7 @@ func TestCreateRewritesValForRewriteFilter(t *testing.T) {
 			},
 			expected: &rewriteConfig{
 				InternalRewrite: "^ $request_uri",
-				MainRewrite:     "^/original(.*)$ /prefix-path$1 break",
+				MainRewrite:     "^/original([^?]*)? /prefix-path$1?$args? break",
 			},
 			msg: "prefix path no trailing slashes",
 		},
@@ -2441,7 +2441,7 @@ func TestCreateRewritesValForRewriteFilter(t *testing.T) {
 			},
 			expected: &rewriteConfig{
 				InternalRewrite: "^ $request_uri",
-				MainRewrite:     "^/original(?:/(.*))?$ /$1 break",
+				MainRewrite:     "^/original(?:/([^?]*))? /$1?$args? break",
 			},
 			msg: "prefix path empty string",
 		},
@@ -2455,7 +2455,7 @@ func TestCreateRewritesValForRewriteFilter(t *testing.T) {
 			},
 			expected: &rewriteConfig{
 				InternalRewrite: "^ $request_uri",
-				MainRewrite:     "^/original(?:/(.*))?$ /$1 break",
+				MainRewrite:     "^/original(?:/([^?]*))? /$1?$args? break",
 			},
 			msg: "prefix path /",
 		},
@@ -2469,7 +2469,7 @@ func TestCreateRewritesValForRewriteFilter(t *testing.T) {
 			},
 			expected: &rewriteConfig{
 				InternalRewrite: "^ $request_uri",
-				MainRewrite:     "^/original(?:/(.*))?$ /trailing/$1 break",
+				MainRewrite:     "^/original(?:/([^?]*))? /trailing/$1?$args? break",
 			},
 			msg: "prefix path replacement with trailing /",
 		},
@@ -2483,7 +2483,7 @@ func TestCreateRewritesValForRewriteFilter(t *testing.T) {
 			},
 			expected: &rewriteConfig{
 				InternalRewrite: "^ $request_uri",
-				MainRewrite:     "^/original/(.*)$ /prefix-path/$1 break",
+				MainRewrite:     "^/original/([^?]*)? /prefix-path/$1?$args? break",
 			},
 			msg: "prefix path original with trailing /",
 		},
@@ -2497,7 +2497,7 @@ func TestCreateRewritesValForRewriteFilter(t *testing.T) {
 			},
 			expected: &rewriteConfig{
 				InternalRewrite: "^ $request_uri",
-				MainRewrite:     "^/original/(.*)$ /trailing/$1 break",
+				MainRewrite:     "^/original/([^?]*)? /trailing/$1?$args? break",
 			},
 			msg: "prefix path both with trailing slashes",
 		},

--- a/site/content/how-to/traffic-management/redirects-and-rewrites.md
+++ b/site/content/how-to/traffic-management/redirects-and-rewrites.md
@@ -189,6 +189,17 @@ URI: /beans
 ```
 
 ```shell
+curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/coffee/mocha\?test\=v1\&test\=v2
+```
+
+```text
+Server address: 10.244.0.235:8080
+Server name: coffee-6db967495b-twn6x
+...
+URI: /beans?test=v1&test=v2
+```
+
+```shell
 curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte/prices
 ```
 
@@ -197,6 +208,18 @@ Server address: 10.244.0.6:8080
 Server name: coffee-6b8b6d6486-7fc78
 ...
 URI: /prices
+```
+
+```shell
+curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte/prices\?test\=v1\&test\=v2
+```
+
+```text
+curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte/prices\?test\=v1\&test\=v2
+Server address: 10.244.0.235:8080
+Server name: coffee-6db967495b-twn6x
+...
+URI: /prices?test=v1&test=v2
 ```
 
 ## Further reading


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Users want query params to be parsed correctly when using `ReplacePrefixMatch`. 

Solution: Updates the regex to parse query params to be parsed separately using the `$args` variable. 

I updated the regex to capture everything from the matching variable to a `?` found (if present) and then use nginx variable `$args` to append the request arguments. This avoids processing the entire variable after the prefix via nginx, leading to encoded characters in the resulting path.

1. Regex update explanation 

`^%s(.*)$` --> `^%s([^?]*)?`  - Captures the path till a `?` is found. Using `?` at the end makes the capture group optional
`%s$1` --> `%s$1?$args?` - `$1` indicates the path captured above till a `?` is found. Concatenating the path captured + ? + args associated with the request. The `?` at the end, tells [Nginx](https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite) to not double append `args`. 

2. Updated documentation in Redirects and Rewrite [example](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/site/content/how-to/traffic-management/redirects-and-rewrites.md) to showcase expected behavior when using query parameters when using `ReplaceFullPath` and `ReplacePrefixMatch` for users.

Testing: 
1. Updated existing unit tests
2. Manual testing with Redirects and Redirects [example](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/site/content/how-to/traffic-management/redirects-and-rewrites.md)  with HTTPRoute slightly modified by adding method GET


```
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: coffee
spec:
  parentRefs:
  - name: cafe
    sectionName: http
  hostnames:
  - "cafe.example.com"
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /latte
      method: GET
    filters:
    - type: URLRewrite
      urlRewrite:
        path:
          type: ReplacePrefixMatch
          replacePrefixMatch: /
    backendRefs:
    - name: coffee
      port: 80
EOF
```

Results

```
curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte/prices
Handling connection for 8080
Server address: 10.244.0.235:8080
Server name: coffee-6db967495b-twn6x
Date: 23/Dec/2024:20:46:15 +0000
URI: /prices
Request ID: 235d5fb72bf8c4be343926d27da0c996
```

```
curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte
Handling connection for 8080
Server address: 10.244.0.235:8080
Server name: coffee-6db967495b-twn6x
Date: 23/Dec/2024:20:46:48 +0000
URI: /
Request ID: a7f8c33333984f922090f9ae672db40f
```

```
curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte/prices\?test\=v1\&test\=v2
Handling connection for 8080
Server address: 10.244.0.235:8080
Server name: coffee-6db967495b-twn6x
Date: 23/Dec/2024:20:47:11 +0000
URI: /prices?test=v1&test=v2
Request ID: b21f0fd7005760a338eb99dfd6595af1
```

```
curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/
Handling connection for 8080
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

3. Testing with the POST method

```
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: coffee
spec:
  parentRefs:
  - name: cafe
    sectionName: http
  hostnames:
  - "cafe.example.com"
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /latte
      method: POST
    filters:
    - type: URLRewrite
      urlRewrite:
        path:
          type: ReplacePrefixMatch
          replacePrefixMatch: /
    backendRefs:
    - name: coffee
      port: 80
EOF
```

Results

```
curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte\?test\=v1 -X POST
Server address: 10.244.0.235:8080
Server name: coffee-6db967495b-twn6x
Date: 23/Dec/2024:18:39:38 +0000
URI: /?test=v1
Request ID: e2231bc3899fa29e1ce1e345c40cfa9b
```

```
curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte/prices\?test\=v1 -X POST
Server address: 10.244.0.235:8080
Server name: coffee-6db967495b-twn6x
Date: 23/Dec/2024:18:40:27 +0000
URI: /prices?test=v1
Request ID: 72068bd237709ec7d4a7a02558cb461a
```

```
curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/latte/ -X POST                
Server address: 10.244.0.235:8080
Server name: coffee-6db967495b-twn6x
Date: 23/Dec/2024:18:40:43 +0000
URI: /
Request ID: bcfb4194707d4c38f35e4e68987745fe
```


Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #2862 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixes rewrite path for ReplacePrefixMatch to parse request arguments correctly.
```
