### PR TITLE
Add support for backend tls config for Gateways

### DIFF
--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -140,9 +140,10 @@ func StartManager(cfg config.Config) error {
 			GenericValidator:    genericValidator,
 			PolicyValidator:     policyManager,
 		},
-		EventRecorder:  recorder,
-		MustExtractGVK: mustExtractGVK,
-		PlusSecrets:    plusSecrets,
+		EventRecorder:        recorder,
+		MustExtractGVK:       mustExtractGVK,
+		PlusSecrets:          plusSecrets,
+		ExperimentalFeatures: cfg.ExperimentalFeatures,
 	})
 
 	var handlerCollector handlerMetricsCollector = collectors.NewControllerNoopCollector()

--- a/internal/controller/nginx/config/base_http_config.go
+++ b/internal/controller/nginx/config/base_http_config.go
@@ -19,6 +19,7 @@ type AccessLog struct {
 type httpConfig struct {
 	DNSResolver             *dataplane.DNSResolverConfig
 	AccessLog               *AccessLog
+	GatewaySecretID         dataplane.SSLKeyPairID
 	Includes                []shared.Include
 	NginxReadinessProbePort int32
 	IPFamily                shared.IPFamily
@@ -35,6 +36,7 @@ func executeBaseHTTPConfig(conf dataplane.Configuration) []executeResult {
 		IPFamily:                getIPFamily(conf.BaseHTTPConfig),
 		DNSResolver:             conf.BaseHTTPConfig.DNSResolver,
 		AccessLog:               buildAccessLog(conf.Logging.AccessLog),
+		GatewaySecretID:         conf.BaseHTTPConfig.GatewaySecretID,
 	}
 
 	results := make([]executeResult, 0, len(includes)+1)

--- a/internal/controller/nginx/config/base_http_config_template.go
+++ b/internal/controller/nginx/config/base_http_config_template.go
@@ -61,6 +61,12 @@ access_log {{ .AccessLog.Path }} {{ .AccessLog.FormatName }};
 {{- end }}
 {{- end }}
 
+{{- if $.GatewaySecretID }}
+# Gateway Certificate
+proxy_ssl_certificate /etc/nginx/secrets/{{ $.GatewaySecretID }}.pem;
+proxy_ssl_certificate_key /etc/nginx/secrets/{{ $.GatewaySecretID }}.pem;
+{{- end }}
+
 {{ range $i := .Includes -}}
 include {{ $i.Name }};
 {{ end -}}

--- a/internal/controller/state/conditions/conditions.go
+++ b/internal/controller/state/conditions/conditions.go
@@ -146,6 +146,14 @@ const (
 	// parametersRef resource is invalid.
 	GatewayReasonParamsRefInvalid v1.GatewayConditionReason = "ParametersRefInvalid"
 
+	// GatewayReasonSecretRefInvalid is used with the "GatewayResolvedRefs" condition when the
+	// secretRef resource is invalid.
+	GatewayReasonSecretRefInvalid v1.GatewayConditionReason = "SecretRefInvalid"
+
+	// GatewayReasonSecretRefNotPermitted is used with the "GatewayResolvedRefs" condition when the
+	// secretRef resource is not permitted by any ReferenceGrant.
+	GatewayReasonSecretRefNotPermitted v1.GatewayConditionReason = "SecretRefNotPermitted"
+
 	// PolicyReasonAncestorLimitReached is used with the "PolicyAccepted" condition when a policy
 	// cannot be applied because the ancestor status list has reached the maximum size of 16.
 	PolicyReasonAncestorLimitReached v1.PolicyConditionReason = "AncestorLimitReached"
@@ -289,6 +297,27 @@ func NewGatewayClassUnsupportedVersion(recommendedVersion string) []Condition {
 				recommendedVersion,
 			),
 		},
+	}
+}
+
+// NewGatewaySecretRefNotPermitted returns Condition that indicates that the Gateway references a TLS secret that is not
+// permitted by any ReferenceGrant.
+func NewGatewaySecretRefNotPermitted(msg string) Condition {
+	return Condition{
+		Type:    string(GatewayReasonResolvedRefs),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(GatewayReasonSecretRefNotPermitted),
+		Message: msg,
+	}
+}
+
+// NewGatewaySecretRefInvalid returns Condition that indicates that the Gateway references a TLS secret that is invalid.
+func NewGatewaySecretRefInvalid(msg string) Condition {
+	return Condition{
+		Type:    string(GatewayReasonResolvedRefs),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(GatewayReasonSecretRefInvalid),
+		Message: msg,
 	}
 }
 
@@ -843,6 +872,25 @@ func NewGatewayInvalid(msg string) []Condition {
 			Message: msg,
 		},
 		NewGatewayNotProgrammedInvalid(msg),
