### PR TITLE
Improve usage reporting in automated tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Setup license file for plus
         if: ${{ inputs.image == 'plus' }}
         env:
-          PLUS_LICENSE: ${{ secrets.JWT_PLUS_REPORTING }}
+          PLUS_LICENSE: ${{ secrets.JWT_PLUS_EXCEPTION_REPORTING }}
         run: echo "${PLUS_LICENSE}" > license.jwt
 
       - name: Setup conformance tests

--- a/tests/framework/nginx_log_levels.go
+++ b/tests/framework/nginx_log_levels.go
@@ -1,6 +1,6 @@
 package framework
 
-// NGINX Log Prefixes for various log levels
+// NGINX Log Prefixes for various log levels.
 const (
 	CritNGINXLog  = "[crit]"
 	ErrorNGINXLog = "[error]"

--- a/tests/framework/nginx_log_levels.go
+++ b/tests/framework/nginx_log_levels.go
@@ -1,0 +1,10 @@
+package framework
+
+// NGINX Log Prefixes for various log levels
+const (
+	CritNGINXLog  = "[crit]"
+	ErrorNGINXLog = "[error]"
+	WarnNGINXLog  = "[warn]"
+	AlertNGINXLog = "[alert]"
+	EmergNGINXLog = "[emerg]"
+)

--- a/tests/suite/graceful_recovery_test.go
+++ b/tests/suite/graceful_recovery_test.go
@@ -400,7 +400,6 @@ func getUnexpectedNginxErrorLogs(ngfPodName string) string {
 	errorLogs := getNginxErrorLogs(ngfPodName)
 
 	for _, line := range strings.Split(errorLogs, "\n") {
-
 		if !slices.ContainsFunc(expectedErrStrings, func(s string) bool {
 			return strings.Contains(line, s)
 		}) {
@@ -423,7 +422,6 @@ func checkNGFContainerLogsForErrors(ngfPodName string) {
 	for _, line := range strings.Split(ngfLogs, "\n") {
 		Expect(line).ToNot(ContainSubstring("\"level\":\"error\""), line)
 	}
-
 }
 
 func checkLeaderLeaseChange(originalLeaseName string) error {

--- a/tests/suite/graceful_recovery_test.go
+++ b/tests/suite/graceful_recovery_test.go
@@ -370,7 +370,13 @@ func getNginxErrorLogs(ngfPodName string) string {
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	errPrefixes := []string{"[crit]", "[error]", "[warn]", "[alert]", "[emerg]"}
+	errPrefixes := []string{
+		framework.CritNGINXLog,
+		framework.ErrorNGINXLog,
+		framework.WarnNGINXLog,
+		framework.AlertNGINXLog,
+		framework.EmergNGINXLog,
+	}
 	errorLogs := ""
 
 	for _, line := range strings.Split(nginxLogs, "\n") {

--- a/tests/suite/reconfig_test.go
+++ b/tests/suite/reconfig_test.go
@@ -598,12 +598,12 @@ type reconfigTestResults struct {
 	TestDescription      string
 	TimeToReadyTotal     string
 	TimeToReadyAvgSingle string
+	NGINXErrorLogs       string
 	EventsBuckets        []framework.Bucket
 	ReloadBuckets        []framework.Bucket
 	NumResources         int
 	NGINXReloads         int
 	NGINXReloadAvgTime   int
-	NGINXErrorLogs       string
 	EventsCount          int
 	EventsAvgTime        int
 }

--- a/tests/suite/reconfig_test.go
+++ b/tests/suite/reconfig_test.go
@@ -405,7 +405,8 @@ var _ = Describe("Reconfiguration Performance Testing", Ordered, Label("nfr", "r
 			).WithTimeout(metricExistTimeout).WithPolling(metricExistPolling).Should(Succeed())
 		}
 
-		checkContainerLogsForErrors(ngfPodName, false)
+		checkNGFContainerLogsForErrors(ngfPodName)
+		nginxErrorLogs := getNginxErrorLogs(ngfPodName)
 
 		reloadCount, err := framework.GetReloadCount(promInstance, ngfPodName)
 		Expect(err).ToNot(HaveOccurred())
@@ -447,6 +448,7 @@ var _ = Describe("Reconfiguration Performance Testing", Ordered, Label("nfr", "r
 			TimeToReadyAvgSingle: timeToReadyAvgSingle,
 			NGINXReloads:         int(reloadCount),
 			NGINXReloadAvgTime:   int(reloadAvgTime),
+			NGINXErrorLogs:       nginxErrorLogs,
 			EventsCount:          int(eventsCount),
 			EventsAvgTime:        int(eventsAvgTime),
 		}
@@ -601,6 +603,7 @@ type reconfigTestResults struct {
 	NumResources         int
 	NGINXReloads         int
 	NGINXReloadAvgTime   int
+	NGINXErrorLogs       string
 	EventsCount          int
 	EventsAvgTime        int
 }
@@ -627,6 +630,9 @@ const reconfigResultTemplate = `
 {{- range .EventsBuckets }}
 	- {{ .Le }}ms: {{ .Val }}
 {{- end }}
+
+### NGINX Error Logs
+{{ .NGINXErrorLogs }}
 `
 
 func writeReconfigResults(dest io.Writer, results reconfigTestResults) error {

--- a/tests/suite/scale_test.go
+++ b/tests/suite/scale_test.go
@@ -368,7 +368,7 @@ The logs are attached only if there are errors.
 		)
 		nginxErrors := checkLogErrors(
 			"nginx",
-			[]string{"[error]", "[emerg]", "[crit]", "[alert]"},
+			[]string{framework.ErrorNGINXLog, framework.EmergNGINXLog, framework.CritNGINXLog, framework.AlertNGINXLog},
 			nil,
 			filepath.Join(testResultsDir, framework.CreateResultsFilename("log", "nginx", *plusEnabled)),
 		)


### PR DESCRIPTION
### Proposed changes

Problem: Pipelines are failing intermittently due to r33 reporting errors. 

Solutions: 
- In the graceful recovery and reconfig tests, do not fail if there are errors in the NGINX logs. Instead, log the errors and continue. In the reconfig tests, all NGINX error logs are captured in the results file. Since the graceful recovery tests are part of the functional tests that run on every push to a PR and merge to main, it is not desirable to write the error logs to a file. Instead, if an unexpected error is seen in the NGINX logs, the test is skipped and the error is logged in the test output. Since we are sending traffic through NGINX during the graceful recovery tests, we will still catch any unrecoverable NGINX errors. 
- Reporting for conformance tests is disabled. 

Testing: Ran graceful recovery and reconfig tests locally and verified new behavior.

Example of NGINX error logs in reconfig results:
<img width="828" alt="Screenshot 2025-01-03 at 9 06 51 AM" src="https://github.com/user-attachments/assets/2b86cbca-64c8-4617-bef1-81977d29e815" />


Example of NGINX error logs outputted by graceful recovery tests (this error was forced by commenting out an expected error message):
![Screenshot 2025-01-03 at 11 19 43 AM](https://github.com/user-attachments/assets/4f00762e-321d-48fd-a3b3-30596082e925)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
