### PR TITLE
Add conditional on listing inference pools (#4104)

### DIFF
--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -259,6 +259,7 @@ func StartManager(cfg config.Config) error {
 		plus:                    cfg.Plus,
 		statusQueue:             statusQueue,
 		nginxDeployments:        nginxUpdater.NginxDeployments,
+		inferenceExtension:      cfg.InferenceExtension,
 	})
 
 	objects, objectLists := prepareFirstEventBatchPreparerArgs(cfg)


### PR DESCRIPTION
Cherry-pick #4104. Add a conditional to inference pool status, so we make a k8sclient call on the InferencePool object only if inference extension is enabled.