### PR TITLE
Use download artifact instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,11 +52,11 @@ jobs:
         with:
           ref: ${{ (inputs.tag != '' && !inputs.dry_run ) && format('refs/tags/v{0}', inputs.tag) || github.ref }}
 
-      - name: Fetch Cached Artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Download Artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
+          name: dist-${{ github.run_id }}
           path: ${{ github.workspace }}/dist
-          key: nginx-gateway-fabric-${{ github.run_id }}-${{ github.run_number }}
 
       - name: Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - "**"
   schedule:
-    - cron: "0 4 * * *" # run every day at 4am UTC
+    - cron: "0 4 * * *" # run every day at 4am UTC (nightly builds)
   workflow_call:
     inputs:
       is_production_release:
@@ -265,11 +265,12 @@ jobs:
           echo "Generated JSON: $json"
           echo "json=$json" >> $GITHUB_OUTPUT
 
-      - name: Cache Artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          name: dist-${{ github.run_id }}
           path: ${{ github.workspace }}/dist
-          key: nginx-gateway-fabric-${{ github.run_id }}-${{ github.run_number }}
+          retention-days: 1
 
   assertion:
     name: Generate and Sign Assertion Documents
@@ -307,11 +308,11 @@ jobs:
         with:
           go-version: stable
 
-      - name: Fetch Cached Artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Download Artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
+          name: dist-${{ github.run_id }}
           path: ${{ github.workspace }}/dist
-          key: nginx-gateway-fabric-${{ github.run_id }}-${{ github.run_number }}
 
       - name: List Dependencies in Go Binary
         id: godeps

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch Cached Artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Download Artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
+          name: dist-${{ github.run_id }}
           path: ${{ github.workspace }}/dist
-          key: nginx-gateway-fabric-${{ github.run_id }}-${{ github.run_number }}
 
       - name: Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1


### PR DESCRIPTION
### Proposed changes

Problem: After the secure build workflow changes, on main or production runs the build binary job was running on a different runner type from the helm tests job meaning the cache doesn't work correctly between these stages.

Additionally, the nightly run attempts to log in to the NGINX image registry using the actor of the pipeline. This has been failing as the actor of the scheduled builds no longer works here.

Solution: Use artifact upload and download instead of cache for the binary so it persists across runner types, and edit the schedule line with a comment so that I appear as the actor for the nightly runs instead

Closes #4032 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
