### PR TITLE
Add support for additional service labels to the helm chart

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -300,6 +300,7 @@ The following table lists the configurable parameters of the NGINX Gateway Fabri
 | `nginxGateway.snippetsFilters.enable` | Enable SnippetsFilters feature. SnippetsFilters allow inserting NGINX configuration into the generated NGINX config for HTTPRoute and GRPCRoute resources. | bool | `false` |
 | `nodeSelector` | The nodeSelector of the NGINX Gateway Fabric pod. | object | `{}` |
 | `service.annotations` | The annotations of the NGINX Gateway Fabric service. | object | `{}` |
+| `service.labels` | The additional labels of the NGINX Gateway Fabric service. | object | `{}` |
 | `service.create` | Creates a service to expose the NGINX Gateway Fabric pods. | bool | `true` |
 | `service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | string | `"Local"` |
 | `service.loadBalancerIP` | The static IP address for the load balancer. Requires service.type set to LoadBalancer. | string | `""` |

--- a/charts/nginx-gateway-fabric/templates/service.yaml
+++ b/charts/nginx-gateway-fabric/templates/service.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-gateway.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -604,6 +604,12 @@
           "title": "annotations",
           "type": "object"
         },
+        "labels": {
+          "description": "The additional labels of the NGINX Gateway Fabric service.",
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
         "create": {
           "default": true,
           "description": "Creates a service to expose the NGINX Gateway Fabric pods.",

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -330,6 +330,9 @@ service:
   # -- The annotations of the NGINX Gateway Fabric service.
   annotations: {}
 
+  # -- The additional labels of the NGINX Gateway Fabric service.
+  labels: {}
+
   # -- The static IP address for the load balancer. Requires service.type set to LoadBalancer.
   loadBalancerIP: ""
 


### PR DESCRIPTION
### Proposed changes

Problem: It's not possible to add extra lables to the nginx gateway service (to select a particular [CiliumLoadBalancerIPPool](https://docs.cilium.io/en/stable/network/lb-ipam/#service-selectors), for example).

Solution: Add support for adding extra labels to the nginx gateway service.

Testing: The following command renders a service manifest with an extra label `lb-ip-pool=private` as expected.
```bash
helm template ngf charts/nginx-gateway-fabric/ --set service.labels.lb-ip-pool=private -s templates/service.yaml
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