+	}
+}
+
+// NewGatewayUnsupportedValue returns Conditions that indicate that a field of the Gateway has an unsupported value.
+// Unsupported means that the value is not supported by the implementation under certain conditions or invalid.
+func NewGatewayUnsupportedValue(msg string) []Condition {
+	return []Condition{
+		{
+			Type:    string(v1.GatewayConditionAccepted),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(GatewayReasonUnsupportedValue),
+			Message: msg,
+		},
+		{
+			Type:    string(v1.GatewayConditionProgrammed),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(GatewayReasonUnsupportedValue),
+			Message: msg,
+		},
 	}
 }
 

--- a/internal/controller/state/dataplane/configuration.go
+++ b/internal/controller/state/dataplane/configuration.go
@@ -85,9 +85,10 @@ func BuildConfiguration(
 			gateway,
 			serviceResolver,
 			g.ReferencedServices,
-			baseHTTPConfig.IPFamily),
+			baseHTTPConfig.IPFamily,
+		),
 		BackendGroups: backendGroups,
-		SSLKeyPairs:   buildSSLKeyPairs(g.ReferencedSecrets, gateway.Listeners),
+		SSLKeyPairs:   buildSSLKeyPairs(g.ReferencedSecrets, gateway),
 		CertBundles: buildCertBundles(
 			buildRefCertificateBundles(g.ReferencedSecrets, g.ReferencedCaCertConfigMaps),
 			backendGroups,
@@ -252,14 +253,14 @@ func buildStreamUpstreams(
 }
 
 // buildSSLKeyPairs builds the SSLKeyPairs from the Secrets. It will only include Secrets that are referenced by
-// valid listeners, so that we don't include unused Secrets in the configuration of the data plane.
+// valid gateway and its listeners, so that we don't include unused Secrets in the configuration of the data plane.
 func buildSSLKeyPairs(
 	secrets map[types.NamespacedName]*graph.Secret,
-	listeners []*graph.Listener,
+	gateway *graph.Gateway,
 ) map[SSLKeyPairID]SSLKeyPair {
 	keyPairs := make(map[SSLKeyPairID]SSLKeyPair)
 
-	for _, l := range listeners {
+	for _, l := range gateway.Listeners {
 		if l.Valid && l.ResolvedSecret != nil {
 			id := generateSSLKeyPairID(*l.ResolvedSecret)
 			secret := secrets[*l.ResolvedSecret]
@@ -269,6 +270,15 @@ func buildSSLKeyPairs(
 				Cert: secret.CertBundle.Cert.TLSCert,
 				Key:  secret.CertBundle.Cert.TLSPrivateKey,
 			}
+		}
+	}
+
+	if gateway.Valid && gateway.SecretRef != nil {
+		id := generateSSLKeyPairID(*gateway.SecretRef)
+		secret := secrets[*gateway.SecretRef]
+		keyPairs[id] = SSLKeyPair{
+			Cert: secret.CertBundle.Cert.TLSCert,
+			Key:  secret.CertBundle.Cert.TLSPrivateKey,
 		}
 	}
 
@@ -1058,6 +1068,10 @@ func buildBaseHTTPConfig(
 		NginxReadinessProbePort: DefaultNginxReadinessProbePort,
 	}
 
+	if gateway.Valid && gateway.SecretRef != nil {
+		baseConfig.GatewaySecretID = generateSSLKeyPairID(*gateway.SecretRef)
+	}
+
 	// safe to access EffectiveNginxProxy since we only call this function when the Gateway is not nil.
 	np := gateway.EffectiveNginxProxy
 	if np == nil {
@@ -1081,7 +1095,19 @@ func buildBaseHTTPConfig(
 		}
 	}
 
+	if port := getNginxReadinessProbePort(np); port != 0 {
+		baseConfig.NginxReadinessProbePort = port
+	}
+
 	baseConfig.RewriteClientIPSettings = buildRewriteClientIPConfig(np.RewriteClientIP)
+
+	baseConfig.DNSResolver = buildDNSResolverConfig(np.DNSResolver)
+
+	return baseConfig
+}
+
+func getNginxReadinessProbePort(np *graph.EffectiveNginxProxy) int32 {
+	var port int32
 
 	if np.Kubernetes != nil {
 		var containerSpec *ngfAPIv1alpha2.ContainerSpec
@@ -1091,13 +1117,10 @@ func buildBaseHTTPConfig(
 			containerSpec = &np.Kubernetes.DaemonSet.Container
 		}
 		if containerSpec != nil && containerSpec.ReadinessProbe != nil && containerSpec.ReadinessProbe.Port != nil {
-			baseConfig.NginxReadinessProbePort = *containerSpec.ReadinessProbe.Port
+			port = *containerSpec.ReadinessProbe.Port
 		}
 	}
-
-	baseConfig.DNSResolver = buildDNSResolverConfig(np.DNSResolver)
-
-	return baseConfig
+	return port
 }
 
 // buildBaseStreamConfig generates the base stream context config that should be applied to all stream servers.

--- a/internal/controller/state/dataplane/types.go
+++ b/internal/controller/state/dataplane/types.go
@@ -26,23 +26,19 @@ const (
 
 // Configuration is an intermediate representation of dataplane configuration.
 type Configuration struct {
-	// AuxiliarySecrets contains additional secret data, like certificates/keys/tokens that are not related to
-	// Gateway API resources.
-	AuxiliarySecrets map[graph.SecretFileType][]byte
 	// CertBundles holds all unique Certificate Bundles.
 	CertBundles map[CertBundleID]CertBundle
 	// BaseStreamConfig holds the configuration options at the stream context.
 	BaseStreamConfig BaseStreamConfig
 	// SSLKeyPairs holds all unique SSLKeyPairs.
 	SSLKeyPairs map[SSLKeyPairID]SSLKeyPair
+	// AuxiliarySecrets contains additional secret data, like certificates/keys/tokens that are not related to
+	// Gateway API resources.
+	AuxiliarySecrets map[graph.SecretFileType][]byte
 	// DeploymentContext contains metadata about NGF and the cluster.
 	DeploymentContext DeploymentContext
 	// Logging defines logging related settings for NGINX.
 	Logging Logging
-	// StreamUpstreams holds all unique stream Upstreams
-	StreamUpstreams []Upstream
-	// TLSPassthroughServers hold all TLSPassthroughServers
-	TLSPassthroughServers []Layer4VirtualServer
 	// BackendGroups holds all unique BackendGroups.
 	BackendGroups []BackendGroup
 	// MainSnippets holds all the snippets that apply to the main context.
@@ -51,10 +47,14 @@ type Configuration struct {
 	Upstreams []Upstream
 	// NginxPlus specifies NGINX Plus additional settings.
 	NginxPlus NginxPlus
-	// SSLServers holds all SSLServers.
-	SSLServers []VirtualServer
 	// HTTPServers holds all HTTPServers.
 	HTTPServers []VirtualServer
+	// StreamUpstreams holds all unique stream Upstreams
+	StreamUpstreams []Upstream
+	// SSLServers holds all SSLServers.
+	SSLServers []VirtualServer
+	// TLSPassthroughServers hold all TLSPassthroughServers
+	TLSPassthroughServers []Layer4VirtualServer
 	// Telemetry holds the Otel configuration.
 	Telemetry Telemetry
 	// BaseHTTPConfig holds the configuration options at the http context.
@@ -393,6 +393,8 @@ type BaseHTTPConfig struct {
 	DNSResolver *DNSResolverConfig
 	// IPFamily specifies the IP family for all servers.
 	IPFamily IPFamilyType
+	// GatewaySecretID is the ID of the secret that contains the gateway backend TLS certificate.
+	GatewaySecretID SSLKeyPairID
 	// Snippets contain the snippets that apply to the http context.
 	Snippets []Snippet
 	// RewriteIPSettings defines configuration for rewriting the client IP to the original client's IP.

--- a/internal/controller/state/graph/graph.go
+++ b/internal/controller/state/graph/graph.go
@@ -242,6 +242,7 @@ func BuildGraph(
 		gc,
 		refGrantResolver,
 		processedNginxProxies,
+		experimentalEnabled,
 	)
 
 	processedBackendTLSPolicies := processBackendTLSPolicies(

--- a/internal/controller/state/graph/multiple_gateways_test.go
+++ b/internal/controller/state/graph/multiple_gateways_test.go
@@ -66,6 +66,8 @@ var (
 			{Kind: kinds.TLSRoute, Group: helpers.GetPointer[gatewayv1.Group](gatewayv1.GroupName)},
 		},
 	}
+
+	experimentalFeaturesEnabled = false
 )
 
 func createGateway(name, namespace, nginxProxyName string, listeners []gatewayv1.Listener) *gatewayv1.Gateway {
@@ -407,7 +409,7 @@ func Test_MultipleGateways_WithNginxProxy(t *testing.T) {
 					PolicyValidator:     fakePolicyValidator,
 				},
 				logr.Discard(),
-				experimentalFeaturesOff,
+				experimentalFeaturesEnabled,
 			)
 
 			g.Expect(helpers.Diff(test.expGraph, result)).To(BeEmpty())
@@ -897,7 +899,7 @@ func Test_MultipleGateways_WithListeners(t *testing.T) {
 					PolicyValidator:     fakePolicyValidator,
 				},
 				logr.Discard(),
-				experimentalFeaturesOff,
+				experimentalFeaturesEnabled,
 			)
 
 			g.Expect(helpers.Diff(test.expGraph, result)).To(BeEmpty())


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Users want to be able to specify their gateway's identity when communicating to the backend pods.

Solution: Add a field to provide a secret name that stores that gateways cert and key to be used when doing TLS handshake with backend pods

NOTE: I refactored this [test](https://github.com/nginx/nginx-gateway-fabric/blob/main/internal/controller/state/dataplane/configuration_test.go#L138) because it was not easy to debug in such large tests as part of this PR. 

Ran unit tests multiple times to avoid data race situations.

Testing: Unit tests added as needed , No IPv6 testing done for this (not related with ports or in container network)

Manual tests

Tested with Securing [backend](https://docs.nginx.com/nginx-gateway-fabric/traffic-security/secure-backend/) traffic by additionally requiring client certificates from backend and ensuring they are signed by the right CN to verify identity

my secure-app config

```
    server {
        listen 8443 ssl;
        listen [::]:8443 ssl;

        server_name secure-app.example.com;

        default_type text/plain;

        ssl_certificate /etc/nginx/ssl/secret/tls.crt;
        ssl_certificate_key /etc/nginx/ssl/secret/tls.key;

        ssl_client_certificate /etc/nginx/ssl/ca-cert/ca.crt;
        ssl_verify_client on;


        # Enable access logging
        access_log /var/log/nginx/access.log ssl_log;


        location / {
            return 200 "hello from pod secure-app\n";
        }
    }

```


NGF config

```
# Gateway Certificate
proxy_ssl_certificate /etc/nginx/secrets/ssl_keypair_default_gateway-presents-this-cert-for-validation.pem;
proxy_ssl_certificate_key /etc/nginx/secrets/ssl_keypair_default_gateway-presents-this-cert-for-validation.pem;


js_preload_object matches from /etc/nginx/conf.d/matches.json;
server {
    listen 80 default_server;
    listen [::]:80 default_server;
    default_type text/html;
    return 404;
}

server {
    listen 80;
    listen [::]:80;

    server_name secure-app.example.com;


    location / {






        proxy_http_version 1.1;
        proxy_set_header Host "$gw_api_compliant_host";
        proxy_set_header X-Forwarded-For "$proxy_add_x_forwarded_for";
        proxy_set_header X-Real-IP "$remote_addr";
        proxy_set_header X-Forwarded-Proto "$scheme";
        proxy_set_header X-Forwarded-Host "$host";
        proxy_set_header X-Forwarded-Port "$server_port";
        proxy_set_header Upgrade "$http_upgrade";
        proxy_set_header Connection "$connection_upgrade";
        proxy_pass https://default_secure-app_8443$request_uri;



        proxy_ssl_server_name on;
        proxy_ssl_verify on;
        proxy_ssl_name secure-app.example.com;
        proxy_ssl_trusted_certificate /etc/nginx/secrets/cert_bundle_default_backend-cert.crt;
    }
}
```


Curl and logs to verify client -- I signed CA with gateway CN so that's what we should see get logged in the backend

```
curl -v --resolve secure-app.example.com:$GW_PORT:$GW_IP http://secure-app.example.com:$GW_PORT/
hello from pod secure-app

k logs secure-app-69c558d9d9-lwcjl
10.244.0.117 ssl_client_verify=SUCCESS ssl_client_subject=CN=gateway
10.244.0.117 ssl_client_verify=SUCCESS ssl_client_subject=CN=gateway
```


when frontend tls is specified error is thrown

```
    backend:
      clientCertificateRef:
        name: gateway-presents-this-cert-for-validation
        kind : Secret
    frontend:
      default:
          validation:
            caCertificateRefs:
              - name: backend-cert
                kind: ConfigMap
                group: ''


    Message:               Gateway accepted but the following unsupported parameters were ignored: TLS.Frontend
    Observed Generation:   1
    Reason:                UnsupportedField
    Status:                True
    Type:                  Accepted
```

when experimental is disabled

```
Conditions:
    Last Transition Time:  2025-11-11T00:03:26Z
    Message:               spec.tls: Forbidden: tls is not supported when experimental features are disabled
    Observed Generation:   1
    Reason:                UnsupportedValue
    Status:                False
    Type:                  Accepted
    Last Transition Time:  2025-11-11T00:03:26Z
    Message:               spec.tls: Forbidden: tls is not supported when experimental features are disabled
    Observed Generation:   1
    Reason:                UnsupportedValue
    Status:                False
    Type:                  Programmed
Events:                    <none>
```




Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #3153 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Added support for configuring backend TLS on Gateways to enable secure communication between the gateway and upstream.
```
