### PR TITLE
Preserve external controller state during reconciliation

### DIFF
--- a/internal/controller/provisioner/setter_test.go
+++ b/internal/controller/provisioner/setter_test.go
@@ -1,0 +1,153 @@
+package provisioner
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestServiceSpecSetter_PreservesExternalAnnotations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		existingAnnotations map[string]string
+		desiredAnnotations  map[string]string
+		expectedAnnotations map[string]string
+		name                string
+	}{
+		{
+			name: "preserves MetalLB annotations while adding NGF annotations",
+			existingAnnotations: map[string]string{
+				"metallb.universe.tf/ip-allocated-from-pool": "production-public-ips",
+				"metallb.universe.tf/loadBalancerIPs":        "192.168.1.100",
+			},
+			desiredAnnotations: map[string]string{
+				"custom.annotation": "from-gateway-infrastructure",
+			},
+			expectedAnnotations: map[string]string{
+				"metallb.universe.tf/ip-allocated-from-pool":         "production-public-ips",
+				"metallb.universe.tf/loadBalancerIPs":                "192.168.1.100",
+				"custom.annotation":                                  "from-gateway-infrastructure",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+		},
+		{
+			name: "NGF annotations take precedence on conflicts",
+			existingAnnotations: map[string]string{
+				"custom.annotation":                "old-value",
+				"metallb.universe.tf/address-pool": "staging",
+			},
+			desiredAnnotations: map[string]string{
+				"custom.annotation": "new-value",
+			},
+			expectedAnnotations: map[string]string{
+				"custom.annotation":                                  "new-value",
+				"metallb.universe.tf/address-pool":                   "staging",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+		},
+		{
+			name:                "creates new service with annotations",
+			existingAnnotations: nil,
+			desiredAnnotations: map[string]string{
+				"custom.annotation": "value",
+			},
+			expectedAnnotations: map[string]string{
+				"custom.annotation": "value",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+		},
+		{
+			name: "removes NGF-managed annotations when no longer desired",
+			existingAnnotations: map[string]string{
+				"custom.annotation":                                  "should-be-removed",
+				"metallb.universe.tf/ip-allocated-from-pool":         "production",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+			desiredAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				"metallb.universe.tf/ip-allocated-from-pool": "production",
+			},
+		},
+		{
+			name: "preserves cloud provider annotations",
+			existingAnnotations: map[string]string{
+				"service.beta.kubernetes.io/aws-load-balancer-type":   "nlb",
+				"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+			},
+			desiredAnnotations: map[string]string{
+				"custom.annotation": "from-nginxproxy-patch",
+			},
+			expectedAnnotations: map[string]string{
+				"service.beta.kubernetes.io/aws-load-balancer-type":   "nlb",
+				"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+				"custom.annotation": "from-nginxproxy-patch",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+		},
+		{
+			name: "updates tracking annotation when managed keys change",
+			existingAnnotations: map[string]string{
+				"annotation-to-keep":                                 "value1",
+				"annotation-to-remove":                               "value2",
+				"metallb.universe.tf/address-pool":                   "production",
+				"gateway.nginx.org/internal-managed-annotation-keys": "annotation-to-keep,annotation-to-remove",
+			},
+			desiredAnnotations: map[string]string{
+				"annotation-to-keep": "value1",
+			},
+			expectedAnnotations: map[string]string{
+				"annotation-to-keep":                                 "value1",
+				"metallb.universe.tf/address-pool":                   "production",
+				"gateway.nginx.org/internal-managed-annotation-keys": "annotation-to-keep",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			// Create existing service with annotations
+			existingService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-service",
+					Namespace:   "default",
+					Annotations: tt.existingAnnotations,
+				},
+			}
+
+			// Create desired object metadata with NGF-managed annotations
+			desiredMeta := metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app": "nginx-gateway",
+				},
+				Annotations: tt.desiredAnnotations,
+			}
+
+			// Create desired spec
+			desiredSpec := corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "http",
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			}
+
+			// Execute the setter
+			setter := serviceSpecSetter(existingService, desiredSpec, desiredMeta)
+			err := setter()
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(existingService.Annotations).To(Equal(tt.expectedAnnotations))
+			g.Expect(existingService.Labels).To(Equal(desiredMeta.Labels))
+			g.Expect(existingService.Spec).To(Equal(desiredSpec))
+		})
+	}
+}


### PR DESCRIPTION
### Proposed changes

Problem: NGINX Gateway Fabric's provisioner removes all annotations during service reconciliation that aren't explicitly managed by NGF. This causes conflicts with external controllers that need to add operational annotations. 

Solution: Implemented a preservation pattern for both service annotations by merging Service annotations instead of overwriting.

Note: This necessitates the use of a new internal annotation `gateway.nginx.org/internal-managed-annotation-keys` to track the user managed annotation keys

Testing: Unit testing, manual testing covering the following scenarios:
- External annotation added and preserved throughout all scenarios, and remains removed when deleted
- User added annotations using both Gateway infrastructure field and patches are preserved, take precedence, and are deleted from the Service when removed from the Gateway or NginxProxy

Closes #4012
Closes #4175

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Preserve external controller annotations.
```
