### PR TITLE
Allow HPA to work when Inference is enabled

### DIFF
--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -1019,6 +1019,7 @@ func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 		},
 	}
 
+	var containerResources corev1.ResourceRequirements
 	if nProxyCfg != nil && nProxyCfg.Kubernetes != nil {
 		var podSpec *ngfAPIv1alpha2.PodSpec
 		var containerSpec *ngfAPIv1alpha2.ContainerSpec
@@ -1042,7 +1043,8 @@ func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 		if containerSpec != nil {
 			container := spec.Spec.Containers[0]
 			if containerSpec.Resources != nil {
-				container.Resources = *containerSpec.Resources
+				containerResources = *containerSpec.Resources
+				container.Resources = containerResources
 			}
 			container.Lifecycle = containerSpec.Lifecycle
 			container.VolumeMounts = append(container.VolumeMounts, containerSpec.VolumeMounts...)
@@ -1174,6 +1176,7 @@ func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 			Image:           p.cfg.GatewayPodConfig.Image,
 			ImagePullPolicy: pullPolicy,
 			Command:         command,
+			Resources:       containerResources,
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: helpers.GetPointer(false),
 				Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
Problem: When the Inference Extension was enabled, the additional container was not given resource specifications, which prevented the HPA from working.

Solution: Add the resource specifications from the NGINX container to the inference container.
Testing: Manually verified that HPA now works with inference enabled

Closes #4245 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix bug that prevented HPA from working when Inference Extension was enabled.
```
