### PR TITLE
Update permissions of gateway binary for UBI (#4404)

### DIFF
--- a/build/ubi/Dockerfile
+++ b/build/ubi/Dockerfile
@@ -33,11 +33,11 @@ COPY --link --chown=101:1001 LICENSE /licenses/
 ENTRYPOINT [ "/usr/bin/gateway" ]
 
 FROM ngf-ubi-minimal AS container
-COPY --from=builder /go/src/github.com/nginxinc/nginx-gateway-fabric/build/out/gateway /usr/bin/gateway
+COPY --chmod=0755 --from=builder /go/src/github.com/nginxinc/nginx-gateway-fabric/build/out/gateway /usr/bin/gateway
 
 FROM ngf-ubi-minimal AS local
-COPY ./build/out/gateway /usr/bin/gateway
+COPY --chmod=0755 ./build/out/gateway /usr/bin/gateway
 
 FROM ngf-ubi-minimal AS goreleaser
 ARG TARGETARCH
-COPY dist/gateway_linux_$TARGETARCH*/gateway /usr/bin/gateway
+COPY --chmod=0755 dist/gateway_linux_$TARGETARCH*/gateway /usr/bin/gateway


### PR DESCRIPTION
### Proposed changes

Cherry-pick of https://github.com/nginx/nginx-gateway-fabric/pull/4404 Update permissions of gateway binary for UBI

This change ensures that the gateway binary that we copy to `/usr/bin/gateway` in our UBI Control Plane Dockerfile has the appropriate permissions to run.

Currently, this causes an error in our UBI deployments that prevents the certificate generator pod from running.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix permission issue with nginx-gateway container for UBI 
```
