### PR TITLE
fix: allow TCPRoute and UDPRoute on same gateway port (#5016)

### DIFF
--- a/internal/controller/nginx/config/stream_servers.go
+++ b/internal/controller/nginx/config/stream_servers.go
@@ -38,6 +38,12 @@ func (g GeneratorImpl) executeStreamServers(conf dataplane.Configuration) []exec
 	}
 }
 
+// portProtoKey uniquely identifies a port and protocol combination for deduplication.
+type portProtoKey struct {
+	protocol string
+	port     int32
+}
+
 func createStreamServers(logger logr.Logger, conf dataplane.Configuration) []stream.Server {
 	totalServers := len(conf.TLSPassthroughServers) + len(conf.TCPServers) + len(conf.UDPServers)
 	if totalServers == 0 {
@@ -45,7 +51,7 @@ func createStreamServers(logger logr.Logger, conf dataplane.Configuration) []str
 	}
 
 	streamServers := make([]stream.Server, 0, totalServers*2)
-	portSet := make(map[int32]struct{})
+	portSet := make(map[portProtoKey]struct{})
 	upstreams := make(map[string]dataplane.Upstream)
 
 	for _, u := range conf.StreamUpstreams {
@@ -70,11 +76,12 @@ func createStreamServers(logger logr.Logger, conf dataplane.Configuration) []str
 			}
 		}
 
-		if _, inPortSet := portSet[server.Port]; inPortSet {
+		key := portProtoKey{port: server.Port, protocol: string(v1.TCPProtocolType)}
+		if _, inPortSet := portSet[key]; inPortSet {
 			continue
 		}
 
-		portSet[server.Port] = struct{}{}
+		portSet[key] = struct{}{}
 
 		// we do not evaluate rewriteClientIP settings for non-socket stream servers
 		streamServer := stream.Server{
@@ -98,7 +105,7 @@ func processLayer4Servers(
 	logger logr.Logger,
 	servers []dataplane.Layer4VirtualServer,
 	upstreams map[string]dataplane.Upstream,
-	portSet map[int32]struct{},
+	portSet map[portProtoKey]struct{},
 	streamServers *[]stream.Server,
 	protocol string,
 ) {
@@ -108,7 +115,8 @@ func processLayer4Servers(
 	}
 
 	for i, server := range servers {
-		if _, inPortSet := portSet[server.Port]; inPortSet {
+		key := portProtoKey{port: server.Port, protocol: protocol}
+		if _, inPortSet := portSet[key]; inPortSet {
 			continue
 		}
 
@@ -160,7 +168,7 @@ func processLayer4Servers(
 			ProxyPass:  proxyPass,
 		}
 		*streamServers = append(*streamServers, streamServer)
-		portSet[server.Port] = struct{}{}
+		portSet[key] = struct{}{}
 	}
 }
 

--- a/internal/controller/nginx/config/stream_servers_test.go
+++ b/internal/controller/nginx/config/stream_servers_test.go
@@ -699,7 +699,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 
 	tests := []struct {
 		upstreams      map[string]dataplane.Upstream
-		portSet        map[int32]struct{}
+		portSet        map[portProtoKey]struct{}
 		expectedServer *stream.Server
 		name           string
 		protocol       string
@@ -710,7 +710,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 			name:          "empty servers",
 			servers:       []dataplane.Layer4VirtualServer{},
 			upstreams:     map[string]dataplane.Upstream{},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 0,
 		},
@@ -725,7 +725,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 					Endpoints: []resolver.Endpoint{{Address: "10.0.0.1", Port: 8080}},
 				},
 			},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 1,
 			expectedServer: &stream.Server{
@@ -745,7 +745,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 					Endpoints: []resolver.Endpoint{{Address: "10.0.0.2", Port: 53}},
 				},
 			},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.UDPProtocolType),
 			expectedCount: 1,
 			expectedServer: &stream.Server{
@@ -775,7 +775,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 					Endpoints: []resolver.Endpoint{{Address: "10.0.0.4", Port: 9000}},
 				},
 			},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 1,
 			expectedServer: &stream.Server{
@@ -785,7 +785,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 			},
 		},
 		{
-			name: "skip server on port already in portSet",
+			name: "skip server on port+protocol already in portSet",
 			servers: []dataplane.Layer4VirtualServer{
 				{Port: 8080, Upstreams: []dataplane.Layer4Upstream{{Name: "backend1"}}},
 			},
@@ -795,9 +795,29 @@ func TestProcessLayer4Servers(t *testing.T) {
 					Endpoints: []resolver.Endpoint{{Address: "10.0.0.1", Port: 8080}},
 				},
 			},
