### PR TITLE
Add assertion doc job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,7 @@ jobs:
   assertion:
     name: Generate and Sign Assertion Documents
     needs: [vars, binary]
+    if: ${{ inputs.is_production_release }}
     permissions:
       contents: read
       id-token: write # for compliance-rules action to sign assertion doc


### PR DESCRIPTION
### Proposed changes

Problem: We need to add the generation and publishing of a signed assertion document to our workflow. The goal of the signed assertion document is to provide a customer facing document that provides provenance for a build artifact. The document will contain information about each dependency included in the build and specifically will contain the signed acquisition document for each process. This will also be signed to guarantee that F5 is the source of the document.

Solution: Use the actions provided by `compliance-rules` to generate and sign the assertion document

Testing: See https://github.com/nginx/nginx-gateway-fabric/actions/runs/18093624043/job/51480400063


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
