### PR TITLE
Upload conformance profiles to the correct release

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -196,7 +196,7 @@ jobs:
         if: ${{ inputs.production-release && inputs.enable-experimental }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} conformance-profile.yaml --clobber
+        run: gh release upload ${{ inputs.release_version }} conformance-profile.yaml --clobber
         working-directory: ./tests
 
       - name: Run inference conformance tests
@@ -217,5 +217,5 @@ jobs:
         if: ${{ inputs.production-release && inputs.enable-experimental }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} conformance-profile-inference.yaml --clobber
+        run: gh release upload ${{ inputs.release_version }} conformance-profile-inference.yaml --clobber
         working-directory: ./tests


### PR DESCRIPTION
### Proposed changes

Problem: The conformance profiles are not being correctly uploaded to the GitHub release

Solution: Update the release upload command to use the inputs.release_version instead of the branch name

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
