### PR TITLE
Update redhat/ubi9-minimal Docker tag to v9.7-1762180032 (#4268)

### DIFF
--- a/build/ubi/Dockerfile
+++ b/build/ubi/Dockerfile
@@ -11,7 +11,7 @@ RUN make build
 
 FROM golang:1.25 AS ca-certs-provider
 
-FROM redhat/ubi9-minimal:9.6 AS ngf-ubi-minimal
+FROM redhat/ubi9-minimal:9.7-1762180032 AS ngf-ubi-minimal
 # CA certs are needed for telemetry report so that NGF can verify the server's certificate.
 COPY --from=ca-certs-provider --link /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 USER 101:1001

--- a/build/ubi/Dockerfile.nginx
+++ b/build/ubi/Dockerfile.nginx
@@ -8,7 +8,7 @@ ADD --link --chown=101:1001 build/ubi/repos/agent.repo agent.repo
 
 FROM ghcr.io/nginx/dependencies/nginx-ubi:ubi9@sha256:77b206aed605f2dca010cd150846a4ab95189460524f82705393771f5047f635 AS ubi9-packages
 
-FROM redhat/ubi9-minimal:9.6 AS ubi-nginx
+FROM redhat/ubi9-minimal:9.7-1762180032 AS ubi-nginx
 
 # renovate: datasource=github-tags depName=nginx/agent
 ARG NGINX_AGENT_VERSION=v3.3.2

--- a/build/ubi/Dockerfile.nginxplus
+++ b/build/ubi/Dockerfile.nginxplus
@@ -8,7 +8,7 @@ ADD --link --chown=101:1001 build/ubi/repos/agent.repo agent.repo
 
 FROM ghcr.io/nginx/dependencies/nginx-ubi:ubi9@sha256:77b206aed605f2dca010cd150846a4ab95189460524f82705393771f5047f635 AS ubi9-packages
 
-FROM redhat/ubi9-minimal:9.6 AS ubi-nginx-plus
+FROM redhat/ubi9-minimal:9.7-1762180032 AS ubi-nginx-plus
 
 ARG NGINX_PLUS_VERSION=R35
 


### PR DESCRIPTION
| datasource | package             | from | to             |
| ---------- | ------------------- | ---- | -------------- |
| docker     | redhat/ubi9-minimal | 9.6  | 9.7-1762180032 |
