### PR TITLE
Align with BackendTLSPolicy validation

### DIFF
--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -147,6 +147,18 @@ const (
 	// when a policy cannot be applied due to the ancestor limit being reached.
 	PolicyMessageAncestorLimitReached = "Policies cannot be applied because the ancestor status list " +
 		"has reached the maximum size. The following policies have been ignored:"
+
+	// BackendTLSPolicyReasonInvalidCACertificateRef is used with the "ResolvedRefs" condition when a
+	// CACertificateRef refers to a resource that cannot be resolved or is misconfigured.
+	BackendTLSPolicyReasonInvalidCACertificateRef v1alpha2.PolicyConditionReason = "InvalidCACertificateRef"
+
+	// BackendTLSPolicyReasonInvalidKind is used with the "ResolvedRefs" condition when a
+	// CACertificateRef refers to an unknown or unsupported kind of resource.
+	BackendTLSPolicyReasonInvalidKind v1alpha2.PolicyConditionReason = "InvalidKind"
+
+	// BackendTLSPolicyReasonNoValidCACertificate is used with the "Accepted" condition when all
+	// CACertificateRefs are invalid.
+	BackendTLSPolicyReasonNoValidCACertificate v1alpha2.PolicyConditionReason = "NoValidCACertificate"
 )
 
 // Condition defines a condition to be reported in the status of resources.
