### PR TITLE
Add conditional on listing inference pools for status

### DIFF
--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -259,6 +259,7 @@ func StartManager(cfg config.Config) error {
 		plus:                    cfg.Plus,
 		statusQueue:             statusQueue,
 		nginxDeployments:        nginxUpdater.NginxDeployments,
+		inferenceExtension:      cfg.InferenceExtension,
 	})
 
 	objects, objectLists := prepareFirstEventBatchPreparerArgs(cfg)


### PR DESCRIPTION
Add a conditional to inference pool status, so we make a k8sclient call on the InferencePool object only if inference extension is enabled. 

Without this fix, if you deploy NGF on main without the inference extension flag enabled, it will print out this error message: 

`
{"level":"error","ts":"2025-10-17T22:34:47Z","logger":"eventHandler","msg":"error listing InferencePools for status update","error":"no matches for kind \"InferencePool\" in version \"inference.networking.k8s.io/v1\"","stacktrace":"github.com/nginx/nginx-gateway-fabric/v2/internal/controller.(*eventHandlerImpl).updateStatuses\n\tgithub.com/nginx/nginx-gateway-fabric/v2/internal/controller/handler.go:378\ngithub.com/nginx/nginx-gateway-fabric/v2/internal/controller.(*eventHandlerImpl).waitForStatusUpdates\n\tgithub.com/nginx/nginx-gateway-fabric/v2/internal/controller/handler.go:295"}
`

However, there should be no functionality impact by this error message. 