### PR TITLE
Fix empty pod owner name when connecting to agent

### DIFF
--- a/internal/controller/nginx/agent/command.go
+++ b/internal/controller/nginx/agent/command.go
@@ -84,6 +84,9 @@ func (cs *commandService) CreateConnection(
 
 	resource := req.GetResource()
 	podName := resource.GetContainerInfo().GetHostname()
+	if podName == "" {
+		podName = resource.GetHostInfo().GetHostname()
+	}
 	cs.logger.Info(fmt.Sprintf("Creating connection for nginx pod: %s", podName))
 
 	owner, _, err := cs.getPodOwner(podName)

--- a/internal/controller/nginx/agent/command_test.go
+++ b/internal/controller/nginx/agent/command_test.go
@@ -164,6 +164,32 @@ func TestCreateConnection(t *testing.T) {
 			},
 		},
 		{
+			name: "uses regular hostname if container info not set",
+			ctx:  createGrpcContext(),
+			request: &pb.CreateConnectionRequest{
+				Resource: &pb.Resource{
+					Info: &pb.Resource_HostInfo{
+						HostInfo: &pb.HostInfo{
+							Hostname: "nginx-pod",
+						},
+					},
+					Instances: []*pb.Instance{
+						{
+							InstanceMeta: &pb.InstanceMeta{
+								InstanceId:   "nginx-id",
+								InstanceType: pb.InstanceMeta_INSTANCE_TYPE_NGINX,
+							},
+						},
+					},
+				},
+			},
+			response: &pb.CreateConnectionResponse{
+				Response: &pb.CommandResponse{
+					Status: pb.CommandResponse_COMMAND_STATUS_OK,
+				},
+			},
+		},
+		{
 			name:      "request is nil",
 			request:   nil,
 			response:  nil,


### PR DESCRIPTION
Problem: Saw an issue where nginx failed to connect to the control plane due to an empty hostname and not being able to find the pod name.

Solution: If ContainerInfo provided by agent is empty, fall back to HostInfo. This should cover all bases to ensure we get the hostname.

Testing: Fixed my issue that I saw locally.

Closes #4366

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixed an issue where control plane and data plane failed to connect due to empty pod name (hostname).
```
