### PR TITLE
Preserve external controller annotations for deployment and daemonSet (#4468)

### DIFF
--- a/internal/controller/provisioner/setter_test.go
+++ b/internal/controller/provisioner/setter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -148,6 +149,203 @@ func TestServiceSpecSetter_PreservesExternalAnnotations(t *testing.T) {
 			g.Expect(existingService.Annotations).To(Equal(tt.expectedAnnotations))
 			g.Expect(existingService.Labels).To(Equal(desiredMeta.Labels))
 			g.Expect(existingService.Spec).To(Equal(desiredSpec))
+		})
+	}
+}
+
+func int32Ptr(i int32) *int32 { return &i }
+
+func TestDeploymentAndDaemonSetSpecSetter(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		existingAnnotations map[string]string
+		desiredAnnotations  map[string]string
+		expectedAnnotations map[string]string
+		name                string
+	}
+
+	tests := []testCase{
+		{
+			name: "preserves external annotations while adding NGF annotations",
+			existingAnnotations: map[string]string{
+				"deployment.kubernetes.io/revision": "1",
+				"field.cattle.io/publicEndpoints":   "192.61.0.19",
+				"field.cattle.io/ports":             "80/tcp",
+			},
+			desiredAnnotations: map[string]string{
+				"custom.annotation": "from-ngf",
+			},
+			expectedAnnotations: map[string]string{
+				"deployment.kubernetes.io/revision":                  "1",
+				"field.cattle.io/publicEndpoints":                    "192.61.0.19",
+				"field.cattle.io/ports":                              "80/tcp",
+				"custom.annotation":                                  "from-ngf",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+		},
+		{
+			name: "preserves existing NGF-managed annotations when still desired",
+			existingAnnotations: map[string]string{
+				"custom.annotation":                                  "keep-me",
+				"argocd.argoproj.io/sync-options":                    "Prune=false",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+			desiredAnnotations: map[string]string{
+				"custom.annotation": "keep-me",
+			},
+			expectedAnnotations: map[string]string{
+				"custom.annotation":                                  "keep-me",
+				"argocd.argoproj.io/sync-options":                    "Prune=false",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+		},
+		{
+			name: "removes NGF-managed annotations when no longer desired",
+			existingAnnotations: map[string]string{
+				"custom.annotation":                                  "should-be-removed",
+				"deployment.kubernetes.io/revision":                  "2",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+			desiredAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				"deployment.kubernetes.io/revision": "2",
+			},
+		},
+		{
+			name: "NGF annotations take precedence on conflicts",
+			existingAnnotations: map[string]string{
+				"custom.annotation":                "old-value",
+				"daemonSet.kubernetes.io/revision": "7",
+			},
+			desiredAnnotations: map[string]string{
+				"custom.annotation": "new-value",
+			},
+			expectedAnnotations: map[string]string{
+				"custom.annotation":                                  "new-value",
+				"daemonSet.kubernetes.io/revision":                   "7",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+		},
+		{
+			name:                "creates new deployment with annotations",
+			existingAnnotations: nil,
+			desiredAnnotations: map[string]string{
+				"custom.annotation": "value",
+			},
+			expectedAnnotations: map[string]string{
+				"custom.annotation": "value",
+				"gateway.nginx.org/internal-managed-annotation-keys": "custom.annotation",
+			},
+		},
+		{
+			name: "updates tracking annotation when managed keys change",
+			existingAnnotations: map[string]string{
+				"annotation-to-keep":                                 "keep-value",
+				"annotation-to-remove":                               "remove-value",
+				"argocd.argoproj.io/sync-options":                    "Validate=true",
+				"gateway.nginx.org/internal-managed-annotation-keys": "annotation-to-keep,annotation-to-remove",
+			},
+			desiredAnnotations: map[string]string{
+				"annotation-to-keep": "updated-keep-value",
+			},
+			expectedAnnotations: map[string]string{
+				"annotation-to-keep":                                 "updated-keep-value",
+				"argocd.argoproj.io/sync-options":                    "Validate=true",
+				"gateway.nginx.org/internal-managed-annotation-keys": "annotation-to-keep",
+			},
+		},
+	}
+
+	labels := map[string]string{
+		"app.kubernetes.io/name":     "nginx-gateway-fabric",
+		"app.kubernetes.io/instance": "nginx-gateway",
+	}
+
+	makeDesiredMeta := func(ann map[string]string) metav1.ObjectMeta {
+		return metav1.ObjectMeta{
+			Labels:      labels,
+			Annotations: ann,
+		}
+	}
+
+	podTemplate := corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: labels},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "nginx-gateway",
+				Image: "nginx:1.25",
+			}},
+		},
+	}
+
+	runners := []struct {
+		run  func(t *testing.T, tc testCase)
+		name string
+	}{
+		{
+			name: "Deployment",
+			run: func(t *testing.T, tc testCase) {
+				t.Helper()
+				g := NewWithT(t)
+
+				existing := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "nginx-gateway",
+						Namespace:   "nginx-gateway",
+						Annotations: tc.existingAnnotations,
+					},
+				}
+
+				spec := appsv1.DeploymentSpec{
+					Replicas: int32Ptr(1),
+					Selector: &metav1.LabelSelector{MatchLabels: labels},
+					Template: podTemplate,
+				}
+
+				err := deploymentSpecSetter(existing, spec, makeDesiredMeta(tc.desiredAnnotations))()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(existing.Annotations).To(Equal(tc.expectedAnnotations))
+				g.Expect(existing.Labels).To(Equal(labels))
+				g.Expect(existing.Spec).To(Equal(spec))
+			},
+		},
+		{
+			name: "DaemonSet",
+			run: func(t *testing.T, tc testCase) {
+				t.Helper()
+				g := NewWithT(t)
+
+				existing := &appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "nginx-gateway",
+						Namespace:   "nginx-gateway",
+						Annotations: tc.existingAnnotations,
+					},
+				}
+
+				spec := appsv1.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: labels},
+					Template: podTemplate,
+				}
+
+				err := daemonSetSpecSetter(existing, spec, makeDesiredMeta(tc.desiredAnnotations))()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(existing.Annotations).To(Equal(tc.expectedAnnotations))
+				g.Expect(existing.Labels).To(Equal(labels))
+				g.Expect(existing.Spec).To(Equal(spec))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, r := range runners {
+				t.Run(r.name, func(t *testing.T) {
+					r.run(t, tc)
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
Cherry-pick for #4468 

Problem: Users want that deployments and daemonSet preserve external annotations like how we do for services

Solution: Adds a solution to track internal annotations and preserver external annotations.

Testing: I verified the behavior by manually adding an annotation to both to deployment and waiting if controller overwrites it and watching the generation


```
kubectl annotate deploy gateway-nginx \
  field.cattle.io/publicEndpoints='[{"addresses":["x"],"port":80}]' --overwrite
deployment.apps/gateway-nginx annotated


 kubectl describe deploy gateway-nginx | sed -n '/Annotations:/,/Selector:/p'

Annotations:            deployment.kubernetes.io/revision: 1
                        field.cattle.io/publicEndpoints: [{"addresses":["x"],"port":80}]
Selector:               app.kubernetes.io/instance=nginx-gateway,app.kubernetes.io/managed-by=nginx-gateway-nginx,app.kubernetes.io/name=gateway-nginx,gateway.networking.k8s.io/gateway-name=gateway
  Annotations:      prometheus.io/port: 9113
                    prometheus.io/scrape: true

kubectl get deploy gateway-nginx -o jsonpath="{.metadata.generation}  {.metadata.resourceVersion}  {.metadata.annotations.field\.cattle\.io/publicEndpoints}{\"\n\"}" --watch
2  2046  [{"addresses":["x"],"port":80}]
```


Daemonset

```
 kubectl annotate daemonsets.apps gateway-nginx \ 
  field.cattle.io/publicEndpoints='[{"addresses":["x"],"port":80}]' --overwrite
daemonset.apps/gateway-nginx annotated

kubectl describe daemonsets.apps gateway-nginx | sed -n '/Annotations:/,/Selector:/p' 
Annotations:    deprecated.daemonset.template.generation: 1
                field.cattle.io/publicEndpoints: [{"addresses":["x"],"port":80}]
Desired Number of Nodes Scheduled: 1
Current Number of Nodes Scheduled: 1

controller  Created pod: gateway-nginx-gdvd7
sa.choudhary@N9939CQ4P0 nginx-gateway-fabric % kubectl get daemonsets.apps gateway-nginx -o jsonpath="{.metadata.generation}  {.metadata.resourceVersion}  {.metadata.annotations.field\.cattle\.io/publicEndpoints}{\"\n\"}" --watch 
1  26427  [{"addresses":["x"],"port":80}]
```
Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #4447 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixes a bug to preserve external controller annotations for Deployment and DaemonSets to avoid constant updates. 
```
