### PR TITLE
Fix cves for pcre2 and libxml2

### DIFF
--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -6,6 +6,10 @@ ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.p
 
 FROM nginx:1.29.2-alpine-otel
 
+# the following apk update and add are to address CVE-2025-58050, CVE-2025-6021/CVE-2025-49795/CVE-2025-49794/CVE-2025-49796 respectively.
+# once a new base image is available with these package updates, they can be removed.
+RUN apk update && apk add --no-cache 'pcre2>=10.46-r0' 'libxml2>=2.13.9-r0'
+
 # renovate: datasource=github-tags depName=nginx/agent
 ARG NGINX_AGENT_VERSION=v3.3.2
 ARG NJS_DIR


### PR DESCRIPTION
Update pcre2 and libxml2 in our base nginx docker image. 