### PR TITLE
Bump operator release version

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -1,6 +1,6 @@
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of the operator.
-VERSION ?= 1.0.1
+VERSION ?= 1.0.2
 
 # renovate: datasource=github-tags depName=operator-framework/operator-sdk
 OPERATOR_SDK_VERSION ?= v1.42.0


### PR DESCRIPTION
### Proposed changes

This change bumps to operator release version to `v1.0.2` in preparation for release `v2.2.2`
