### PR TITLE
Use relative module path

### DIFF
--- a/internal/controller/nginx/conf/nginx-plus.conf
+++ b/internal/controller/nginx/conf/nginx-plus.conf
@@ -12,8 +12,8 @@ events {
 http {
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/mime.types;
-  js_import /usr/lib/nginx/modules/njs/httpmatches.js;
-  js_import /usr/lib/nginx/modules/njs/epp.js;
+  js_import modules/njs/httpmatches.js;
+  js_import modules/njs/epp.js;
 
   default_type application/octet-stream;
 

--- a/internal/controller/nginx/conf/nginx.conf
+++ b/internal/controller/nginx/conf/nginx.conf
@@ -12,8 +12,8 @@ events {
 http {
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/mime.types;
-  js_import /usr/lib/nginx/modules/njs/httpmatches.js;
-  js_import /usr/lib/nginx/modules/njs/epp.js;
+  js_import modules/njs/httpmatches.js;
+  js_import modules/njs/epp.js;
 
   default_type application/octet-stream;
 


### PR DESCRIPTION
In https://github.com/nginx/nginx-gateway-fabric/pull/4004 we updated several files to use `moduels/` instead of `/usr/lib/nginx/modules` as NGINX creates a symlink from `/etc/nginx/moduels` to the appropriate modules directory based on the operating system.

That change was done to ensure consistent behavior between images built on different operating systems.

This change ensure we do the same for the new `epp.njs` module

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
