### PR TITLE
Reject mixed Gateway/Route TargetRefs in PSP

### DIFF
--- a/apis/v1alpha1/proxysettingspolicy_types.go
+++ b/apis/v1alpha1/proxysettingspolicy_types.go
@@ -51,6 +51,7 @@ type ProxySettingsPolicySpec struct {
 	// +kubebuilder:validation:XValidation:message="TargetRef Kind must be one of: Gateway, HTTPRoute, or GRPCRoute",rule="self.all(t, t.kind == 'Gateway' || t.kind == 'HTTPRoute' || t.kind == 'GRPCRoute')"
 	// +kubebuilder:validation:XValidation:message="TargetRef Group must be gateway.networking.k8s.io",rule="self.all(t, t.group == 'gateway.networking.k8s.io')"
 	// +kubebuilder:validation:XValidation:message="TargetRef Kind and Name combination must be unique",rule="self.all(t1, self.exists_one(t2, t1.group == t2.group && t1.kind == t2.kind && t1.name == t2.name))"
+	// +kubebuilder:validation:XValidation:message="Cannot mix Gateway kind with HTTPRoute or GRPCRoute kinds in targetRefs",rule="!(self.exists(t, t.kind == 'Gateway') && self.exists(t, t.kind == 'HTTPRoute' || t.kind == 'GRPCRoute'))"
 	//nolint:lll
 	TargetRefs []gatewayv1.LocalPolicyTargetReference `json:"targetRefs"`
 }

--- a/config/crd/bases/gateway.nginx.org_proxysettingspolicies.yaml
+++ b/config/crd/bases/gateway.nginx.org_proxysettingspolicies.yaml
@@ -143,6 +143,10 @@ spec:
                 - message: TargetRef Kind and Name combination must be unique
                   rule: self.all(t1, self.exists_one(t2, t1.group == t2.group && t1.kind
                     == t2.kind && t1.name == t2.name))
+                - message: Cannot mix Gateway kind with HTTPRoute or GRPCRoute kinds
+                    in targetRefs
+                  rule: '!(self.exists(t, t.kind == ''Gateway'') && self.exists(t,
+                    t.kind == ''HTTPRoute'' || t.kind == ''GRPCRoute''))'
             required:
             - targetRefs
             type: object

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -9530,6 +9530,10 @@ spec:
                 - message: TargetRef Kind and Name combination must be unique
                   rule: self.all(t1, self.exists_one(t2, t1.group == t2.group && t1.kind
                     == t2.kind && t1.name == t2.name))
+                - message: Cannot mix Gateway kind with HTTPRoute or GRPCRoute kinds
+                    in targetRefs
+                  rule: '!(self.exists(t, t.kind == ''Gateway'') && self.exists(t,
+                    t.kind == ''HTTPRoute'' || t.kind == ''GRPCRoute''))'
             required:
             - targetRefs
             type: object

--- a/operators/config/rbac/role.yaml
+++ b/operators/config/rbac/role.yaml
@@ -146,6 +146,7 @@ rules:
   - nginxproxies/finalizers
   - clientsettingspolicies
   - observabilitypolicies
+  - proxysettingspolicies
   - upstreamsettingspolicies
   - snippetsfilters
   verbs:
@@ -161,6 +162,7 @@ rules:
   resources:
   - clientsettingspolicies/status
   - observabilitypolicies/status
+  - proxysettingspolicies/status
   - upstreamsettingspolicies/status
   - snippetsfilters/status
   verbs:

