### PR TITLE
Enable running conformance tests from GWAPI main again

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,6 +38,7 @@ endif
 
 .PHONY: update-go-modules
 update-go-modules: ## Update the gateway-api go modules to latest main version
+	cd .. && go get -u sigs.k8s.io/gateway-api@main && go mod tidy
 	go get -u sigs.k8s.io/gateway-api@main
 	go mod tidy
 
@@ -122,7 +123,7 @@ cleanup-conformance-tests: ## Clean up conformance tests fixtures
 
 .PHONY: reset-go-modules
 reset-go-modules: ## Reset the go modules changes
-	git checkout -- ../go.mod ../go.sum
+	git checkout -- ../go.mod ../go.sum go.mod go.sum
 
 -include ../Makefile
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -188,7 +188,7 @@ make install-ngf-local-no-build-with-plus
 ### Step 2 - Build conformance test runner image
 
 > Note: If you want to run the latest conformance tests from the Gateway API `main` branch, run the following
-> make command to update the Go modules to `main`:
+> make command to update the Go modules to `main` in both the root and tests modules:
 
 ```makefile
 make update-go-modules


### PR DESCRIPTION
### Proposed changes

Problem: Updating to use the conformance test suite from the GWAPI main branch is failing. See [here for an examples failure](https://github.com/nginx/nginx-gateway-fabric/actions/runs/21892137022/job/63201196698 ).

The issue is the tests/go.mod has a replace directive pointing to the root module:

`replace github.com/nginx/nginx-gateway-fabric/v2 => ../`

So the tests module depends on the root module, and the root module pins sigs.k8s.io/gateway-api v1.4.1. When you run go get -u sigs.k8s.io/gateway-api@main only in the tests/ directory, it will update the tests/go.mod, but the root module still has gateway-api v1.4.1. Since the root module is pulled in via the replace directive, Go's MVS (minimum version selection) will still require at least v1.4.1 from the root — and if the root module's code imports types from gateway-api that have changed on main, you'll get build errors or version conflicts.

Solution: Update the root module first

Testing: Checked `make update-go-modules` works

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
