### PR TITLE
Add telemetry for ProxySettingsPolicy

### DIFF
--- a/internal/controller/telemetry/collector_test.go
+++ b/internal/controller/telemetry/collector_test.go
@@ -510,8 +510,6 @@ var _ = Describe("Collector", Ordered, func() {
 					SnippetsFilterCount:                      3,
 					UpstreamSettingsPolicyCount:              1,
 					GatewayAttachedNpCount:                   2,
-					GatewayAttachedProxySettingsPolicyCount:  2,
-					RouteAttachedProxySettingsPolicyCount:    4,
 				}
 				expData.ClusterVersion = "1.29.2"
 				expData.ClusterPlatform = "kind"
@@ -547,6 +545,8 @@ var _ = Describe("Collector", Ordered, func() {
 				expData.BuildOS = "alpine"
 
 				expData.InferencePoolCount = 3
+				expData.GatewayAttachedProxySettingsPolicyCount = 2
+				expData.RouteAttachedProxySettingsPolicyCount = 4
 
 				data, err := dataCollector.Collect(ctx)
 				Expect(err).ToNot(HaveOccurred())
@@ -828,11 +828,11 @@ var _ = Describe("Collector", Ordered, func() {
 					UpstreamSettingsPolicyCount:              1,
 					GatewayAttachedNpCount:                   1,
 					BackendTLSPolicyCount:                    1,
-					GatewayAttachedProxySettingsPolicyCount:  2,
-					RouteAttachedProxySettingsPolicyCount:    3,
 				}
 				expData.NginxPodCount = 1
 				expData.InferencePoolCount = 1
+				expData.GatewayAttachedProxySettingsPolicyCount = 2
+				expData.RouteAttachedProxySettingsPolicyCount = 3
 
 				data, err := dataCollector.Collect(ctx)
 

--- a/internal/controller/telemetry/data.avdl
+++ b/internal/controller/telemetry/data.avdl
@@ -105,14 +105,6 @@ attached at the Gateway level. */
 		/** GatewayAttachedNpCount is the total number of NginxProxy resources that are attached to a Gateway. */
 		long? GatewayAttachedNpCount = null;
 		
-		/** GatewayAttachedProxySettingsPolicyCount is the number of relevant ProxySettingsPolicies
-attached at the Gateway level. */
-		long? GatewayAttachedProxySettingsPolicyCount = null;
-		
-		/** RouteAttachedProxySettingsPolicyCount is the number of relevant ProxySettingsPolicies
-attached at the Route level. */
-		long? RouteAttachedProxySettingsPolicyCount = null;
-		
 		/** NginxPodCount is the total number of Nginx data plane Pods. */
 		long? NginxPodCount = null;
 		
@@ -127,6 +119,14 @@ attached at the Route level. */
 		
 		/** BuildOS is the base operating system the control plane was built on (e.g. alpine, ubi). */
 		string? BuildOS = null;
+		
+		/** GatewayAttachedProxySettingsPolicyCount is the number of relevant ProxySettingsPolicies
+attached at the Gateway level. */
+		long? GatewayAttachedProxySettingsPolicyCount = null;
+		
+		/** RouteAttachedProxySettingsPolicyCount is the number of relevant ProxySettingsPolicies
+attached at the Route level. */
+		long? RouteAttachedProxySettingsPolicyCount = null;
 		
 	}
 }

--- a/internal/controller/telemetry/data_attributes_generated.go
+++ b/internal/controller/telemetry/data_attributes_generated.go
@@ -25,6 +25,8 @@ func (d *Data) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Bool("NginxOneConnectionEnabled", d.NginxOneConnectionEnabled))
 	attrs = append(attrs, attribute.Int64("InferencePoolCount", d.InferencePoolCount))
 	attrs = append(attrs, attribute.String("BuildOS", d.BuildOS))
+	attrs = append(attrs, attribute.Int64("GatewayAttachedProxySettingsPolicyCount", d.GatewayAttachedProxySettingsPolicyCount))
+	attrs = append(attrs, attribute.Int64("RouteAttachedProxySettingsPolicyCount", d.RouteAttachedProxySettingsPolicyCount))
 
 	return attrs
 }

--- a/internal/controller/telemetry/data_test.go
+++ b/internal/controller/telemetry/data_test.go
@@ -41,15 +41,15 @@ func TestDataAttributes(t *testing.T) {
 			SnippetsFilterCount:                      13,
 			UpstreamSettingsPolicyCount:              14,
 			GatewayAttachedNpCount:                   15,
-			GatewayAttachedProxySettingsPolicyCount:  17,
-			RouteAttachedProxySettingsPolicyCount:    18,
 		},
