### PR TITLE
Fix hostNetwork data plane pod connection issue

### DIFF
--- a/internal/controller/nginx/agent/file_test.go
+++ b/internal/controller/nginx/agent/file_test.go
@@ -43,9 +43,8 @@ func TestGetFile(t *testing.T) {
 
 	connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
 	conn := agentgrpc.Connection{
-		PodName:    "nginx-pod",
 		InstanceID: "12345",
-		Parent:     deploymentName,
+		ParentName: deploymentName,
 	}
 	connTracker.GetConnectionReturns(conn)
 
@@ -109,9 +108,8 @@ func TestGetFile_InvalidRequest(t *testing.T) {
 	deploymentName := types.NamespacedName{Name: "nginx-deployment", Namespace: "default"}
 	connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
 	conn := agentgrpc.Connection{
-		PodName:    "nginx-pod",
 		InstanceID: "12345",
-		Parent:     deploymentName,
+		ParentName: deploymentName,
 	}
 	connTracker.GetConnectionReturns(conn)
 
@@ -165,9 +163,8 @@ func TestGetFile_DeploymentNotFound(t *testing.T) {
 
 	connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
 	conn := agentgrpc.Connection{
-		PodName:    "nginx-pod",
 		InstanceID: "12345",
-		Parent:     deploymentName,
+		ParentName: deploymentName,
 	}
 	connTracker.GetConnectionReturns(conn)
 
@@ -198,9 +195,8 @@ func TestGetFile_FileNotFound(t *testing.T) {
 
 	connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
 	conn := agentgrpc.Connection{
-		PodName:    "nginx-pod",
 		InstanceID: "12345",
-		Parent:     deploymentName,
+		ParentName: deploymentName,
 	}
 	connTracker.GetConnectionReturns(conn)
 
@@ -234,9 +230,8 @@ func TestGetFileStream(t *testing.T) {
 
 	connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
 	conn := agentgrpc.Connection{
-		PodName:    "nginx-pod",
 		InstanceID: "12345",
-		Parent:     deploymentName,
+		ParentName: deploymentName,
 	}
 	connTracker.GetConnectionReturns(conn)
 
@@ -312,9 +307,8 @@ func TestGetFileStream_InvalidRequest(t *testing.T) {
 	deploymentName := types.NamespacedName{Name: "nginx-deployment", Namespace: "default"}
 	connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
 	conn := agentgrpc.Connection{
-		PodName:    "nginx-pod",
 		InstanceID: "12345",
-		Parent:     deploymentName,
+		ParentName: deploymentName,
 	}
 	connTracker.GetConnectionReturns(conn)
 
@@ -369,9 +363,8 @@ func TestUpdateOverview(t *testing.T) {
 
 	connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
 	conn := agentgrpc.Connection{
-		PodName:    "nginx-pod",
 		InstanceID: "12345",
-		Parent:     deploymentName,
+		ParentName: deploymentName,
 	}
 	connTracker.GetConnectionReturns(conn)
 
@@ -504,9 +497,8 @@ func TestUpdateOverview_DeploymentNotFound(t *testing.T) {
 
 	connTracker := &agentgrpcfakes.FakeConnectionsTracker{}
 	conn := agentgrpc.Connection{
-		PodName:    "nginx-pod",
 		InstanceID: "12345",
-		Parent:     deploymentName,
+		ParentName: deploymentName,
 	}
 	connTracker.GetConnectionReturns(conn)
 

--- a/internal/controller/nginx/agent/grpc/connections.go
+++ b/internal/controller/nginx/agent/grpc/connections.go
@@ -21,9 +21,9 @@ type ConnectionsTracker interface {
 
 // Connection contains the data about a single nginx agent connection.
 type Connection struct {
-	PodName    string
 	InstanceID string
-	Parent     types.NamespacedName
+	ParentType string
+	ParentName types.NamespacedName
 }
 
 // Ready returns if the connection is ready to be used. In other words, agent

--- a/internal/controller/nginx/agent/grpc/connections_test.go
+++ b/internal/controller/nginx/agent/grpc/connections_test.go
@@ -16,9 +16,8 @@ func TestGetConnection(t *testing.T) {
 	tracker := agentgrpc.NewConnectionsTracker()
 
 	conn := agentgrpc.Connection{
-		PodName:    "pod1",
 		InstanceID: "instance1",
-		Parent:     types.NamespacedName{Namespace: "default", Name: "parent1"},
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
 	}
 	tracker.Track("key1", conn)
 
@@ -34,9 +33,8 @@ func TestConnectionIsReady(t *testing.T) {
 	g := NewWithT(t)
 
 	conn := agentgrpc.Connection{
-		PodName:    "pod1",
 		InstanceID: "instance1",
-		Parent:     types.NamespacedName{Namespace: "default", Name: "parent1"},
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
 	}
 
 	g.Expect(conn.Ready()).To(BeTrue())
@@ -47,8 +45,7 @@ func TestConnectionIsNotReady(t *testing.T) {
 	g := NewWithT(t)
 
 	conn := agentgrpc.Connection{
-		PodName: "pod1",
-		Parent:  types.NamespacedName{Namespace: "default", Name: "parent1"},
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
 	}
 
 	g.Expect(conn.Ready()).To(BeFalse())
@@ -60,8 +57,7 @@ func TestSetInstanceID(t *testing.T) {
 
 	tracker := agentgrpc.NewConnectionsTracker()
 	conn := agentgrpc.Connection{
-		PodName: "pod1",
-		Parent:  types.NamespacedName{Namespace: "default", Name: "parent1"},
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
 	}
 	tracker.Track("key1", conn)
 
@@ -81,9 +77,8 @@ func TestRemoveConnection(t *testing.T) {
 
 	tracker := agentgrpc.NewConnectionsTracker()
 	conn := agentgrpc.Connection{
-		PodName:    "pod1",
 		InstanceID: "instance1",
-		Parent:     types.NamespacedName{Namespace: "default", Name: "parent1"},
+		ParentName: types.NamespacedName{Namespace: "default", Name: "parent1"},
 	}
 	tracker.Track("key1", conn)
 

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor.go
@@ -84,12 +84,12 @@ func (c ContextSetter) Unary(logger logr.Logger) grpc.UnaryServerInterceptor {
 // validateConnection checks that the connection is valid and returns a new
 // context containing information used by the gRPC command/file services.
 func (c ContextSetter) validateConnection(ctx context.Context) (context.Context, error) {
-	gi, err := getGrpcInfo(ctx)
+	grpcInfo, err := getGrpcInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.validateToken(ctx, gi)
+	return c.validateToken(ctx, grpcInfo)
 }
 
 func getGrpcInfo(ctx context.Context) (*grpcContext.GrpcInfo, error) {
@@ -114,11 +114,11 @@ func getGrpcInfo(ctx context.Context) (*grpcContext.GrpcInfo, error) {
 	}, nil
 }
 
-func (c ContextSetter) validateToken(ctx context.Context, gi *grpcContext.GrpcInfo) (context.Context, error) {
+func (c ContextSetter) validateToken(ctx context.Context, grpcInfo *grpcContext.GrpcInfo) (context.Context, error) {
 	tokenReview := &authv1.TokenReview{
 		Spec: authv1.TokenReviewSpec{
 			Audiences: []string{c.audience},
-			Token:     gi.Token,
+			Token:     grpcInfo.Token,
 		},
 	}
 
@@ -169,5 +169,5 @@ func (c ContextSetter) validateToken(ctx context.Context, gi *grpcContext.GrpcIn
 		return nil, status.Error(codes.Unauthenticated, msg)
 	}
 
-	return grpcContext.NewGrpcContext(ctx, *gi), nil
+	return grpcContext.NewGrpcContext(ctx, *grpcInfo), nil
 }

--- a/internal/controller/nginx/agent/grpc/interceptor/interceptor_test.go
+++ b/internal/controller/nginx/agent/grpc/interceptor/interceptor_test.go
@@ -253,7 +253,7 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 
 	testCases := []struct {
 		pod       *corev1.Pod
-		gi        *grpcContext.GrpcInfo
+		grpcInfo  *grpcContext.GrpcInfo
 		name      string
 		shouldErr bool
 	}{
@@ -269,7 +269,7 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 				},
 				Status: corev1.PodStatus{Phase: corev1.PodRunning},
 			},
-			gi:        &grpcContext.GrpcInfo{Token: "dummy-token"},
+			grpcInfo:  &grpcContext.GrpcInfo{Token: "dummy-token"},
 			shouldErr: false,
 		},
 		{
@@ -284,7 +284,7 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 				},
 				Status: corev1.PodStatus{Phase: corev1.PodRunning},
 			},
-			gi:        &grpcContext.GrpcInfo{Token: "dummy-token"},
+			grpcInfo:  &grpcContext.GrpcInfo{Token: "dummy-token"},
 			shouldErr: true,
 		},
 		{
@@ -299,7 +299,7 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 				},
 				Status: corev1.PodStatus{Phase: corev1.PodRunning},
 			},
-			gi:        &grpcContext.GrpcInfo{Token: "dummy-token"},
+			grpcInfo:  &grpcContext.GrpcInfo{Token: "dummy-token"},
 			shouldErr: true,
 		},
 		{
@@ -312,7 +312,7 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 				},
 				Status: corev1.PodStatus{Phase: corev1.PodRunning},
 			},
-			gi:        &grpcContext.GrpcInfo{Token: "dummy-token"},
+			grpcInfo:  &grpcContext.GrpcInfo{Token: "dummy-token"},
 			shouldErr: true,
 		},
 		{
@@ -327,7 +327,7 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 				},
 				Status: corev1.PodStatus{Phase: corev1.PodPending},
 			},
-			gi:        &grpcContext.GrpcInfo{Token: "dummy-token"},
+			grpcInfo:  &grpcContext.GrpcInfo{Token: "dummy-token"},
 			shouldErr: true,
 		},
 	}
@@ -352,7 +352,7 @@ func TestValidateToken_PodListOptions(t *testing.T) {
 			patchedClient := &patchClient{fakeClient}
 			csPatched := NewContextSetter(patchedClient, "ngf-audience")
 
-			resultCtx, err := csPatched.validateToken(t.Context(), tc.gi)
+			resultCtx, err := csPatched.validateToken(t.Context(), tc.grpcInfo)
 			if tc.shouldErr {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring("no running pods"))

--- a/internal/controller/nginx/types/types.go
+++ b/internal/controller/nginx/types/types.go
@@ -4,3 +4,14 @@ const (
 	// Nginx503Server is used as a backend for services that cannot be resolved (have no IP address).
 	Nginx503Server = "unix:/var/run/nginx/nginx-503-server.sock"
 )
+
+const (
+	// AgentOwnerNameLabel is the label key used to store the owner name of the nginx agent.
+	AgentOwnerNameLabel = "owner-name"
+	// AgentOwnerTypeLabel is the label key used to store the owner type of the nginx agent.
+	AgentOwnerTypeLabel = "owner-type"
+	// DaemonSetType is the value used to represent a DaemonSet owner type.
+	DaemonSetType = "DaemonSet"
+	// DeploymentType is the value used to represent a Deployment owner type.
+	DeploymentType = "Deployment"
+)

--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -47,6 +47,7 @@ func TestBuildNginxResourceObjects(t *testing.T) {
 				Image:     "ngf-image",
 			},
 			AgentTLSSecretName: agentTLSTestSecretName,
+			AgentLabels:        make(map[string]string),
 		},
 		baseLabelSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -253,6 +254,7 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 				Version:   "1.0.0",
 			},
 			AgentTLSSecretName: agentTLSTestSecretName,
+			AgentLabels:        make(map[string]string),
 		},
 		baseLabelSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -494,6 +496,7 @@ func TestBuildNginxResourceObjects_DeploymentReplicasFromHPA(t *testing.T) {
 						Image:     "ngf-image",
 					},
 					AgentTLSSecretName: agentTLSTestSecretName,
+					AgentLabels:        make(map[string]string),
 				},
 				baseLabelSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{"app": "nginx"},
@@ -594,6 +597,7 @@ func TestBuildNginxResourceObjects_Plus(t *testing.T) {
 				SkipVerify:          true,
 			},
 			AgentTLSSecretName: agentTLSTestSecretName,
+			AgentLabels:        make(map[string]string),
 		},
 		k8sClient: fakeClient,
 		baseLabelSelector: metav1.LabelSelector{
@@ -747,6 +751,7 @@ func TestBuildNginxResourceObjects_DockerSecrets(t *testing.T) {
 			},
 			NginxDockerSecretNames: []string{dockerTestSecretName, dockerSecretRegistry1Name, dockerSecretRegistry2Name},
 			AgentTLSSecretName:     agentTLSTestSecretName,
+			AgentLabels:            make(map[string]string),
 		},
 		k8sClient: fakeClient,
 		baseLabelSelector: metav1.LabelSelector{
@@ -838,6 +843,7 @@ func TestBuildNginxResourceObjects_DaemonSet(t *testing.T) {
 				Namespace: ngfNamespace,
 			},
 			AgentTLSSecretName: agentTLSTestSecretName,
+			AgentLabels:        make(map[string]string),
 		},
 		k8sClient: fakeClient,
 		baseLabelSelector: metav1.LabelSelector{
@@ -924,6 +930,7 @@ func TestBuildNginxResourceObjects_OpenShift(t *testing.T) {
 				Namespace: ngfNamespace,
 			},
 			AgentTLSSecretName: agentTLSTestSecretName,
+			AgentLabels:        make(map[string]string),
 		},
 		k8sClient: fakeClient,
 		baseLabelSelector: metav1.LabelSelector{
@@ -997,6 +1004,7 @@ func TestBuildNginxResourceObjects_DataplaneKeySecret(t *testing.T) {
 				EndpointPort:           443,
 				EndpointTLSSkipVerify:  false,
 			},
+			AgentLabels: make(map[string]string),
 		},
 		k8sClient: fakeClient,
 		baseLabelSelector: metav1.LabelSelector{
@@ -1353,6 +1361,7 @@ func TestBuildNginxConfigMaps_WorkerConnections(t *testing.T) {
 				Namespace:   "default",
 				ServiceName: "test-service",
 			},
+			AgentLabels: make(map[string]string),
 		},
 	}
 	objectMeta := metav1.ObjectMeta{Name: "test", Namespace: "default"}
