### PR TITLE
Update libexpat package to fix cve

### DIFF
--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -6,9 +6,9 @@ ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.p
 
 FROM nginx:1.29.4-alpine-otel
 
-# the following apk update and add is to address CVE-2026-22801/CVE-2026-22695.
+# the following apk update and add is to address CVE-2026-22801/CVE-2026-22695 and CVE-2026-24515 respectively.
 # once a new base image is available with these package updates, this can be removed.
-RUN apk update && apk add --no-cache 'libpng>=1.6.54-r0'
+RUN apk update && apk add --no-cache 'libpng>=1.6.54-r0' 'libexpat>=2.7.4-r0'
 
 # renovate: datasource=github-tags depName=nginx/agent
 ARG NGINX_AGENT_VERSION=v3.7.0


### PR DESCRIPTION
Update Dockerfile alpine packages libexpat to fix CVE-2026-24515.

Verified NGINX Plus image does not contain libexpat alpine package, and after these changes, the package in the OSS image has the updated version.