@@ -1051,5 +1063,49 @@ func NewClientSettingsPolicyAffected() Condition {
 		Status:  metav1.ConditionTrue,
 		Reason:  string(PolicyAffectedReason),
 		Message: "ClientSettingsPolicy is applied to the resource",
+	}
+}
+
+// NewBackendTLSPolicyResolvedRefs returns a Condition that indicates that all CACertificateRefs
+// in the BackendTLSPolicy are resolved.
+func NewBackendTLSPolicyResolvedRefs() Condition {
+	return Condition{
+		Type:    string(GatewayResolvedRefs),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(GatewayResolvedRefs),
+		Message: "All CACertificateRefs are resolved",
+	}
+}
+
+// NewBackendTLSPolicyInvalidCACertificateRef returns a Condition that indicates that a
+// CACertificateRef in the BackendTLSPolicy refers to a resource that cannot be resolved or is misconfigured.
+func NewBackendTLSPolicyInvalidCACertificateRef(message string) Condition {
+	return Condition{
+		Type:    string(GatewayResolvedRefs),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(BackendTLSPolicyReasonInvalidCACertificateRef),
+		Message: message,
+	}
+}
+
+// NewBackendTLSPolicyInvalidKind returns a Condition that indicates that a CACertificateRef
+// in the BackendTLSPolicy refers to an unknown or unsupported kind of resource.
+func NewBackendTLSPolicyInvalidKind(message string) Condition {
+	return Condition{
+		Type:    string(GatewayResolvedRefs),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(BackendTLSPolicyReasonInvalidKind),
+		Message: message,
+	}
+}
+
+// NewBackendTLSPolicyNoValidCACertificate returns a Condition that indicates that all
+// CACertificateRefs in the BackendTLSPolicy are invalid.
+func NewBackendTLSPolicyNoValidCACertificate(message string) Condition {
+	return Condition{
+		Type:    string(v1alpha2.PolicyConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(BackendTLSPolicyReasonNoValidCACertificate),
+		Message: message,
 	}
 }

--- a/internal/controller/state/graph/backend_refs_test.go
+++ b/internal/controller/state/graph/backend_refs_test.go
@@ -1707,7 +1707,13 @@ func TestFindBackendTLSPolicyForService(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			btp, err := findBackendTLSPolicyForService(test.backendTLSPolicies, ref.Namespace, string(ref.Name), "test")
+			btp, err := findBackendTLSPolicyForService(
+				test.backendTLSPolicies,
+				ref.Namespace,
+				string(ref.Name),
+				"test",
+				v1.ServicePort{Name: "https", Port: 443},
+			)
 
 			g.Expect(btp.Source.Name).To(Equal(test.expectedBtpName))
 			g.Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/state/graph/graph_test.go
+++ b/internal/controller/state/graph/graph_test.go
@@ -50,6 +50,7 @@ func TestBuildGraph(t *testing.T) {
 	}
 
 	btpAcceptedConds := []conditions.Condition{
+		conditions.NewBackendTLSPolicyResolvedRefs(),
 		conditions.NewPolicyAccepted(),
 		conditions.NewPolicyAccepted(),
 		conditions.NewPolicyAccepted(),


### PR DESCRIPTION
### Proposed changes

Problem: The BackendTLSPolicy spec was updated to include specific rules around certificate validation that we were not adhering to

Solution: Update our validation and conditions to match the updated spec

Testing: Local, unit, and conformance testing

```
--- PASS: TestConformance/BackendTLSPolicyConflictResolution (1.19s)
--- PASS: TestConformance/BackendTLSPolicyConflictResolution/Conflicting_BackendTLSPolicies_targeting_the_same_Service_without_a_section_name (0.01s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/Conflicting_BackendTLSPolicies_targeting_the_same_Service_without_a_section_name/First_BackendTLSPolicy_should_be_accepted (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/Conflicting_BackendTLSPolicies_targeting_the_same_Service_without_a_section_name/Second_BackendTLSPolicy_should_have_a_false_Accepted_condition_with_reason_Conflicted_ (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/Conflicting_BackendTLSPolicies_targeting_the_same_Service_without_a_section_name/HTTP_request_sent_to_Service_using_the_accepted_BackendTLSPolicy_should_succeed (0.01s)
--- PASS: TestConformance/BackendTLSPolicyConflictResolution/Conflicting_BackendTLSPolicies_targeting_the_same_Service_with_the_same_section_name (0.01s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/Conflicting_BackendTLSPolicies_targeting_the_same_Service_with_the_same_section_name/First_BackendTLSPolicy_should_be_accepted (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/Conflicting_BackendTLSPolicies_targeting_the_same_Service_with_the_same_section_name/Second_BackendTLSPolicy_should_have_a_false_Accepted_condition_with_reason_Conflicted_ (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/Conflicting_BackendTLSPolicies_targeting_the_same_Service_with_the_same_section_name/HTTP_request_sent_to_Service_using_the_accepted_BackendTLSPolicy_should_succeed (0.01s)
--- PASS: TestConformance/BackendTLSPolicyConflictResolution/BackendTLSPolicies_targeting_the_same_Service_with_and_without_a_section_name (0.02s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/BackendTLSPolicies_targeting_the_same_Service_with_and_without_a_section_name/BackendTLSPolicy_with_section_name_should_be_accepted (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/BackendTLSPolicies_targeting_the_same_Service_with_and_without_a_section_name/BackendTLSPolicy_without_section_name_should_be_accepted (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/BackendTLSPolicies_targeting_the_same_Service_with_and_without_a_section_name/HTTP_request_sent_to_Service_using_the_BackendTLSPolicy_with_section_name_should_succeed (0.01s)
	--- PASS: TestConformance/BackendTLSPolicyConflictResolution/BackendTLSPolicies_targeting_the_same_Service_with_and_without_a_section_name/HTTP_request_sent_to_Service_using_the_BackendTLSPolicy_without_section_name_should_succeed (0.01s)
--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef (1.11s)
--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef/BackendTLSPolicy_nonexistent-ca-certificate-ref (0.01s)
	--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef/BackendTLSPolicy_nonexistent-ca-certificate-ref/BackendTLSPolicy_with_a_single_invalid_CACertificateRef_has_a_Accepted_Condition_with_status_False_and_Reason_NoValidCACertificate (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef/BackendTLSPolicy_nonexistent-ca-certificate-ref/BackendTLSPolicy_with_a_single_invalid_CACertificateRef_has_a_ResolvedRefs_Condition_with_status_False_and_Reason_InvalidCACertificateRef (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef/BackendTLSPolicy_nonexistent-ca-certificate-ref/HTTP_Request_to_backend_targeted_by_an_invalid_BackendTLSPolicy_receive_a_5xx (0.00s)
--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef/BackendTLSPolicy_malformed-ca-certificate-ref (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef/BackendTLSPolicy_malformed-ca-certificate-ref/BackendTLSPolicy_with_a_single_invalid_CACertificateRef_has_a_Accepted_Condition_with_status_False_and_Reason_NoValidCACertificate (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef/BackendTLSPolicy_malformed-ca-certificate-ref/BackendTLSPolicy_with_a_single_invalid_CACertificateRef_has_a_ResolvedRefs_Condition_with_status_False_and_Reason_InvalidCACertificateRef (0.00s)
	--- PASS: TestConformance/BackendTLSPolicyInvalidCACertificateRef/BackendTLSPolicy_malformed-ca-certificate-ref/HTTP_Request_to_backend_targeted_by_an_invalid_BackendTLSPolicy_receive_a_5xx (0.00s)
--- PASS: TestConformance/BackendTLSPolicyInvalidKind (1.07s)
--- PASS: TestConformance/BackendTLSPolicyInvalidKind/BackendTLSPolicy_with_a_single_invalid_CACertificateRef_has_a_Accepted_Condition_with_status_False_and_Reason_NoValidCACertificate (0.00s)
--- PASS: TestConformance/BackendTLSPolicyInvalidKind/BackendTLSPolicy_with_a_single_invalid_CACertificateRef_has_a_ResolvedRefs_Condition_with_status_False_and_Reason_InvalidKind (0.00s)
--- PASS: TestConformance/BackendTLSPolicyInvalidKind/HTTP_Request_to_backend_targeted_by_an_invalid_BackendTLSPolicy_receive_a_5xx (0.00s)
--- FAIL: TestConformance/BackendTLSPolicyObservedGenerationBump (60.08s)
--- FAIL: TestConformance/BackendTLSPolicyObservedGenerationBump/observedGeneration_should_increment (60.02s)
--- SKIP: TestConformance/BackendTLSPolicySANValidation (0.00s)
--- PASS: TestConformance/BackendTLSPolicy (2.24s)
--- PASS: TestConformance/BackendTLSPolicy/Re-encrypt_HTTPS_request_sent_to_Service_with_valid_BackendTLSPolicy_should_succeed (2.05s)
--- PASS: TestConformance/BackendTLSPolicy/HTTP_request_sent_to_Service_with_valid_BackendTLSPolicy_should_succeed (0.01s)
--- PASS: TestConformance/BackendTLSPolicy/HTTP_request_sent_to_Service_targeted_by_BackendTLSPolicy_with_mismatched_hostname_should_return_an_HTTP_error (0.01s)
--- PASS: TestConformance/BackendTLSPolicy/HTTP_request_send_to_Service_targeted_by_BackendTLSPolicy_with_mismatched_cert_should_return_HTTP_error (0.02s)
 ```
-> see https://github.com/nginx/nginx-gateway-fabric/actions/runs/17551266824/job/49845122033?pr=3871

NOTE: `BackendTLSPolicyObservedGenerationBump/observedGeneration_should_increment` is failing due to what looks like a test fixtures failure as the error is related to not being able to find the ConfigMap - this is not related to the validation changes and will be followed up I a separate ticket

Closes #3651 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Updated BackendTLSPolicy validation to align with the updated spec.
```
