### PR TITLE
Add regex example to advanced routing

### DIFF
--- a/examples/advanced-routing/regex-route.yaml
+++ b/examples/advanced-routing/regex-route.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: coffee-regex
+spec:
+  parentRefs:
+  - name: cafe
+  hostnames:
+  - cafe.example.com
+  rules:
+  - matches:
+    - path:
+        type: RegularExpression
+        value: /coffee/[a-z]+
+    backendRefs:
+    - name: coffee-v1-svc
+      port: 80


### PR DESCRIPTION
### Proposed changes

Problem: The advanced routing guide in the documentation is being updated to include an example for regex path type so we need to update our examples to reflect this

Solution: Add the new regex route yaml corresponding to the guide

Closes #3946 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
