### PR TITLE
Fix helm linter in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -125,6 +125,7 @@ jobs:
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
         with:
           version: 3.14.0 # renovate: datasource=github-tags depName=helm/chart-testing
+          # v6.0.0 resolved the compatibility issue with Python > 3.13. may be removed after the action itself is updated
           yamale_version: "6.0.0"
 
       - name: Run chart-testing


### PR DESCRIPTION
Issue with yamale inside helm chart tester. This pins the yamale version to the fixed version.

Issue and solution shown: https://github.com/helm/chart-testing-action/issues/177