-			portSet:       map[int32]struct{}{8080: {}},
+			portSet:       map[portProtoKey]struct{}{{port: 8080, protocol: "TCP"}: {}},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 0,
+		},
+		{
+			name: "allow UDP server when TCP already in portSet for same port",
+			servers: []dataplane.Layer4VirtualServer{
+				{Port: 8080, Upstreams: []dataplane.Layer4Upstream{{Name: "backend1"}}},
+			},
+			upstreams: map[string]dataplane.Upstream{
+				"backend1": {
+					Name:      "backend1",
+					Endpoints: []resolver.Endpoint{{Address: "10.0.0.1", Port: 8080}},
+				},
+			},
+			portSet:       map[portProtoKey]struct{}{{port: 8080, protocol: "TCP"}: {}},
+			protocol:      string(v1.UDPProtocolType),
+			expectedCount: 1,
+			expectedServer: &stream.Server{
+				Listen:     "8080 udp",
+				StatusZone: "UDP_8080",
+				ProxyPass:  "backend1",
+			},
 		},
 		{
 			name: "skip server with no upstreams",
@@ -805,7 +825,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 				{Port: 8080, Upstreams: []dataplane.Layer4Upstream{}},
 			},
 			upstreams:     map[string]dataplane.Upstream{},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 0,
 		},
@@ -815,7 +835,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 				{Port: 8080, Upstreams: []dataplane.Layer4Upstream{{Name: "missing-backend"}}},
 			},
 			upstreams:     map[string]dataplane.Upstream{},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 0,
 		},
@@ -830,7 +850,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 					Endpoints: []resolver.Endpoint{},
 				},
 			},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 0,
 		},
@@ -849,7 +869,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 				"backend-v1": {Name: "backend-v1", Endpoints: []resolver.Endpoint{}},
 				"backend-v2": {Name: "backend-v2", Endpoints: []resolver.Endpoint{}},
 			},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 0,
 		},
@@ -871,7 +891,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 				},
 				"backend-v2": {Name: "backend-v2", Endpoints: []resolver.Endpoint{}},
 			},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 1,
 			expectedServer: &stream.Server{
@@ -896,7 +916,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 					Endpoints: []resolver.Endpoint{{Address: "10.0.0.2", Port: 9000}},
 				},
 			},
