### PR TITLE
Bump minimum k8s version to v1.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           K8S_KIND_VERSION=v1.35.1 # renovate: datasource=docker depName=kindest/node
           echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
-          echo "min_k8s_version=v1.25.16" >> $GITHUB_OUTPUT
+          echo "min_k8s_version=v1.31.14" >> $GITHUB_OUTPUT
           echo "k8s_latest=${K8S_KIND_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check if go.mod and go.sum are up to date

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following table lists the software versions NGINX Gateway Fabric supports.
 
 | NGINX Gateway Fabric | Gateway API | Kubernetes | NGINX OSS | NGINX Plus | NGINX Agent |
 |----------------------|-------------|------------|-----------|------------|-------------|
-| Edge                 | 1.4.1       | 1.25+      | 1.29.5    | R36        | v3.7.1      |
+| Edge                 | 1.4.1       | 1.31+      | 1.29.5    | R36        | v3.7.1      |
 | 2.4.2                | 1.4.1       | 1.25+      | 1.29.5    | R36        | v3.7.1      |
 | 2.4.1                | 1.4.1       | 1.25+      | 1.29.5    | R36        | v3.7.0      |
 | 2.4.0                | 1.4.1       | 1.25+      | 1.29.4    | R36        | v3.6.2      |

--- a/charts/nginx-gateway-fabric/Chart.yaml
+++ b/charts/nginx-gateway-fabric/Chart.yaml
@@ -4,7 +4,7 @@ description: NGINX Gateway Fabric
 type: application
 version: 2.4.2
 appVersion: "edge"
-kubeVersion: ">= 1.25.0-0"
+kubeVersion: ">= 1.31.0-0"
 home: https://github.com/nginx/nginx-gateway-fabric
 icon: https://raw.githubusercontent.com/nginx/nginx-gateway-fabric/main/charts/nginx-gateway-fabric/chart-icon.png
 sources:

--- a/charts/nginx-gateway-fabric/README.md
+++ b/charts/nginx-gateway-fabric/README.md
@@ -48,7 +48,7 @@ kubectl kustomize https://github.com/nginx/nginx-gateway-fabric/config/crd/gatew
 
 ## Requirements
 
-Kubernetes: `>= 1.25.0-0`
+Kubernetes: `>= 1.31.0-0`
 
 ## Installing the Chart
 

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -91,6 +91,7 @@ To create a new release, follow these steps:
 9. Prepare and merge a PR into the main branch of the [documentation repository](https://github.com/nginx/documentation) from the relevant release branch, such as `ngf-release-2.0`.
    - In the NGF repo, run `make generate-api-docs` and copy the generated file from `docs/api/content.md` into the documentation repo to `content/ngf/reference/api.md`.
    - Update the HTML file located at `layouts/shortcodes/version-ngf.html` with the latest version. Ensure you do not add an empty line to the file.
+   - Update the Technical Specifications table to match the latest table in our repo's README.
    - Documentation is built and deployed automatically from `main`, and will trigger when merging to it.
    - Create a new branch for the next release version, in the format `ngf-release-<i>.<i>`, substituting the *i* placeholders for major and minor version numbers.
 10. Close the issue created in Step 1.
@@ -120,4 +121,4 @@ To create a new release, follow these steps:
 4. Test the release branch for release-readiness.
 5. If a problem is found, return to Step 2.
 6. Follow Steps 5-8 from the [Major or Minor Release](#major-or-minor-release) section.
-7. Prepare and merge a PR into the main branch of the [documentation repository](https://github.com/nginx/documentation) to update the NGF version in `layouts/shortcodes/version-ngf.html`. If any of our APIs have changed, in the NGF repo, run `make generate-api-docs` and copy the generated file from `docs/api/content.md` into the documentation repo to `content/ngf/reference/api.md`.
+7. Prepare and merge a PR into the main branch of the [documentation repository](https://github.com/nginx/documentation) to update the NGF version in `layouts/shortcodes/version-ngf.html`. If any of our APIs have changed, in the NGF repo, run `make generate-api-docs` and copy the generated file from `docs/api/content.md` into the documentation repo to `content/ngf/reference/api.md`. Update the Technical Specifications table to match the latest table in our repo's README.


### PR DESCRIPTION
Problem: With Gateway API 1.5, TLSRoute is getting CEL validation that is only available in k8s v1.31 or later.

Solution: Update our minimum supported version to v1.31.

Closes #4258

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Bump minimum required k8s version to v1.31
```
