### PR TITLE
Expose ability to configure cert generator Job ttlSecondsAfterFinished. Set default to 30s.

### DIFF
--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -252,7 +252,7 @@ The following table lists the configurable parameters of the NGINX Gateway Fabri
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
-| `certGenerator` | The certGenerator section contains the configuration for the cert-generator Job. | object | `{"affinity":{},"agentTLSSecretName":"agent-tls","annotations":{},"nodeSelector":{},"overwrite":false,"serverTLSSecretName":"server-tls","tolerations":[],"topologySpreadConstraints":[]}` |
+| `certGenerator` | The certGenerator section contains the configuration for the cert-generator Job. | object | `{"affinity":{},"agentTLSSecretName":"agent-tls","annotations":{},"nodeSelector":{},"overwrite":false,"serverTLSSecretName":"server-tls","tolerations":[],"topologySpreadConstraints":[],"ttlSecondsAfterFinished":30}` |
 | `certGenerator.affinity` | The affinity of the cert-generator pod. | object | `{}` |
 | `certGenerator.agentTLSSecretName` | The name of the base Secret containing TLS CA, certificate, and key for the NGINX Agent to securely communicate with the NGINX Gateway Fabric control plane. Must exist in the same namespace that the NGINX Gateway Fabric control plane is running in (default namespace: nginx-gateway). | string | `"agent-tls"` |
 | `certGenerator.annotations` | The annotations of the cert-generator Job. | object | `{}` |
@@ -261,6 +261,7 @@ The following table lists the configurable parameters of the NGINX Gateway Fabri
 | `certGenerator.serverTLSSecretName` | The name of the Secret containing TLS CA, certificate, and key for the NGINX Gateway Fabric control plane to securely communicate with the NGINX Agent. Must exist in the same namespace that the NGINX Gateway Fabric control plane is running in (default namespace: nginx-gateway). | string | `"server-tls"` |
 | `certGenerator.tolerations` | Tolerations for the cert-generator pod. | list | `[]` |
 | `certGenerator.topologySpreadConstraints` | The topology spread constraints for the cert-generator pod. | list | `[]` |
+| `certGenerator.ttlSecondsAfterFinished` | How long to wait after the cert generator job has finished before it is removed by the job controller. | int | `30` |
 | `clusterDomain` | The DNS cluster domain of your Kubernetes cluster. | string | `"cluster.local"` |
 | `gateways` | A list of Gateway objects. View https://gateway-api.sigs.k8s.io/reference/spec/#gateway for full Gateway reference. | list | `[]` |
 | `nginx` | The nginx section contains the configuration for all NGINX data plane deployments installed by the NGINX Gateway Fabric control plane. | object | `{"config":{},"container":{},"debug":false,"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/nginx/nginx-gateway-fabric/nginx","tag":"2.0.0"},"imagePullSecret":"","imagePullSecrets":[],"kind":"deployment","plus":false,"pod":{},"replicas":1,"service":{"externalTrafficPolicy":"Local","loadBalancerClass":"","loadBalancerIP":"","loadBalancerSourceRanges":[],"nodePorts":[],"type":"LoadBalancer"},"usage":{"caSecretName":"","clientSSLSecretName":"","endpoint":"","resolver":"","secretName":"nplus-license","skipVerify":false}}` |

--- a/charts/nginx-gateway-fabric/templates/certs-job.yaml
+++ b/charts/nginx-gateway-fabric/templates/certs-job.yaml
@@ -169,4 +169,4 @@ spec:
       nodeSelector:
       {{- toYaml .Values.certGenerator.nodeSelector | nindent 8 }}
       {{- end }}
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: {{ .Values.certGenerator.ttlSecondsAfterFinished }}

--- a/charts/nginx-gateway-fabric/values.schema.json
+++ b/charts/nginx-gateway-fabric/values.schema.json
@@ -60,6 +60,13 @@
           "required": [],
           "title": "topologySpreadConstraints",
           "type": "array"
+        },
+        "ttlSecondsAfterFinished": {
+          "default": 30,
+          "description": "How long to wait after the cert generator job has finished before it is removed by the job controller.",
+          "required": [],
+          "title": "ttlSecondsAfterFinished",
+          "type": "integer"
         }
       },
       "required": [],

--- a/charts/nginx-gateway-fabric/values.yaml
+++ b/charts/nginx-gateway-fabric/values.yaml
@@ -479,6 +479,9 @@ certGenerator:
   # -- Overwrite existing TLS Secrets on startup.
   overwrite: false
 
+  # -- How long to wait after the cert generator job has finished before it is removed by the job controller.
+  ttlSecondsAfterFinished: 30
+
   # -- Tolerations for the cert-generator pod.
   tolerations: []
 

--- a/deploy/azure/deploy.yaml
+++ b/deploy/azure/deploy.yaml
@@ -367,7 +367,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/default/deploy.yaml
+++ b/deploy/default/deploy.yaml
@@ -365,7 +365,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/experimental-nginx-plus/deploy.yaml
+++ b/deploy/experimental-nginx-plus/deploy.yaml
@@ -373,7 +373,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/experimental/deploy.yaml
+++ b/deploy/experimental/deploy.yaml
@@ -370,7 +370,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/nginx-plus/deploy.yaml
+++ b/deploy/nginx-plus/deploy.yaml
@@ -368,7 +368,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/nodeport/deploy.yaml
+++ b/deploy/nodeport/deploy.yaml
@@ -365,7 +365,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -387,7 +387,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/snippets-filters-nginx-plus/deploy.yaml
+++ b/deploy/snippets-filters-nginx-plus/deploy.yaml
@@ -371,7 +371,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/deploy/snippets-filters/deploy.yaml
+++ b/deploy/snippets-filters/deploy.yaml
@@ -368,7 +368,7 @@ spec:
         fsGroup: 1001
         runAsNonRoot: true
       serviceAccountName: nginx-gateway-cert-generator
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass


### PR DESCRIPTION
Cherry pick [commit](https://github.com/nginx/nginx-gateway-fabric/commit/fbc098b71a96cf470eb57c08f67dff1a7234e620) for release 2.0.1

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Expose ability to configure cert generator Job ttlSecondsAfterFinished. Set default to 30s.
```
