### PR TITLE
Update community support issue number

### DIFF
--- a/.github/nginx-bot.yml
+++ b/.github/nginx-bot.yml
@@ -1,4 +1,4 @@
-prAssigneeFromIssueNumber: 583
+prAssigneeFromIssueNumber: 4631
 warnMissingIssue: true
 missingIssueMessage: |
   Please make sure to include the issue number in the PR description to automatically close the issue when the PR is merged.


### PR DESCRIPTION
### Proposed changes

Problem: We have a workflow that auto assigns the current team member on the community support rotation to community PRs, however it is pointing at the old issue

Solution: Update the issue number to the [current community support issue](https://github.com/nginx/nginx-gateway-fabric/issues/4631)


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