@@ -1422,6 +1431,8 @@ func TestBuildNginxConfigMaps_AgentFields(t *testing.T) {
 
 	g.Expect(data).To(ContainSubstring("key1: val1"))
 	g.Expect(data).To(ContainSubstring("key2: val2"))
+	g.Expect(data).To(ContainSubstring("owner-name: default_test"))
+	g.Expect(data).To(ContainSubstring("owner-type: Deployment"))
 	g.Expect(data).To(ContainSubstring("host: console.example.com"))
 	g.Expect(data).To(ContainSubstring("port: 443"))
 	g.Expect(data).To(ContainSubstring("skip_verify: false"))
@@ -1542,6 +1553,7 @@ func TestBuildNginxResourceObjects_Patches(t *testing.T) {
 				Image:     "ngf-image",
 			},
 			AgentTLSSecretName: agentTLSTestSecretName,
+			AgentLabels:        make(map[string]string),
 		},
 		baseLabelSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -1866,6 +1878,7 @@ func TestBuildNginxResourceObjects_InferenceExtension(t *testing.T) {
 			InferenceExtension:          true,
 			EndpointPickerDisableTLS:    true,
 			EndpointPickerTLSSkipVerify: true,
+			AgentLabels:                 make(map[string]string),
 		},
 		k8sClient: fakeClient,
 		baseLabelSelector: metav1.LabelSelector{

--- a/internal/controller/provisioner/provisioner.go
+++ b/internal/controller/provisioner/provisioner.go
@@ -146,6 +146,9 @@ func NewNginxProvisioner(
 		cfg.Logger.Error(err, "failed to collect agent labels")
 	}
 	cfg.AgentLabels = agentLabels
+	if cfg.AgentLabels == nil {
+		cfg.AgentLabels = make(map[string]string)
+	}
 
 	provisioner := &NginxProvisioner{
 		k8sClient:                  mgr.GetClient(),


### PR DESCRIPTION
Problem: When hostNetwork was enabled, the data plane pod would connect and give us its hostname, which was the name of the node instead of the pod. This would cause issues internally with both tracking and acquiring the pod's owner so we know which config to send to it.

Solution: Add the owner's name and type via labels in the agent config. These labels are then sent to the control plane when an agent connects, and can be used to determine which configuration to send. Updated all trackin to use the UUID instead of pod name.

Testing: Enabling hostNetwork now allows the nginx pod to connect.

Closes #4426 
Closes #4351 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix an issue where nginx pod could not connect to control plane when hostnetwork is enabled.
```
