### PR TITLE
Ignore ubi patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,15 @@
       "groupName": "NGINX Agent"
     },
     {
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/**"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "enabled": false
+    },
+    {
       "groupName": "Docker digests",
       "matchDatasources": [
         "docker"


### PR DESCRIPTION
### Proposed changes

Problem: Renovate updates our ubi builds to the latest patch/ build, which is unnecessary pinning because we'll automatically pull the latest available build every time we rebuild the images

Solution: Update renovate to skip patches for ubi images.

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