-		SnippetsFiltersDirectives:      []string{"main-three-count", "http-two-count", "server-one-count"},
-		SnippetsFiltersDirectivesCount: []int64{3, 2, 1},
-		NginxPodCount:                  3,
-		ControlPlanePodCount:           3,
-		NginxOneConnectionEnabled:      true,
-		InferencePoolCount:             16,
+		SnippetsFiltersDirectives:               []string{"main-three-count", "http-two-count", "server-one-count"},
+		SnippetsFiltersDirectivesCount:          []int64{3, 2, 1},
+		NginxPodCount:                           3,
+		ControlPlanePodCount:                    3,
+		NginxOneConnectionEnabled:               true,
+		InferencePoolCount:                      16,
+		GatewayAttachedProxySettingsPolicyCount: 17,
+		RouteAttachedProxySettingsPolicyCount:   18,
 	}
 
 	expected := []attribute.KeyValue{
@@ -86,13 +86,13 @@ func TestDataAttributes(t *testing.T) {
 		attribute.Int64("SnippetsFilterCount", 13),
 		attribute.Int64("UpstreamSettingsPolicyCount", 14),
 		attribute.Int64("GatewayAttachedNpCount", 15),
-		attribute.Int64("GatewayAttachedProxySettingsPolicyCount", 17),
-		attribute.Int64("RouteAttachedProxySettingsPolicyCount", 18),
 		attribute.Int64("NginxPodCount", 3),
 		attribute.Int64("ControlPlanePodCount", 3),
 		attribute.Bool("NginxOneConnectionEnabled", true),
 		attribute.Int64("InferencePoolCount", 16),
 		attribute.String("BuildOS", ""),
+		attribute.Int64("GatewayAttachedProxySettingsPolicyCount", 17),
+		attribute.Int64("RouteAttachedProxySettingsPolicyCount", 18),
 	}
 
 	result := data.Attributes()
@@ -136,13 +136,13 @@ func TestDataAttributesWithEmptyData(t *testing.T) {
 		attribute.Int64("SnippetsFilterCount", 0),
 		attribute.Int64("UpstreamSettingsPolicyCount", 0),
 		attribute.Int64("GatewayAttachedNpCount", 0),
-		attribute.Int64("GatewayAttachedProxySettingsPolicyCount", 0),
-		attribute.Int64("RouteAttachedProxySettingsPolicyCount", 0),
 		attribute.Int64("NginxPodCount", 0),
 		attribute.Int64("ControlPlanePodCount", 0),
 		attribute.Bool("NginxOneConnectionEnabled", false),
 		attribute.Int64("InferencePoolCount", 0),
 		attribute.String("BuildOS", ""),
+		attribute.Int64("GatewayAttachedProxySettingsPolicyCount", 0),
+		attribute.Int64("RouteAttachedProxySettingsPolicyCount", 0),
 	}
 
 	result := data.Attributes()

--- a/internal/controller/telemetry/ngfresourcecounts_attributes_generated.go
+++ b/internal/controller/telemetry/ngfresourcecounts_attributes_generated.go
@@ -28,8 +28,6 @@ func (d *NGFResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("SnippetsFilterCount", d.SnippetsFilterCount))
 	attrs = append(attrs, attribute.Int64("UpstreamSettingsPolicyCount", d.UpstreamSettingsPolicyCount))
 	attrs = append(attrs, attribute.Int64("GatewayAttachedNpCount", d.GatewayAttachedNpCount))
-	attrs = append(attrs, attribute.Int64("GatewayAttachedProxySettingsPolicyCount", d.GatewayAttachedProxySettingsPolicyCount))
-	attrs = append(attrs, attribute.Int64("RouteAttachedProxySettingsPolicyCount", d.RouteAttachedProxySettingsPolicyCount))
 
 	return attrs
 }

--- a/tests/suite/telemetry_test.go
+++ b/tests/suite/telemetry_test.go
@@ -93,13 +93,13 @@ var _ = Describe("Telemetry test with OTel collector", Label("telemetry"), func(
 				"SnippetsFilterCount: Int(0)",
 				"UpstreamSettingsPolicyCount: Int(0)",
 				"GatewayAttachedNpCount: Int(0)",
-				"GatewayAttachedProxySettingsPolicyCount: Int(0)",
-				"RouteAttachedProxySettingsPolicyCount: Int(0)",
 				"NginxPodCount: Int(0)",
 				"ControlPlanePodCount: Int(1)",
 				"NginxOneConnectionEnabled: Bool(false)",
 				"InferencePoolCount: Int(0)",
 				"BuildOS:",
+				"GatewayAttachedProxySettingsPolicyCount: Int(0)",
+				"RouteAttachedProxySettingsPolicyCount: Int(0)",
 			},
 		)
 	})


### PR DESCRIPTION
### Proposed changes

Problem: Need to track ProxySettingsPolicy telemetry
Solution:
add a product telemetry field to track the usage of ProxySettingsPolicy
update product telemetry doc with this new tracking information
(https://github.com/nginx/documentation/pull/1527)

Testing: unit tests.
Databricks PROD testing:
<img width="1250" height="711" alt="image" src="https://github.com/user-attachments/assets/52be8b2b-f580-4d4b-b118-404dd0478d0a" />


Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #4304 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
