### PR TITLE
Ensure agent collector logs go to stdout

### DIFF
--- a/internal/controller/provisioner/templates.go
+++ b/internal/controller/provisioner/templates.go
@@ -79,6 +79,8 @@ auxiliary_command:
 {{- end }}
 {{- if .EnableMetrics }}
 collector:
+    log:
+       path: "stdout"
     exporters:
         prometheus:
             server:
@@ -86,7 +88,7 @@ collector:
                 port: {{ .MetricsPort }}
     pipelines:
         metrics:
-            "ngf":
+            "default":
                 receivers: ["host_metrics", "nginx_metrics"]
                 exporters: ["prometheus"]
 {{- end }}


### PR DESCRIPTION
### Proposed changes

Problem: NGINX Agent collector is writing a large amount of logs to disk.

Solution: Update NGINX Agent configuration to log to stdout and update configuration to override default metrics pipeline in NGINX Agent collector.

Closes [#4647](https://github.com/nginx/nginx-gateway-fabric/issues/4647)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Write agent collector logs to stdout instead of disk to fix memory consumption issues.
```
