### PR TITLE
Add fix for inference pool status

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,8 +18,8 @@ EXPERIMENTAL_CONFORMANCE_PROFILES = GATEWAY-TLS
 CONFORMANCE_PROFILES = $(STANDARD_CONFORMANCE_PROFILES) # by default we use the standard conformance profiles. If experimental is enabled we override this and add the experimental profiles.
 SKIP_TESTS =
 CEL_TEST_TARGET =
-INFERENCE_SUPPORTED_FEATURES = GatewayFollowingEPPRouting,EppUnAvailableFailOpen,HTTPRouteInvalidInferencePoolRef,InferencePoolAccepted,HTTPRouteMultipleGatewaysDifferentPools,HTTPRouteMultipleRulesDifferentPools,InferencePoolHTTPRoutePortValidation,InferencePoolInvalidEPPService
-INFERENCE_SKIP_TESTS = InferencePoolResolvedRefsCondition
+INFERENCE_SUPPORTED_FEATURES = GatewayFollowingEPPRouting,EppUnAvailableFailOpen,HTTPRouteInvalidInferencePoolRef,InferencePoolAccepted,HTTPRouteMultipleGatewaysDifferentPools,HTTPRouteMultipleRulesDifferentPools,InferencePoolHTTPRoutePortValidation,InferencePoolInvalidEPPService,InferencePoolResolvedRefsCondition
+INFERENCE_SKIP_TESTS = 
 
 # Check if ENABLE_EXPERIMENTAL is true
 ifeq ($(ENABLE_EXPERIMENTAL),true)


### PR DESCRIPTION
PR that goes into the ongoing `tests/inference-conformance` branch. Passes `InferencePoolResolvedRefsCondition` conformance test.

When setting inference pool statuses, it loops through all the inference pools and checks if there are any nginx gateways that have parentRefs in the statuses. If there are AND the infernece pool is not referenced (not connected to the graph), it will remove that parentRef. 