### PR TITLE
Run nightly on production runners, ignore .git for vm sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           if [[ "${{ secrets.ARTIFACTORY_USER }}" == "" ]]; then
           echo "No Artifactory secrets available - using direct GOPROXY"
           GOPROXY_VALUE="direct"
-          elif [[ "${{ inputs.is_production_release }}" == "true" ]] || [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "${{ inputs.is_production_release }}" == "true" ]] || [[ ("${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "schedule") && "${{ github.ref }}" == "refs/heads/main" ]]; then
           echo "Production mode - using production Artifactory"
           GOPROXY_VALUE="https://${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_TOKEN }}@${{ secrets.ARTIFACTORY_ENDPOINT }}"
           else
@@ -167,7 +167,7 @@ jobs:
 
   binary:
     name: Build Binary
-    runs-on: ${{ github.repository_owner == 'nginx' && (inputs.is_production_release || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'ubuntu-24.04-amd64' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'nginx' && (inputs.is_production_release || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')) && 'ubuntu-24.04-amd64' || 'ubuntu-24.04' }}
     needs: [vars, unit-tests, njs-unit-tests]
     outputs:
       json: ${{ steps.gateway_binaries.outputs.json }}
@@ -187,7 +187,7 @@ jobs:
           if [[ "${{ secrets.ARTIFACTORY_USER }}" == "" ]]; then
           echo "No Artifactory secrets available - using direct GOPROXY"
           GOPROXY_VALUE="direct"
-          elif [[ "${{ inputs.is_production_release }}" == "true" ]] || [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "${{ inputs.is_production_release }}" == "true" ]] || [[ ("${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "schedule") && "${{ github.ref }}" == "refs/heads/main" ]]; then
           echo "Production mode - using production Artifactory"
           GOPROXY_VALUE="https://${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_TOKEN }}@${{ secrets.ARTIFACTORY_ENDPOINT }}"
           else
@@ -288,16 +288,8 @@ jobs:
       - name: Configure GOPROXY
         id: goproxy
         run: |
-          if [[ "${{ secrets.ARTIFACTORY_USER }}" == "" ]]; then
-          echo "No Artifactory secrets available - using direct GOPROXY"
-          GOPROXY_VALUE="direct"
-          elif [[ "${{ inputs.is_production_release }}" == "true" ]] || [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
           echo "Production mode - using production Artifactory"
           GOPROXY_VALUE="https://${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_TOKEN }}@${{ secrets.ARTIFACTORY_ENDPOINT }}"
-          else
-          echo "Development mode - using dev Artifactory"
-          GOPROXY_VALUE="https://${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_TOKEN }}@${{ secrets.ARTIFACTORY_DEV_ENDPOINT }}"
-          fi
           echo "GOPROXY=${GOPROXY_VALUE}" >> $GITHUB_ENV
 
       - name: Setup Golang Environment
@@ -476,7 +468,7 @@ jobs:
 
   publish-helm:
     name: Package and Publish Helm Chart
-    runs-on: ${{ github.repository_owner == 'nginx' && (inputs.is_production_release || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'ubuntu-24.04-amd64' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'nginx' && (inputs.is_production_release || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')) && 'ubuntu-24.04-amd64' || 'ubuntu-24.04' }}
     needs: [vars, helm-tests]
     if: ${{ (inputs.is_production_release && (inputs.dry_run == false || inputs.dry_run == null)) || (github.event_name == 'push' && ! startsWith(github.ref, 'refs/heads/release-')) }}
     permissions:

--- a/tests/scripts/sync-files-to-vm.sh
+++ b/tests/scripts/sync-files-to-vm.sh
@@ -8,4 +8,4 @@ NGF_DIR=$(dirname "$PWD")/
 
 gcloud compute config-ssh --ssh-config-file ngf-gcp.ssh >/dev/null
 
-rsync -ave 'ssh -F ngf-gcp.ssh' "${NGF_DIR}" username@"${RESOURCE_NAME}"."${GKE_CLUSTER_ZONE}"."${GKE_PROJECT}":~/nginx-gateway-fabric
+rsync -ave 'ssh -F ngf-gcp.ssh' --exclude '.git' "${NGF_DIR}" username@"${RESOURCE_NAME}"."${GKE_CLUSTER_ZONE}"."${GKE_PROJECT}":~/nginx-gateway-fabric


### PR DESCRIPTION
### Proposed changes

Problem: Nightly run is still failing 

Solution: Run nightly on production runners, as they have access to push to the Plus registry

Also simplified the go proxy setup for the assertion job, and removed syncing the `.git` directory for vm sync

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
