### PR TITLE
fix: host readiness probe on ipv6 in addition to ipv4

### DIFF
--- a/internal/controller/nginx/config/base_http_config.go
+++ b/internal/controller/nginx/config/base_http_config.go
@@ -12,8 +12,9 @@ var baseHTTPTemplate = gotemplate.Must(gotemplate.New("baseHttp").Parse(baseHTTP
 
 type httpConfig struct {
 	Includes                []shared.Include
-	HTTP2                   bool
 	NginxReadinessProbePort int32
+	IPFamily                shared.IPFamily
+	HTTP2                   bool
 }
 
 func executeBaseHTTPConfig(conf dataplane.Configuration) []executeResult {
@@ -23,6 +24,7 @@ func executeBaseHTTPConfig(conf dataplane.Configuration) []executeResult {
 		HTTP2:                   conf.BaseHTTPConfig.HTTP2,
 		Includes:                includes,
 		NginxReadinessProbePort: conf.BaseHTTPConfig.NginxReadinessProbePort,
+		IPFamily:                getIPFamily(conf.BaseHTTPConfig),
 	}
 
 	results := make([]executeResult, 0, len(includes)+1)

--- a/internal/controller/nginx/config/base_http_config_template.go
+++ b/internal/controller/nginx/config/base_http_config_template.go
@@ -26,7 +26,12 @@ map $request_uri $request_uri_path {
 
 # NGINX health check server block.
 server {
+		{{- if $.IPFamily.IPv4 }}
     listen {{ .NginxReadinessProbePort }};
+		{{- end }}
+		{{- if $.IPFamily.IPv6 }}
+    listen [::]:{{ .NginxReadinessProbePort }};
+		{{- end }}
 
     location = /readyz {
         access_log off;


### PR DESCRIPTION
### Proposed changes

Problem: the readiness probe endpoint is not available on IPv6. This is a problem on IPv6 only clusters when using IPv6 for the pod network. The gateway pod refuses to come up because the readyz condition never fulfills.
Example: 
```
Warning  Unhealthy  88s (x160 over 26m)  kubelet            Readiness probe failed: Get "http://[fdd3:7046:2ad5:430a:39bb:bc6d:e254:a621]:8081/readyz": dial tcp [fdd3:7046:2ad5:430a:39bb:bc6d:e254:a621]:8081: connect: connection refused
```

Solution: host the readyz endpoint on IPv6 as well.

Testing: deployed on an IPv6 only cluster, gateway pod now comes up successfully, HTTPRoutes become available.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix an issue regarding the readiness probe for the gateway pod on clusters with IPv6 pod networking
```