--- a/tests/cel/proxysettingspolicy_test.go
+++ b/tests/cel/proxysettingspolicy_test.go
@@ -67,7 +67,8 @@ func TestProxySettingsPolicyTargetRefsKind(t *testing.T) {
 			},
 		},
 		{
-			name: "Validate TargetRefs of kind Gateway and HTTPRoute are allowed",
+			name:       "Validate TargetRefs of kind Gateway and HTTPRoute are not allowed",
+			wantErrors: []string{"Cannot mix Gateway kind with HTTPRoute or GRPCRoute kinds in targetRefs"},
 			spec: ngfAPIv1alpha1.ProxySettingsPolicySpec{
 				TargetRefs: []gatewayv1.LocalPolicyTargetReference{
 					{
@@ -76,6 +77,42 @@ func TestProxySettingsPolicyTargetRefsKind(t *testing.T) {
 					},
 					{
 						Kind:  httpRouteKind,
+						Group: gatewayGroup,
+					},
+				},
+			},
+		},
+		{
+			name:       "Validate TargetRefs of kind Gateway and GRPCRoute are not allowed",
+			wantErrors: []string{"Cannot mix Gateway kind with HTTPRoute or GRPCRoute kinds in targetRefs"},
+			spec: ngfAPIv1alpha1.ProxySettingsPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReference{
+					{
+						Kind:  gatewayKind,
+						Group: gatewayGroup,
+					},
+					{
+						Kind:  grpcRouteKind,
+						Group: gatewayGroup,
+					},
+				},
+			},
+		},
+		{
+			name:       "Validate TargetRefs with Gateway, HTTPRoute, and GRPCRoute are not allowed",
+			wantErrors: []string{"Cannot mix Gateway kind with HTTPRoute or GRPCRoute kinds in targetRefs"},
+			spec: ngfAPIv1alpha1.ProxySettingsPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReference{
+					{
+						Kind:  gatewayKind,
+						Group: gatewayGroup,
+					},
+					{
+						Kind:  httpRouteKind,
+						Group: gatewayGroup,
+					},
+					{
+						Kind:  grpcRouteKind,
 						Group: gatewayGroup,
 					},
 				},
@@ -267,10 +304,6 @@ func TestProxySettingsPolicyTargetRefsNameUniqueness(t *testing.T) {
 			spec: ngfAPIv1alpha1.ProxySettingsPolicySpec{
 				TargetRefs: []gatewayv1.LocalPolicyTargetReference{
 					{
-						Kind:  gatewayKind,
-						Group: gatewayGroup,
-					},
-					{
 						Kind:  httpRouteKind,
 						Group: gatewayGroup,
 					},
@@ -286,14 +319,9 @@ func TestProxySettingsPolicyTargetRefsNameUniqueness(t *testing.T) {
 			spec: ngfAPIv1alpha1.ProxySettingsPolicySpec{
 				TargetRefs: []gatewayv1.LocalPolicyTargetReference{
 					{
-						Kind:  gatewayKind,
-						Group: gatewayGroup,
-						Name:  "duplicate-service-name",
-					},
-					{
 						Kind:  httpRouteKind,
 						Group: gatewayGroup,
-						Name:  "duplicate-service-name", // Same name as above
+						Name:  "duplicate-service-name",
 					},
 					{
 						Kind:  grpcRouteKind,
@@ -327,7 +355,7 @@ func TestProxySettingsPolicyTargetRefsNameUniqueness(t *testing.T) {
 			spec: ngfAPIv1alpha1.ProxySettingsPolicySpec{
 				TargetRefs: []gatewayv1.LocalPolicyTargetReference{
 					{
-						Kind:  gatewayKind,
+						Kind:  grpcRouteKind,
 						Group: gatewayGroup,
 						Name:  "unique-service-1",
 					},


### PR DESCRIPTION
### Proposed changes

Problem: When a ProxySettingsPolicy has multiple targetRefs with mixed Gateway/Route t5ypes (e.g., Gateway + HTTPRoute), the same policy instance generates config files that get included in both the http block (from Gateway) and location block (from HTTPRoute), causing NGINX to see duplicate directives. The problem is that generator.go generates a single file per policy instance, regardless of how many times that policy is passed through different contexts.

Solution: Restrict attaching a policy to both Gateway and Route TargetRefs (note: mixed HTTPRoute and GRPCRoute types are allowed)

Testing: Updated the cel tests

Also updates the operator RBAC rules.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
