### PR TITLE
Add PLM connectivity check and default to https

### DIFF
--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -1081,6 +1081,10 @@ func createWAFFetcher(
 		return nil, fmt.Errorf("failed to create S3 fetcher: %w", err)
 	}
 
+	if err := fetcher.ValidateConnectivity(context.Background()); err != nil {
+		logger.Error(err, "PLM storage connectivity check failed; bundle fetches may fail until the issue is resolved")
+	}
+
 	logger.Info("Created WAF fetcher for PLM storage", "url", plmStorageURL)
 
 	return fetcher, nil

--- a/internal/framework/fetch/fetch.go
+++ b/internal/framework/fetch/fetch.go
@@ -55,6 +55,10 @@ type Fetcher interface {
 	// GetObject fetches an object from S3-compatible storage.
 	// The location should be in the format "bucket/key" or just "key" if bucket is configured.
 	GetObject(ctx context.Context, bucket, key string) ([]byte, error)
+	// ValidateConnectivity checks that the storage endpoint is reachable and the configured
+	// credentials are accepted. It should be called once at startup to surface auth or
+	// connectivity problems early, before any bundle fetch is attempted.
+	ValidateConnectivity(ctx context.Context) error
 	// UpdateTLSConfig updates the TLS configuration and recreates the underlying client.
 	// This is used to refresh TLS certificates when secrets change.
 	UpdateTLSConfig(tlsConfig *tls.Config) error
@@ -75,10 +79,10 @@ type S3Fetcher struct {
 
 // NewS3Fetcher creates a new S3Fetcher for the given endpoint URL.
 // The endpoint URL should be the storage service URL.
-// If the URL does not include a scheme, http:// is prepended.
+// If the URL does not include a scheme, https:// is prepended.
 func NewS3Fetcher(endpointURL string, opts ...Option) (*S3Fetcher, error) {
 	if !strings.Contains(endpointURL, "://") {
-		endpointURL = "http://" + endpointURL
+		endpointURL = "https://" + endpointURL
 	}
 
 	fetcher := &S3Fetcher{
@@ -121,6 +125,21 @@ func (f *S3Fetcher) GetObject(ctx context.Context, bucket, key string) ([]byte, 
 	}
 
 	return data, nil
+}
+
+// ValidateConnectivity verifies that the storage endpoint is reachable and the configured
+// credentials are valid by issuing a ListBuckets request. It returns an error if the endpoint
+// is unreachable or the credentials are rejected, allowing auth problems to be surfaced at
+// startup rather than at bundle-fetch time.
+func (f *S3Fetcher) ValidateConnectivity(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, f.timeout)
+	defer cancel()
+
+	if _, err := f.client.ListBuckets(ctx, &s3.ListBucketsInput{}); err != nil {
+		return fmt.Errorf("connectivity check failed: %w", err)
+	}
+
+	return nil
 }
 
 // UpdateTLSConfig updates the TLS configuration and recreates the S3 client.

--- a/internal/framework/fetch/fetch_test.go
+++ b/internal/framework/fetch/fetch_test.go
@@ -85,7 +85,7 @@ func TestNewS3Fetcher(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "endpoint without scheme gets http prepended",
+			name:        "endpoint without scheme gets https prepended",
 			endpointURL: "storage.example.svc.cluster.local:8333",
 			options:     []Option{},
 			expectError: false,
@@ -126,6 +126,22 @@ func TestGetObjectError(t *testing.T) {
 	_, err = fetcher.GetObject(ctx, "test-bucket", "test-key")
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("failed to get object"))
+}
+
+func TestValidateConnectivity(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	// Pointing to a non-existent endpoint surfaces a connectivity error.
+	fetcher, err := NewS3Fetcher(
+		"http://localhost:1",
+		WithTimeout(100*time.Millisecond),
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = fetcher.ValidateConnectivity(context.Background())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("connectivity check failed"))
 }
 
 func TestTLSConfigFromSecret(t *testing.T) {

--- a/internal/framework/fetch/fetchfakes/fake_fetcher.go
+++ b/internal/framework/fetch/fetchfakes/fake_fetcher.go
@@ -48,6 +48,17 @@ type FakeFetcher struct {
 	updateTLSConfigReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ValidateConnectivityStub        func(context.Context) error
+	validateConnectivityMutex       sync.RWMutex
+	validateConnectivityArgsForCall []struct {
+		arg1 context.Context
+	}
+	validateConnectivityReturns struct {
+		result1 error
+	}
+	validateConnectivityReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -237,6 +248,67 @@ func (fake *FakeFetcher) UpdateTLSConfigReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.updateTLSConfigReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeFetcher) ValidateConnectivity(arg1 context.Context) error {
+	fake.validateConnectivityMutex.Lock()
+	ret, specificReturn := fake.validateConnectivityReturnsOnCall[len(fake.validateConnectivityArgsForCall)]
+	fake.validateConnectivityArgsForCall = append(fake.validateConnectivityArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.ValidateConnectivityStub
+	fakeReturns := fake.validateConnectivityReturns
+	fake.recordInvocation("ValidateConnectivity", []interface{}{arg1})
+	fake.validateConnectivityMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeFetcher) ValidateConnectivityCallCount() int {
+	fake.validateConnectivityMutex.RLock()
+	defer fake.validateConnectivityMutex.RUnlock()
+	return len(fake.validateConnectivityArgsForCall)
+}
+
+func (fake *FakeFetcher) ValidateConnectivityCalls(stub func(context.Context) error) {
+	fake.validateConnectivityMutex.Lock()
+	defer fake.validateConnectivityMutex.Unlock()
+	fake.ValidateConnectivityStub = stub
+}
+
+func (fake *FakeFetcher) ValidateConnectivityArgsForCall(i int) context.Context {
+	fake.validateConnectivityMutex.RLock()
+	defer fake.validateConnectivityMutex.RUnlock()
+	argsForCall := fake.validateConnectivityArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeFetcher) ValidateConnectivityReturns(result1 error) {
+	fake.validateConnectivityMutex.Lock()
+	defer fake.validateConnectivityMutex.Unlock()
+	fake.ValidateConnectivityStub = nil
+	fake.validateConnectivityReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeFetcher) ValidateConnectivityReturnsOnCall(i int, result1 error) {
+	fake.validateConnectivityMutex.Lock()
+	defer fake.validateConnectivityMutex.Unlock()
+	fake.ValidateConnectivityStub = nil
+	if fake.validateConnectivityReturnsOnCall == nil {
+		fake.validateConnectivityReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validateConnectivityReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }


### PR DESCRIPTION
### Proposed changes

Problem: We don't ensure we can connect with the PLM storage service on startup, and we default to http when no scheme is provided

Solution: Add a connectivity check and default to https when no scheme is provided

Testing: Locally on GKE

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
