### PR TITLE
Update JWT auth proposal to include new caCertificateRefs field

### DIFF
--- a/docs/proposals/authentication-filter.md
+++ b/docs/proposals/authentication-filter.md
@@ -259,16 +259,24 @@ type JWTFileKeySource struct {
   SecretRef LocalObjectReference `json:"secretRef"`
 }
 
- // JWTRemoteKeySource specifies remote JWKS configuration.
+// JWTRemoteKeySource specifies remote JWKS configuration.
 type JWTRemoteKeySource struct {
-  // TLS defines HTTPS client parameters for retrieving JWKS.
+  // URI is the JWKS endpoint.
+  //
+  //nolint:lll
+  // +kubebuilder:validation:Pattern=`^https:\/\/[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*(:[0-9]{1,5})?(\/[a-zA-Z0-9._~:\/?@!&'()*+,=-]*)?$`
+  URI string `json:"uri"`
+  // CACertificateRefs references a list of secrets containing trusted CA certificates
+  // in PEM format used to verify the server certificate of the JWKS endpoint.
+  // The referenced secrets must contain an entry with the key "ca.crt".
+  // Only one secret can be referenced currently.
+  // If not specified, the system CA bundle is used.
+  //
+  // Directive: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_trusted_certificate
   //
   // +optional
-  TLS *JWTRemoteTLSConfig `json:"tls,omitempty"`
-
-  // URI is the JWKS endpoint.
-  // +kubebuilder:validation:Pattern=`^(?:http?:\/\/)?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*(?::\d{1,5})?$`
-  URI string `json:"uri"`
+  // +kubebuilder:validation:MaxItems=1
+  CACertificateRefs []LocalObjectReference `json:"caCertificateRefs,omitempty"`
 }
 
 // JWTRequiredClaims specifies exact-match requirements for JWT claims.
@@ -305,38 +313,6 @@ type JWTCustomClaim struct {
   Value  *string  `json:"value,omitempty"`
   // +optional
   Values []string `json:"values,omitempty"`
-}
-
-// JWTRemoteTLSConfig defines TLS settings for remote JWKS retrieval.
-type JWTRemoteTLSConfig struct {
-  // SecretRef references a Secret containing client TLS cert and key.
-  // Expectes secret type kubernetes.io/tls.
-  //
-  // +optional
-  SecretRef *LocalObjectReference `json:"secretRef,omitempty"`
-
-
-  // Verify controls server certificate verification.
-  //
-  // +optional
-  // +kubebuilder:default=true
-  Verify *bool `json:"verify,omitempty"`
-
-  // SNI controls server name indication.
-  // Configures `proxy_ssl_server_name` directive.
-  // https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name
-  //
-  // +optional
-  // +kubebuilder:default=true
-  SNI *bool `json:"sni,omitempty"`
-
-  // SNIName sets a custom SNI.
-  // By default, NGINX uses the host from proxy_pass.
-  // Configures `proxy_ssl_name` directive.
-  // https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_name
-  //
-  // +optional
-  SNIName *string `json:"sniName,omitempty"`
 }
 
 // AuthenticationFilterStatus defines the state of AuthenticationFilter.
@@ -537,7 +513,7 @@ spec:
 
 This configuration will access the public JSON Web Key Set (JWKS) from a remote server.
 This could be a self-hosted server or a hosted identity provider (IdP).
-To ensure a secure connection can be established to the remote JWKS URI, the `remote.tls` will allow users to define a secret of type `kubernetes.io/tls` with the TLS cert and key of their IdP.
+The `remote.uri` must use HTTPS. To verify the JWKS endpoint's server certificate with a custom CA, users can optionally reference a Secret containing the CA certificate in PEM format (key `ca.crt`) via `remote.caCertificateRefs`. If omitted, the system CA bundle is used.
 
 ```yaml
 apiVersion: gateway.nginx.org/v1alpha1
@@ -552,18 +528,13 @@ spec:
     source: Remote
     remote:
       uri: https://issuer.example.com/.well-known/jwks.json
-      tls:
-        secretRef:
-          name: cafe-secret
-        verify: true # Defaults to true
-        sni: true # Defaults to true
-        sniName: foo.bar.com # Defaults to server name in proxy_pass
+      # Optional: CA certificate for verifying the JWKS endpoint's TLS certificate.
+      # If omitted, the system CA bundle is used.
+      caCertificateRefs:
+        - name: idp-ca-secret
 ```
 
