### PR TITLE
Fix events RBAC and action

### DIFF
--- a/charts/nginx-gateway-fabric/templates/_helpers.tpl
+++ b/charts/nginx-gateway-fabric/templates/_helpers.tpl
@@ -139,6 +139,7 @@ Create namespaced RBAC rules.
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/azure/deploy.yaml
+++ b/deploy/azure/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/default/deploy.yaml
+++ b/deploy/default/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/experimental-nginx-plus/deploy.yaml
+++ b/deploy/experimental-nginx-plus/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/experimental/deploy.yaml
+++ b/deploy/experimental/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/inference-nginx-plus/deploy.yaml
+++ b/deploy/inference-nginx-plus/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/inference/deploy.yaml
+++ b/deploy/inference/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/nginx-plus/deploy.yaml
+++ b/deploy/nginx-plus/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/nodeport/deploy.yaml
+++ b/deploy/nodeport/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/openshift/deploy.yaml
+++ b/deploy/openshift/deploy.yaml
@@ -126,6 +126,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/snippets-filters-nginx-plus/deploy.yaml
+++ b/deploy/snippets-filters-nginx-plus/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/deploy/snippets-filters/deploy.yaml
+++ b/deploy/snippets-filters/deploy.yaml
@@ -117,6 +117,7 @@ rules:
   - watch
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -327,7 +327,7 @@ func (h *eventHandlerImpl) waitForStatusUpdates(ctx context.Context) {
 					gw.Source,
 					v1.EventTypeWarning,
 					"GetServiceIPFailed",
-					"",
+					"None",
 					msg+": %s",
 					err.Error(),
 				)
@@ -367,7 +367,7 @@ func (h *eventHandlerImpl) updateStatuses(ctx context.Context, gr *graph.Graph, 
 			gw.Source,
 			v1.EventTypeWarning,
 			"GetServiceIPFailed",
-			"",
+			"None",
 			msg+": %s",
 			err.Error(),
 		)
@@ -405,7 +405,7 @@ func (h *eventHandlerImpl) updateStatuses(ctx context.Context, gr *graph.Graph, 
 				nil,
 				v1.EventTypeWarning,
 				"ListInferencePoolsFailed",
-				"",
+				"None",
 				msg+": %s",
 				err.Error(),
 			)
@@ -512,7 +512,7 @@ func (h *eventHandlerImpl) updateControlPlaneAndSetStatus(
 			nil,
 			v1.EventTypeWarning,
 			"UpdateFailed",
-			"",
+			"None",
 			msg+": %s",
 			err.Error(),
 		)
@@ -725,7 +725,7 @@ func (h *eventHandlerImpl) ensureInferencePoolServices(
 				},
 				v1.EventTypeWarning,
 				"ServiceCreateOrUpdateFailed",
-				"",
+				"None",
 				"%s %q: %v", msg, pool.Source.Name, err,
 			)
 			continue

--- a/internal/controller/provisioner/provisioner.go
+++ b/internal/controller/provisioner/provisioner.go
@@ -284,7 +284,7 @@ func (p *NginxProvisioner) provisionNginx(
 				gateway,
 				corev1.EventTypeWarning,
 				"CreateOrUpdateFailed",
-				"",
+				"None",
 				"Failed to create or update nginx resource: %s",
 				fullErr.Error(),
 			)
@@ -360,7 +360,7 @@ func (p *NginxProvisioner) provisionNginx(
 				gateway,
 				corev1.EventTypeWarning,
 				"RestartFailed",
-				"",
+				"None",
 				"Failed to restart nginx after agent config update: %s",
 				err.Error(),
 			)
@@ -402,7 +402,7 @@ func (p *NginxProvisioner) reprovisionNginx(
 				gateway,
 				corev1.EventTypeWarning,
 				"CreateFailed",
-				"",
+				"None",
 				"Failed to create nginx resource: %s",
 				err.Error(),
 			)
@@ -443,7 +443,7 @@ func (p *NginxProvisioner) deprovisionNginx(ctx context.Context, gatewayNSName t
 					},
 					corev1.EventTypeWarning,
 					"DeleteFailed",
-					"",
+					"None",
 					"Failed to delete nginx resource: %s",
 					err.Error(),
 				)
@@ -472,7 +472,7 @@ func (p *NginxProvisioner) deleteObject(ctx context.Context, obj client.Object) 
 			nil,
 			corev1.EventTypeWarning,
 			"DeleteFailed",
-			"",
+			"None",
 			"Failed to delete nginx resource: %s",
 			err.Error(),
 		)


### PR DESCRIPTION
Problem: In the controller-runtime update, the events API group was changed. However, the old API group is still used by the client-go library, causing errors. The "action" field of the new Event formatting is also required.

Solution: Add the previous API group back into the RBAC. Add a non-empty action string.

Testing: Previous errors are gone.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
