### PR TITLE
fix: pass IPv6 DNS resolvers correctly

### DIFF
--- a/internal/controller/nginx/config/base_http_config_test.go
+++ b/internal/controller/nginx/config/base_http_config_test.go
@@ -318,6 +318,28 @@ func TestExecuteBaseHttp_DNSResolver(t *testing.T) {
 			expectedConfig: "resolver 8.8.8.8;",
 		},
 		{
+			name: "DNS resolver with single IPv6 address",
+			conf: dataplane.Configuration{
+				BaseHTTPConfig: dataplane.BaseHTTPConfig{
+					DNSResolver: &dataplane.DNSResolverConfig{
+						Addresses: []string{"2606:4700:4700::64"},
+					},
+				},
+			},
+			expectedConfig: "resolver [2606:4700:4700::64];",
+		},
+		{
+			name: "DNS resolver with one IPv6 address and one IPv4 address",
+			conf: dataplane.Configuration{
+				BaseHTTPConfig: dataplane.BaseHTTPConfig{
+					DNSResolver: &dataplane.DNSResolverConfig{
+						Addresses: []string{"2606:4700:4700::64", "8.8.8.8"},
+					},
+				},
+			},
+			expectedConfig: "resolver [2606:4700:4700::64] 8.8.8.8;",
+		},
+		{
 			name: "no DNS resolver",
 			conf: dataplane.Configuration{
 				BaseHTTPConfig: dataplane.BaseHTTPConfig{

--- a/internal/controller/nginx/config/stream_servers.go
+++ b/internal/controller/nginx/config/stream_servers.go
@@ -19,7 +19,7 @@ func (g GeneratorImpl) executeStreamServers(conf dataplane.Configuration) []exec
 		Servers:     streamServers,
 		IPFamily:    getIPFamily(conf.BaseHTTPConfig),
 		Plus:        g.plus,
-		DNSResolver: conf.BaseStreamConfig.DNSResolver,
+		DNSResolver: buildDNSResolver(conf.BaseStreamConfig.DNSResolver),
 	}
 
 	streamServerResult := executeResult{

--- a/internal/controller/nginx/config/stream_servers_test.go
+++ b/internal/controller/nginx/config/stream_servers_test.go
@@ -471,7 +471,7 @@ server {
 			},
 			expectedConfig: `
 # DNS resolver configuration for ExternalName services
-resolver 2001:4860:4860::8888 valid=30s;
+resolver [2001:4860:4860::8888] valid=30s;
 resolver_timeout 5s;
 
 server {


### PR DESCRIPTION
### Proposed changes

Problem: nginx expects IPv6 DNS resolvers to be passed with [] brackets:
`invalid port in resolver \"2606:4700:4700::1111\" in /etc/nginx/stream-conf.d/stream.conf`
But passing resolvers with brackets is not possible:
`gatewayClassNp="&{Source:0xc0014382c0 ErrMsgs:[spec.dnsResolver.addresses[0].value: Invalid value: \"[2606:4700:4700::1111]\": must be a valid IP address] Valid:false}"`

Solution: detect IPv6 resolvers and add brackets in the config templating.

Testing: deployed on an IPv6 capable cluster and configured DNS resolvers using the helm chart, deployed a gateway and http route pointing to an ExternalName service (which requires configuring a DNS resolver).

Fixes https://github.com/nginx/nginx-gateway-fabric/issues/4369

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixed an issue regarding configuring IPv6 DNS resolvers for ExternalName services
```