-			portSet:       map[int32]struct{}{},
+			portSet:       map[portProtoKey]struct{}{},
 			protocol:      string(v1.TCPProtocolType),
 			expectedCount: 2,
 			expectedServer: &stream.Server{
@@ -915,7 +935,7 @@ func TestProcessLayer4Servers(t *testing.T) {
 			streamServers := []stream.Server{}
 			portSet := tt.portSet
 			if portSet == nil {
-				portSet = map[int32]struct{}{}
+				portSet = map[portProtoKey]struct{}{}
 			}
 
 			logger := logr.Discard()

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
@@ -47,6 +48,12 @@ const (
 	defaultImagePullPolicy     = corev1.PullIfNotPresent
 	defaultInitialDelaySeconds = int32(3)
 )
+
+// portProtoEntry represents a unique port and protocol combination.
+type portProtoEntry struct {
+	Protocol corev1.Protocol
+	Port     int32
+}
 
 var emptyDirVolumeSource = corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}
 
@@ -134,7 +141,7 @@ func (p *NginxProvisioner) buildNginxResourceObjects(
 	var healthcheckPort int32
 	if isNginxReadinessProbeExposed(nProxyCfg) {
 		healthcheckPort = dataplane.GetNginxReadinessProbePort(nProxyCfg)
-		ports[healthcheckPort] = corev1.ProtocolTCP
+		ports = appendUniquePortProtoEntry(ports, portProtoEntry{Port: healthcheckPort, Protocol: corev1.ProtocolTCP})
 	}
 
 	// build service
@@ -285,18 +292,36 @@ func (p *NginxProvisioner) buildServiceAccount(
 	return serviceAccount, nil
 }
 
-// buildPortsFromListeners builds a map of ports to protocols from the Gateway listeners.
-func (p *NginxProvisioner) buildPortsFromListeners(listeners []gatewayv1.Listener) map[int32]corev1.Protocol {
-	ports := make(map[int32]corev1.Protocol, len(listeners))
+// buildPortsFromListeners builds a list of port/protocol entries from the Gateway listeners.
+// A port number can appear multiple times if it has different protocols (e.g., TCP and UDP on port 53).
+func (p *NginxProvisioner) buildPortsFromListeners(listeners []gatewayv1.Listener) []portProtoEntry {
+	seen := make(map[portProtoEntry]struct{}, len(listeners))
+	ports := make([]portProtoEntry, 0, len(listeners))
 	for _, listener := range listeners {
+		var protocol corev1.Protocol
 		switch listener.Protocol {
 		case gatewayv1.UDPProtocolType:
-			ports[listener.Port] = corev1.ProtocolUDP
+			protocol = corev1.ProtocolUDP
 		default:
-			ports[listener.Port] = corev1.ProtocolTCP
+			protocol = corev1.ProtocolTCP
+		}
+		entry := portProtoEntry{Port: listener.Port, Protocol: protocol}
+		if _, exists := seen[entry]; !exists {
+			seen[entry] = struct{}{}
+			ports = append(ports, entry)
 		}
 	}
 	return ports
+}
+
+// appendUniquePortProtoEntry appends the entry to ports only if an identical port+protocol does not already exist.
+func appendUniquePortProtoEntry(ports []portProtoEntry, entry portProtoEntry) []portProtoEntry {
+	for _, p := range ports {
+		if p.Port == entry.Port && p.Protocol == entry.Protocol {
+			return ports
+		}
+	}
+	return append(ports, entry)
 }
 
 // cloneObjectMeta clones the given ObjectMeta.
@@ -612,7 +637,7 @@ func (p *NginxProvisioner) buildOpenshiftObjects(
 func buildNginxService(
 	objectMeta metav1.ObjectMeta,
 	nProxyCfg *graph.EffectiveNginxProxy,
-	ports map[int32]corev1.Protocol,
+	ports []portProtoEntry,
 	healthcheckPort int32,
 	selectorLabels map[string]string,
 	addresses []gatewayv1.GatewaySpecAddress,
@@ -665,27 +690,36 @@ func buildNginxService(
 }
 
 func buildServicePorts(
-	ports map[int32]corev1.Protocol,
+	ports []portProtoEntry,
 	healthcheckPort int32,
 	serviceType corev1.ServiceType,
 	nodePorts []ngfAPIv1alpha2.NodePort,
 ) []corev1.ServicePort {
+	// Determine which port numbers have multiple protocols (e.g., TCP and UDP on the same port).
+	protocolsPerPort := make(map[int32]int)
+	for _, entry := range ports {
+		protocolsPerPort[entry.Port]++
+	}
+
 	servicePorts := make([]corev1.ServicePort, 0, len(ports))
-	for port, protocol := range ports {
-		name := fmt.Sprintf("port-%d", port)
-		if healthcheckPort > 0 && port == healthcheckPort {
+	for _, entry := range ports {
+		name := fmt.Sprintf("port-%d", entry.Port)
+		if protocolsPerPort[entry.Port] > 1 {
+			name = fmt.Sprintf("port-%d-%s", entry.Port, strings.ToLower(string(entry.Protocol)))
+		}
+		if healthcheckPort > 0 && entry.Port == healthcheckPort && entry.Protocol == corev1.ProtocolTCP {
 			name = "health"
 		}
 		servicePort := corev1.ServicePort{
 			Name:       name,
-			Port:       port,
-			TargetPort: intstr.FromInt32(port),
-			Protocol:   protocol,
+			Port:       entry.Port,
+			TargetPort: intstr.FromInt32(entry.Port),
+			Protocol:   entry.Protocol,
 		}
 
 		if serviceType != corev1.ServiceTypeClusterIP {
 			for _, nodePort := range nodePorts {
-				if nodePort.ListenerPort == port {
+				if nodePort.ListenerPort == entry.Port {
 					servicePort.NodePort = nodePort.Port
 				}
 			}
@@ -697,7 +731,10 @@ func buildServicePorts(
 	// need to sort ports so everytime buildNginxService is called it will generate the exact same
 	// array of ports. This is needed to satisfy deterministic results of the method.
 	sort.Slice(servicePorts, func(i, j int) bool {
-		return servicePorts[i].Port < servicePorts[j].Port
+		if servicePorts[i].Port != servicePorts[j].Port {
+			return servicePorts[i].Port < servicePorts[j].Port
+		}
+		return servicePorts[i].Protocol < servicePorts[j].Protocol
 	})
 
 	return servicePorts
@@ -737,7 +774,7 @@ func setSvcLoadBalancerSettings(svcCfg ngfAPIv1alpha2.ServiceSpec, svcSpec *core
 func (p *NginxProvisioner) buildNginxDeployment(
 	objectMeta metav1.ObjectMeta,
 	nProxyCfg *graph.EffectiveNginxProxy,
-	ports map[int32]corev1.Protocol,
+	ports []portProtoEntry,
 	selectorLabels map[string]string,
 	names resourceNames,
 ) (client.Object, error) {
@@ -913,15 +950,25 @@ func applyPatches(obj client.Object, patches []ngfAPIv1alpha2.Patch) error {
 func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 	objectMeta metav1.ObjectMeta,
 	nProxyCfg *graph.EffectiveNginxProxy,
-	ports map[int32]corev1.Protocol,
+	ports []portProtoEntry,
 	names resourceNames,
 ) corev1.PodTemplateSpec {
+	// Determine which port numbers have multiple protocols for naming.
+	protocolsPerPort := make(map[int32]int)
+	for _, entry := range ports {
+		protocolsPerPort[entry.Port]++
+	}
+
 	containerPorts := make([]corev1.ContainerPort, 0, len(ports))
-	for port, protocol := range ports {
+	for _, entry := range ports {
+		name := fmt.Sprintf("port-%d", entry.Port)
+		if protocolsPerPort[entry.Port] > 1 {
+			name = fmt.Sprintf("port-%d-%s", entry.Port, strings.ToLower(string(entry.Protocol)))
+		}
 		containerPort := corev1.ContainerPort{
-			Name:          fmt.Sprintf("port-%d", port),
-			ContainerPort: port,
-			Protocol:      protocol,
+			Name:          name,
+			ContainerPort: entry.Port,
+			Protocol:      entry.Protocol,
 		}
 		containerPorts = append(containerPorts, containerPort)
 	}
@@ -947,7 +994,10 @@ func (p *NginxProvisioner) buildNginxPodTemplateSpec(
 	// need to sort ports so everytime buildNginxPodTemplateSpec is called it will generate the exact same
 	// array of ports. This is needed to satisfy deterministic results of the method.
 	sort.Slice(containerPorts, func(i, j int) bool {
-		return containerPorts[i].ContainerPort < containerPorts[j].ContainerPort
+		if containerPorts[i].ContainerPort != containerPorts[j].ContainerPort {
+			return containerPorts[i].ContainerPort < containerPorts[j].ContainerPort
+		}
+		return containerPorts[i].Protocol < containerPorts[j].Protocol
 	})
 
 	image, pullPolicy := p.buildImage(nProxyCfg)

--- a/internal/controller/state/graph/route_common.go
+++ b/internal/controller/state/graph/route_common.go
@@ -853,7 +853,7 @@ func bindToListenerL4(
 	hostnames := make([]string, 0)
 
 	for _, h := range acceptedListenerHostnames {
-		portHostname := fmt.Sprintf("%s:%d", h, l.Source.Port)
+		portHostname := fmt.Sprintf("%s:%d:%s", h, l.Source.Port, l.Source.Protocol)
 		_, ok := portHostnamesMap[portHostname]
 		if !ok {
 			portHostnamesMap[portHostname] = struct{}{}

--- a/internal/controller/state/graph/route_common_test.go
+++ b/internal/controller/state/graph/route_common_test.go
@@ -2480,6 +2480,141 @@ func TestBindL4RouteToListeners(t *testing.T) {
 	}
 }
 
+func TestBindL4RouteToListeners_TCPAndUDPSamePortNoConflict(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "gateway",
+		},
+	}
+	gwNsName := client.ObjectKeyFromObject(gw)
+
+	// Two listeners on the same port (53) but different protocols.
+	tcpListener := &Listener{
+		Name:        "tcp-listener",
+		GatewayName: gwNsName,
+		Source: gatewayv1.Listener{
+			Name:     "tcp-listener",
+			Port:     53,
+			Protocol: gatewayv1.TCPProtocolType,
+		},
+		SupportedKinds: []gatewayv1.RouteGroupKind{
+			{Kind: gatewayv1.Kind(kinds.TCPRoute)},
+		},
+		Valid:      true,
+		Attachable: true,
+		Routes:     map[RouteKey]*L7Route{},
+		L4Routes:   map[L4RouteKey]*L4Route{},
+	}
+	udpListener := &Listener{
+		Name:        "udp-listener",
+		GatewayName: gwNsName,
+		Source: gatewayv1.Listener{
+			Name:     "udp-listener",
+			Port:     53,
+			Protocol: gatewayv1.UDPProtocolType,
+		},
+		SupportedKinds: []gatewayv1.RouteGroupKind{
+			{Kind: gatewayv1.Kind(kinds.UDPRoute)},
+		},
+		Valid:      true,
+		Attachable: true,
+		Routes:     map[RouteKey]*L7Route{},
+		L4Routes:   map[L4RouteKey]*L4Route{},
+	}
+
+	gateway := &Gateway{
+		Source: gw,
+		Valid:  true,
+		DeploymentName: types.NamespacedName{
+			Namespace: "test",
+			Name:      "gateway",
+		},
+		Listeners: []*Listener{tcpListener, udpListener},
+	}
+
+	tcpRoute := &L4Route{
+		Source: &v1alpha2.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "tcp-dns"},
+			Spec: v1alpha2.TCPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name:        gatewayv1.ObjectName(gw.Name),
+							SectionName: helpers.GetPointer[gatewayv1.SectionName]("tcp-listener"),
+						},
+					},
+				},
+			},
+		},
+		Valid:      true,
+		Attachable: true,
+		Spec:       L4RouteSpec{Hostnames: []gatewayv1.Hostname{}},
+		ParentRefs: []ParentRef{
+			{
+				Idx:         0,
+				Gateway:     &ParentRefGateway{NamespacedName: gwNsName},
+				SectionName: helpers.GetPointer[gatewayv1.SectionName]("tcp-listener"),
+			},
+		},
+	}
+
+	udpRoute := &L4Route{
+		Source: &v1alpha2.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "udp-dns"},
+			Spec: v1alpha2.UDPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name:        gatewayv1.ObjectName(gw.Name),
+							SectionName: helpers.GetPointer[gatewayv1.SectionName]("udp-listener"),
+						},
+					},
+				},
+			},
+		},
+		Valid:      true,
+		Attachable: true,
+		Spec:       L4RouteSpec{Hostnames: []gatewayv1.Hostname{}},
+		ParentRefs: []ParentRef{
+			{
+				Idx:         0,
+				Gateway:     &ParentRefGateway{NamespacedName: gwNsName},
+				SectionName: helpers.GetPointer[gatewayv1.SectionName]("udp-listener"),
+			},
+		},
+	}
+
+	namespaces := map[types.NamespacedName]*v1.Namespace{
+		{Name: "test"}: {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "test",
+				Labels: map[string]string{"app": "allowed"},
+			},
+		},
+	}
+
+	// Use a shared portHostnamesMap so hostname conflict detection spans both bind calls.
+	portHostnamesMap := map[string]struct{}{}
+
+	bindL4RouteToListeners(tcpRoute, gateway, namespaces, portHostnamesMap)
+	bindL4RouteToListeners(udpRoute, gateway, namespaces, portHostnamesMap)
+
+	// Both routes should attach successfully without HostnameConflict.
+	g.Expect(tcpRoute.ParentRefs[0].Attachment).ToNot(BeNil())
+	g.Expect(tcpRoute.ParentRefs[0].Attachment.Attached).To(BeTrue(),
+		"TCPRoute should attach to TCP listener on port 53")
+	g.Expect(tcpRoute.ParentRefs[0].Attachment.FailedConditions).To(BeEmpty())
+
+	g.Expect(udpRoute.ParentRefs[0].Attachment).ToNot(BeNil())
+	g.Expect(udpRoute.ParentRefs[0].Attachment.Attached).To(BeTrue(),
+		"UDPRoute should attach to UDP listener on port 53 without hostname conflict")
+	g.Expect(udpRoute.ParentRefs[0].Attachment.FailedConditions).To(BeEmpty())
+}
+
 // Helper functions for L4 route testing.
 func createTestL4Gateway(name string, listeners ...*Listener) *Gateway {
 	return &Gateway{


### PR DESCRIPTION
Cherrypick of #5016 

### Proposed changes

**Problem:** When a TCPRoute and UDPRoute are attached to the same Gateway port (e.g., port 53 for DNS), both routes fail. The UDPRoute is rejected with a `HostnameConflict` condition, and even if it were accepted, the NGINX stream config would only generate a TCP `listen` directive, missing the `udp` parameter. Additionally, the provisioned Service would only contain one protocol entry for the shared port.

This is caused by four separate locations where data structures are keyed only by port number without considering the protocol, so the second protocol on a shared port is either overwritten or rejected.

**Solution:** Fixed four bugs across three files:

1. **`internal/controller/nginx/config/stream_servers.go`** — Changed `portSet` from `map[int32]struct{}` to `map[portProtoKey]struct{}` (a new struct with `port` and `protocol` fields), so TCP and UDP servers on the same port are tracked independently.

2. **`internal/controller/provisioner/objects.go`** — Changed `buildPortsFromListeners` to return `[]portProtoEntry` instead of `map[int32]corev1.Protocol`, preventing protocol overwrite when TCP and UDP share a port.

3. **`internal/controller/provisioner/objects.go`** — Updated Service port naming to include a protocol suffix (`port-53-tcp`, `port-53-udp`) when multiple protocols share the same port number, preventing duplicate port name conflicts.

4. **`internal/controller/state/graph/route_common.go`** — Changed the `portHostnamesMap` key from `hostname:port` to `hostname:port:protocol`, preventing false `HostnameConflict` rejection between TCPRoute and UDPRoute on the same port.

**Testing:**
- Updated unit tests in `stream_servers_test.go` to use the new `portProtoKey` type and added a new test case verifying that a UDP server is correctly created when TCP already occupies the same port.
- All existing unit tests pass (`go test ./...`).
- `make lint` passes with 0 issues.
- Verified end-to-end on a local kind cluster:
  - Both Gateway listeners (`dns-over-tcp`, `dns-over-udp`) show `attachedRoutes=1`
  - UDPRoute status: `Accepted=True`
  - Service has both `port-53-tcp: 53/TCP` and `port-53-udp: 53/UDP`
  - NGINX stream config contains both `listen 53;` (TCP) and `listen 53 udp;` server blocks
<img width="657" height="546" alt="Screenshot 2026-03-28 at 07 12 58" src="https://github.com/user-attachments/assets/25d19b8b-6450-46e5-bb60-c39e45be3a73" />


**Please focus on:** The `portHostnamesMap` change in `route_common.go` — this was a fourth bug discovered during end-to-end testing that wasn't apparent from code inspection alone.

Closes #4945

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

```release-note
Fixed an issue where TCPRoute and UDPRoute attached to the same Gateway port (e.g., port 53 for DNS) would cause both routes to fail. TCP and UDP listeners on the same port are now correctly supported.
```
