### PR TITLE
Move permissions to higher context

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -24,7 +24,12 @@ defaults:
     shell: bash
 
 permissions:
-  contents: read
+  contents: write
+  packages: write
+  id-token: write
+  security-events: write
+  issues: write
+  actions: write
 
 jobs:
   create-tag-and-release:
@@ -94,10 +99,3 @@ jobs:
       operator_version: ${{ github.event.inputs.operator-version }}
       dry_run: ${{ github.event.inputs.dry_run }}
     secrets: inherit
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
-      security-events: write
-      issues: write
-      actions: write


### PR DESCRIPTION
### Proposed changes

Fix production workflow by moving permissions to workflow level

The production-build job was getting stuck because GitHub Actions
does not support job-level permissions for workflow_call jobs.

Moved permissions from the production-build job to the workflow
level so ci.yml can inherit them. The create-tag-and-release job
retains its restricted permissions via job-level override.

Fixes the greyed-out production-build job issue.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
