### PR TITLE
Add nginx image version validation during agent connections

### DIFF
--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -208,6 +208,13 @@ func (h *eventHandlerImpl) sendNginxConfig(ctx context.Context, logger logr.Logg
 			panic("expected deployment, got nil")
 		}
 
+		nginxImage, _ := provisioner.DetermineNginxImageName(
+			gw.EffectiveNginxProxy,
+			h.cfg.plus,
+			h.cfg.gatewayPodConfig.Version,
+		)
+		deployment.SetImageVersion(nginxImage)
+
 		cfg := dataplane.BuildConfiguration(ctx, logger, gr, gw, h.cfg.serviceResolver, h.cfg.plus)
 		depCtx, getErr := h.getDeploymentContext(ctx)
 		if getErr != nil {

--- a/internal/controller/nginx/agent/deployment.go
+++ b/internal/controller/nginx/agent/deployment.go
@@ -40,6 +40,8 @@ type Deployment struct {
 
 	broadcaster broadcast.Broadcaster
 
+	imageVersion string
+
 	configVersion string
 	// error that is set if a ConfigApply call failed for a Pod. This is needed
 	// because if subsequent upstream API calls are made within the same update event,
@@ -71,6 +73,14 @@ func newDeployment(broadcaster broadcast.Broadcaster) *Deployment {
 // GetBroadcaster returns the deployment's broadcaster.
 func (d *Deployment) GetBroadcaster() broadcast.Broadcaster {
 	return d.broadcaster
+}
+
+// SetImageVersion sets the deployment's image version.
+func (d *Deployment) SetImageVersion(imageVersion string) {
+	d.FileLock.Lock()
+	defer d.FileLock.Unlock()
+
+	d.imageVersion = imageVersion
 }
 
 // SetLatestConfigError sets the latest config apply error for the deployment.

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -1112,35 +1112,7 @@ func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 }
 
 func (p *NginxProvisioner) buildImage(nProxyCfg *graph.EffectiveNginxProxy) (string, corev1.PullPolicy) {
-	image := defaultNginxImagePath
-	tag := p.cfg.GatewayPodConfig.Version
-	pullPolicy := defaultImagePullPolicy
-
-	getImageAndPullPolicy := func(container ngfAPIv1alpha2.ContainerSpec) (string, string, corev1.PullPolicy) {
-		if container.Image != nil {
-			if container.Image.Repository != nil {
-				image = *container.Image.Repository
-			}
-			if container.Image.Tag != nil {
-				tag = *container.Image.Tag
-			}
-			if container.Image.PullPolicy != nil {
-				pullPolicy = corev1.PullPolicy(*container.Image.PullPolicy)
-			}
-		}
-
-		return image, tag, pullPolicy
-	}
-
-	if nProxyCfg != nil && nProxyCfg.Kubernetes != nil {
-		if nProxyCfg.Kubernetes.Deployment != nil {
-			image, tag, pullPolicy = getImageAndPullPolicy(nProxyCfg.Kubernetes.Deployment.Container)
-		} else if nProxyCfg.Kubernetes.DaemonSet != nil {
-			image, tag, pullPolicy = getImageAndPullPolicy(nProxyCfg.Kubernetes.DaemonSet.Container)
-		}
-	}
-
-	return fmt.Sprintf("%s:%s", image, tag), pullPolicy
+	return DetermineNginxImageName(nProxyCfg, p.cfg.Plus, p.cfg.GatewayPodConfig.Version)
 }
 
 func buildNginxDeploymentHPA(
@@ -1380,4 +1352,42 @@ func (p *NginxProvisioner) buildReadinessProbe(nProxyCfg *graph.EffectiveNginxPr
 	}
 
 	return probe
+}
+
+func DetermineNginxImageName(
+	nProxyCfg *graph.EffectiveNginxProxy,
+	isPlus bool, version string,
+) (string, corev1.PullPolicy) {
+	image := defaultNginxImagePath
+	if isPlus {
+		image = defaultNginxPlusImagePath
+	}
+	tag := version
+	pullPolicy := defaultImagePullPolicy
+
+	getImageAndPullPolicy := func(container ngfAPIv1alpha2.ContainerSpec) (string, string, corev1.PullPolicy) {
+		if container.Image != nil {
+			if container.Image.Repository != nil {
+				image = *container.Image.Repository
+			}
+			if container.Image.Tag != nil {
+				tag = *container.Image.Tag
+			}
+			if container.Image.PullPolicy != nil {
+				pullPolicy = corev1.PullPolicy(*container.Image.PullPolicy)
+			}
+		}
+
+		return image, tag, pullPolicy
+	}
+
+	if nProxyCfg != nil && nProxyCfg.Kubernetes != nil {
+		if nProxyCfg.Kubernetes.Deployment != nil {
+			image, tag, pullPolicy = getImageAndPullPolicy(nProxyCfg.Kubernetes.Deployment.Container)
+		} else if nProxyCfg.Kubernetes.DaemonSet != nil {
+			image, tag, pullPolicy = getImageAndPullPolicy(nProxyCfg.Kubernetes.DaemonSet.Container)
+		}
+	}
+
+	return fmt.Sprintf("%s:%s", image, tag), pullPolicy
 }


### PR DESCRIPTION
Cherry pick for [PR](https://github.com/nginx/nginx-gateway-fabric/pull/3928)

Closes #3867 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Added nginx image version validation during agent connections to prevent newer config being sent to pods running previous image versions during upgrades
```
