### PR TITLE
Upload NFR test results even if test fails

### DIFF
--- a/.github/workflows/nfr.yml
+++ b/.github/workflows/nfr.yml
@@ -149,6 +149,7 @@ jobs:
         run: make create-gke-router || true
 
       - name: Run Tests
+        continue-on-error: true
         working-directory: ./tests
         run: |
           if ${{ needs.vars.outputs.test_label != 'all' }}; then


### PR DESCRIPTION
### Proposed changes

Problem: If there's a test failure in the NFR test pipeline, we don't upload any artifacts or open the PR which means it's difficult to debug and means we may miss failures

Solution: Add continue-on-error to the run tests step, and update the script to scp the results files before exiting

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
