### PR TITLE
Update nginx version to 1.29.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following table lists the software versions NGINX Gateway Fabric supports.
 
 | NGINX Gateway Fabric | Gateway API | Kubernetes | NGINX OSS | NGINX Plus | NGINX Agent |
 |----------------------|-------------|------------|-----------|------------|-------------|
-| Edge                 | 1.4.1       | 1.25+      | 1.29.4    | R36        | v3.7.0      |
+| Edge                 | 1.4.1       | 1.25+      | 1.29.5    | R36        | v3.7.0      |
 | 2.4.0                | 1.4.1       | 1.25+      | 1.29.4    | R36        | v3.6.2      |
 | 2.3.0                | 1.4.1       | 1.25+      | 1.29.3    | R36        | v3.6.0      |
 | 2.2.2                | 1.3.0       | 1.25+      | 1.29.2    | R35        | v3.6.0      |

--- a/build/Dockerfile.nginx
+++ b/build/Dockerfile.nginx
@@ -4,11 +4,7 @@ FROM scratch AS nginx-files
 # the following links can be replaced with local files if needed, i.e. ADD --chown=101:1001 <local_file> <container_file>
 ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.pub nginx_signing.rsa.pub
 
-FROM nginx:1.29.4-alpine-otel
-
-# the following apk update and add is to address CVE-2026-22801/CVE-2026-22695.
-# once a new base image is available with these package updates, this can be removed.
-RUN apk update && apk add --no-cache 'libpng>=1.6.54-r0'
+FROM nginx:1.29.5-alpine-otel
 
 # renovate: datasource=github-tags depName=nginx/agent
 ARG NGINX_AGENT_VERSION=v3.7.0


### PR DESCRIPTION
Update nginx version to 1.29.5. Verified previous package vulnerable to CVE is fixed, and recent fix to the libexpat package is also included. 