### PR TITLE
Collect InferencePoolCount in telemetry

### DIFF
--- a/internal/controller/telemetry/collector.go
+++ b/internal/controller/telemetry/collector.go
@@ -66,6 +66,8 @@ type Data struct {
 	ControlPlanePodCount int64
 	// NginxOneConnectionEnabled is a boolean that indicates whether the connection to the Nginx One Console is enabled.
 	NginxOneConnectionEnabled bool
+	// InferencePoolCount is the number of InferencePools that are referenced by at least one Route.
+	InferencePoolCount int64
 }
 
 // NGFResourceCounts stores the counts of all relevant resources that NGF processes and generates configuration from.
@@ -105,8 +107,6 @@ type NGFResourceCounts struct {
 	UpstreamSettingsPolicyCount int64
 	// GatewayAttachedNpCount is the total number of NginxProxy resources that are attached to a Gateway.
 	GatewayAttachedNpCount int64
-	// InferencePoolCount is the number of InferencePools that are referenced by at least one Route.
-	InferencePoolCount int64
 }
 
 // DataCollectorConfig holds configuration parameters for DataCollectorImpl.
@@ -176,6 +176,8 @@ func (c DataCollectorImpl) Collect(ctx context.Context) (Data, error) {
 
 	nginxPodCount := getNginxPodCount(g, clusterInfo.NodeCount)
 
+	inferencePoolCount := int64(len(g.ReferencedInferencePools))
+
 	data := Data{
 		Data: tel.Data{
 			ProjectName:         "NGF",
@@ -196,6 +198,7 @@ func (c DataCollectorImpl) Collect(ctx context.Context) (Data, error) {
 		NginxPodCount:                  nginxPodCount,
 		ControlPlanePodCount:           int64(replicaCount),
 		NginxOneConnectionEnabled:      c.cfg.NginxOneConsoleConnection,
+		InferencePoolCount:             inferencePoolCount,
 	}
 
 	return data, nil
@@ -266,8 +269,6 @@ func collectGraphResourceCount(
 	}
 
 	ngfResourceCounts.GatewayAttachedNpCount = gatewayAttachedNPCount
-
-	ngfResourceCounts.InferencePoolCount = int64(len(g.ReferencedInferencePools))
 
 	return ngfResourceCounts
 }

--- a/internal/controller/telemetry/collector_test.go
+++ b/internal/controller/telemetry/collector_test.go
@@ -492,7 +492,6 @@ var _ = Describe("Collector", Ordered, func() {
 					SnippetsFilterCount:                      3,
 					UpstreamSettingsPolicyCount:              1,
 					GatewayAttachedNpCount:                   2,
-					InferencePoolCount:                       3,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"
@@ -525,6 +524,8 @@ var _ = Describe("Collector", Ordered, func() {
 				expData.NginxPodCount = int64(8)
 				expData.ControlPlanePodCount = int64(2)
 				expData.NginxOneConnectionEnabled = true
+
+				expData.InferencePoolCount = 3
 
 				data, err := dataCollector.Collect(ctx)
 				Expect(err).ToNot(HaveOccurred())
@@ -790,9 +791,9 @@ var _ = Describe("Collector", Ordered, func() {
 					UpstreamSettingsPolicyCount:              1,
 					GatewayAttachedNpCount:                   1,
 					BackendTLSPolicyCount:                    1,
-					InferencePoolCount:                       1,
 				}
 				expData.NginxPodCount = 1
+				expData.InferencePoolCount = 1
 
 				data, err := dataCollector.Collect(ctx)
 

--- a/internal/controller/telemetry/data.avdl
+++ b/internal/controller/telemetry/data.avdl
@@ -105,9 +105,6 @@ attached at the Gateway level. */
 		/** GatewayAttachedNpCount is the total number of NginxProxy resources that are attached to a Gateway. */
 		long? GatewayAttachedNpCount = null;
 		
-		/** InferencePoolCount is the number of InferencePools that are referenced by at least one Route. */
-		long? InferencePoolCount = null;
-		
 		/** NginxPodCount is the total number of Nginx data plane Pods. */
 		long? NginxPodCount = null;
 		
@@ -116,6 +113,9 @@ attached at the Gateway level. */
 		
 		/** NginxOneConnectionEnabled is a boolean that indicates whether the connection to the Nginx One Console is enabled. */
 		boolean? NginxOneConnectionEnabled = null;
+		
+		/** InferencePoolCount is the number of InferencePools that are referenced by at least one Route. */
+		long? InferencePoolCount = null;
 		
 	}
 }

--- a/internal/controller/telemetry/data_attributes_generated.go
+++ b/internal/controller/telemetry/data_attributes_generated.go
@@ -23,6 +23,7 @@ func (d *Data) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("NginxPodCount", d.NginxPodCount))
 	attrs = append(attrs, attribute.Int64("ControlPlanePodCount", d.ControlPlanePodCount))
 	attrs = append(attrs, attribute.Bool("NginxOneConnectionEnabled", d.NginxOneConnectionEnabled))
+	attrs = append(attrs, attribute.Int64("InferencePoolCount", d.InferencePoolCount))
 
 	return attrs
 }

--- a/internal/controller/telemetry/data_test.go
+++ b/internal/controller/telemetry/data_test.go
@@ -41,13 +41,13 @@ func TestDataAttributes(t *testing.T) {
 			SnippetsFilterCount:                      13,
 			UpstreamSettingsPolicyCount:              14,
 			GatewayAttachedNpCount:                   15,
-			InferencePoolCount:                       16,
 		},
 		SnippetsFiltersDirectives:      []string{"main-three-count", "http-two-count", "server-one-count"},
 		SnippetsFiltersDirectivesCount: []int64{3, 2, 1},
 		NginxPodCount:                  3,
 		ControlPlanePodCount:           3,
 		NginxOneConnectionEnabled:      true,
+		InferencePoolCount:             16,
 	}
 
 	expected := []attribute.KeyValue{
@@ -84,10 +84,10 @@ func TestDataAttributes(t *testing.T) {
 		attribute.Int64("SnippetsFilterCount", 13),
 		attribute.Int64("UpstreamSettingsPolicyCount", 14),
 		attribute.Int64("GatewayAttachedNpCount", 15),
-		attribute.Int64("InferencePoolCount", 16),
 		attribute.Int64("NginxPodCount", 3),
 		attribute.Int64("ControlPlanePodCount", 3),
 		attribute.Bool("NginxOneConnectionEnabled", true),
+		attribute.Int64("InferencePoolCount", 16),
 	}
 
 	result := data.Attributes()
@@ -131,10 +131,10 @@ func TestDataAttributesWithEmptyData(t *testing.T) {
 		attribute.Int64("SnippetsFilterCount", 0),
 		attribute.Int64("UpstreamSettingsPolicyCount", 0),
 		attribute.Int64("GatewayAttachedNpCount", 0),
-		attribute.Int64("InferencePoolCount", 0),
 		attribute.Int64("NginxPodCount", 0),
 		attribute.Int64("ControlPlanePodCount", 0),
 		attribute.Bool("NginxOneConnectionEnabled", false),
+		attribute.Int64("InferencePoolCount", 0),
 	}
 
 	result := data.Attributes()

--- a/internal/controller/telemetry/ngfresourcecounts_attributes_generated.go
+++ b/internal/controller/telemetry/ngfresourcecounts_attributes_generated.go
@@ -28,7 +28,6 @@ func (d *NGFResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("SnippetsFilterCount", d.SnippetsFilterCount))
 	attrs = append(attrs, attribute.Int64("UpstreamSettingsPolicyCount", d.UpstreamSettingsPolicyCount))
 	attrs = append(attrs, attribute.Int64("GatewayAttachedNpCount", d.GatewayAttachedNpCount))
-	attrs = append(attrs, attribute.Int64("InferencePoolCount", d.InferencePoolCount))
 
 	return attrs
 }

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -93,10 +93,10 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 				"SnippetsFilterCount: Int(0)",
 				"UpstreamSettingsPolicyCount: Int(0)",
 				"GatewayAttachedNpCount: Int(0)",
-				"InferencePoolCount: Int(0)",
 				"NginxPodCount: Int(0)",
 				"ControlPlanePodCount: Int(1)",
 				"NginxOneConnectionEnabled: Bool(false)",
+				"InferencePoolCount: Int(0)",
 			},
 		)
 	})


### PR DESCRIPTION
### Proposed changes

Problem: Want to collect number of referenced InferencePools in cluster.

Solution: Collect the count of referenced InferencePools.

Testing: Unit tests and manually verified collection via debug logs. 

Closes #3843

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Collect InferencePool count for telemetry data. 
```