-Optionally, users can also toggle and configure SNI capabilities through `remote.tls.sni` and `remote.tls.sniName`.
-SNI will be enabled by default using the [proxy_ssl_server_name](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name) directive.
-By default, NGINX will use the server name defined in the `proxy_pass` when `proxy_ssl_server_name` is on.
-Users can optionally set a specific host using `remote.tls.sniName`, which will configure the [proxy_ssl_name](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_name) directive
+The `remote.uri` must use HTTPS. To verify the JWKS endpoint's server certificate with a custom CA, reference a Secret containing the CA certificate in PEM format with the key `ca.crt` via `remote.caCertificateRefs`. If `caCertificateRefs` is omitted, the system CA bundle is used. Up to one CA certificate secret may be referenced.
 
 ### Secret creation and reference for JWT Auth
 
@@ -1074,7 +1045,7 @@ The table below summarizes the capabilities enabled by the current JWT Authentic
 | Enable JWT authentication and set realm | `spec.type = "JWT"`; `spec.jwt.realm` | `auth_jwt "<realm>"` | Currently does not expose defining `token` |
 | Provide JWT keys from local JWKS (Secret) | `spec.jwt.source = "File"`; `spec.jwt.file.secretRef.name`; Secret type `nginx.org/jwt`; data key `auth` | `auth_jwt_key_file /etc/nginx/secrets/jwt_auth_<namespace>_<secret-name>` | Secret must exist in same namespace and must be of type `nginx.org/jwt` |
 | Secret handling/validation for local JWKS | Secret type `nginx.org/jwt`; data key `auth`; `LocalObjectReference` | Validates presence/type/key; NGF loads JWKS into key file | Cross-namespace secrets not supported initially; future work may add `ReferenceGrant`-based access |
-| Provide JWT keys from remote JWKS | `spec.jwt.source = "Remote"`; `spec.jwt.remote.uri`; `spec.jwt.remote.tls.secretRef` (type `kubernetes.io/tls`); `spec.jwt.remote.tls.verify` (default `true`); `spec.jwt.remote.tls.sni` (default `true`); `spec.jwt.remote.tls.sniName` (optional; default to server name in `proxy_pass`) | `auth_jwt_key_request /_ngf-internal-<namespace>_<filter-name>_jwks_uri`; internal location `proxy_pass` to remote JWKS; optional client TLS. | Requires DNS resolver via `NginxProxy.spec.dnsResolver`; `verify` controls server cert verification; key caching optional |
+| Provide JWT keys from remote JWKS | `spec.jwt.source = "Remote"`; `spec.jwt.remote.uri` (HTTPS only); `spec.jwt.remote.caCertificateRefs[]` (optional; Secret with key `ca.crt`; max 1) | `auth_jwt_key_request /_ngf-internal-<namespace>_<filter-name>_jwks_uri`; internal location `proxy_pass` to remote JWKS; `proxy_ssl_trusted_certificate` set when CA ref provided. | Requires DNS resolver via `NginxProxy.spec.dnsResolver`; URI must be HTTPS; if `caCertificateRefs` is omitted, system CA bundle is used; key caching optional |
 | Configure DNS resolver for remote JWKS | `NginxProxy.spec.dnsResolver.addresses` (separate resource) | `resolver` set at `http` context for name resolution used by `auth_jwt_key_request` | Required for remote JWKS URIs; managed outside the filter |
 | Configure JWT key cache duration | `spec.jwt.keyCache` (Duration) | `auth_jwt_key_cache <duration>` | Disabled by default to avoid stale keys |
 | Configure acceptable clock skew for `exp`/`nbf` | `spec.jwt.leeway` (Duration) | `auth_jwt_leeway <duration>` | Applies only if `exp`/`nbf` claims are present; default `0s` |


### PR DESCRIPTION
### Proposed changes

This PR updates the AuthenticationFilter proposal based on changes made to the API.
The TLS field has being removed and replaced with caCertificateRefs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
