### PR TITLE
Fix CORS failure when attached to HTTPS Listener (#5071)

### DIFF
--- a/internal/controller/nginx/config/maps.go
+++ b/internal/controller/nginx/config/maps.go
@@ -37,7 +37,7 @@ func executeMaps(conf dataplane.Configuration) []executeResult {
 
 	maps := buildAddHeaderMaps(httpAndSSLServers)
 	maps = append(maps, buildInferenceMaps(conf.BackendGroups)...)
-	maps = append(maps, buildCorsMaps(httpAndSSLServers)...)
+	maps = append(maps, buildCorsMaps(conf.HTTPServers, conf.SSLServers)...)
 
 	if !conf.BaseHTTPConfig.DisableSNIHostValidation {
 		maps = append(maps, buildMisdirectedRequestMaps(conf.SSLListenerHostnames)...)
@@ -51,35 +51,44 @@ func executeMaps(conf dataplane.Configuration) []executeResult {
 	return []executeResult{result}
 }
 
-func buildCorsMaps(servers []dataplane.VirtualServer) []shared.Map {
+func buildCorsMaps(httpServers, sslServers []dataplane.VirtualServer) []shared.Map {
 	originMaps := make([]shared.Map, 0)
 
-	for serverIndex, s := range servers {
+	for serverIndex, s := range httpServers {
 		serverID := fmt.Sprintf("%d", serverIndex)
-		if s.SSL != nil {
-			serverID = fmt.Sprintf("SSL_%d", serverIndex)
-		}
+		originMaps = append(originMaps, buildCorsMapsForServer(s, serverID)...)
+	}
 
-		for pathRuleIndex, pr := range s.PathRules {
-			for matchRuleIndex, mr := range pr.MatchRules {
-				if mr.Filters.CORSFilter != nil {
-					corsFilter := mr.Filters.CORSFilter
-					if corsFilter.AllowOrigins != nil {
-						nginxVar := generateCORSAllowedOriginVariableName(serverID, pathRuleIndex, matchRuleIndex)
-						originMaps = append(originMaps, shared.Map{
-							Source:     "$http_origin",
-							Variable:   nginxVar,
-							Parameters: buildCORSOriginMapParameters(corsFilter.AllowOrigins),
-						})
-					}
-					if corsFilter.AllowCredentials {
-						nginxVar := generateCORSAllowCredentialsVariableName(serverID, pathRuleIndex, matchRuleIndex)
-						originMaps = append(originMaps, shared.Map{
-							Source:     "$http_origin",
-							Variable:   nginxVar,
-							Parameters: buildCORSAllowCredentialsMapParameters(corsFilter.AllowOrigins),
-						})
-					}
+	for serverIndex, s := range sslServers {
+		serverID := fmt.Sprintf("SSL_%d", serverIndex)
+		originMaps = append(originMaps, buildCorsMapsForServer(s, serverID)...)
+	}
+
+	return originMaps
+}
+
+func buildCorsMapsForServer(s dataplane.VirtualServer, serverID string) []shared.Map {
+	originMaps := make([]shared.Map, 0)
+
+	for pathRuleIndex, pr := range s.PathRules {
+		for matchRuleIndex, mr := range pr.MatchRules {
+			if mr.Filters.CORSFilter != nil {
+				corsFilter := mr.Filters.CORSFilter
+				if corsFilter.AllowOrigins != nil {
+					nginxVar := generateCORSAllowedOriginVariableName(serverID, pathRuleIndex, matchRuleIndex)
+					originMaps = append(originMaps, shared.Map{
+						Source:     "$http_origin",
+						Variable:   nginxVar,
+						Parameters: buildCORSOriginMapParameters(corsFilter.AllowOrigins),
+					})
+				}
+				if corsFilter.AllowCredentials {
+					nginxVar := generateCORSAllowCredentialsVariableName(serverID, pathRuleIndex, matchRuleIndex)
+					originMaps = append(originMaps, shared.Map{
+						Source:     "$http_origin",
+						Variable:   nginxVar,
+						Parameters: buildCORSAllowCredentialsMapParameters(corsFilter.AllowOrigins),
+					})
 				}
 			}
 		}

--- a/internal/controller/nginx/config/maps_test.go
+++ b/internal/controller/nginx/config/maps_test.go
@@ -734,18 +734,20 @@ func TestBuildCorsMaps(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		virtualServers []dataplane.VirtualServer
-		expected       []shared.Map
+		name        string
+		httpServers []dataplane.VirtualServer
+		sslServers  []dataplane.VirtualServer
+		expected    []shared.Map
 	}{
 		{
-			name:           "empty virtual servers",
-			virtualServers: []dataplane.VirtualServer{},
-			expected:       []shared.Map{},
+			name:        "empty virtual servers",
+			httpServers: []dataplane.VirtualServer{},
+			sslServers:  []dataplane.VirtualServer{},
+			expected:    []shared.Map{},
 		},
 		{
 			name: "virtual server with no CORS filter",
-			virtualServers: []dataplane.VirtualServer{
+			httpServers: []dataplane.VirtualServer{
 				{
 					Port: 80,
 					PathRules: []dataplane.PathRule{
@@ -760,11 +762,12 @@ func TestBuildCorsMaps(t *testing.T) {
 					},
 				},
 			},
-			expected: []shared.Map{},
+			sslServers: []dataplane.VirtualServer{},
+			expected:   []shared.Map{},
 		},
 		{
 			name: "virtual server with CORS filter - AllowOrigins only",
-			virtualServers: []dataplane.VirtualServer{
+			httpServers: []dataplane.VirtualServer{
 				{
 					Port: 80,
 					PathRules: []dataplane.PathRule{
@@ -783,6 +786,7 @@ func TestBuildCorsMaps(t *testing.T) {
 					},
 				},
 			},
+			sslServers: []dataplane.VirtualServer{},
 			expected: []shared.Map{
 				{
 					Source:   "$http_origin",
@@ -801,10 +805,12 @@ func TestBuildCorsMaps(t *testing.T) {
 			},
 		},
 		{
-			name: "virtual server with CORS filter - both AllowOrigins and AllowCredentials",
-			virtualServers: []dataplane.VirtualServer{
+			name:        "SSL virtual server with CORS filter - both AllowOrigins and AllowCredentials",
+			httpServers: []dataplane.VirtualServer{},
+			sslServers: []dataplane.VirtualServer{
 				{
 					Port: 443,
+					SSL:  &dataplane.SSL{},
 					PathRules: []dataplane.PathRule{
 						{
 							Path: "/test-path",
@@ -825,7 +831,7 @@ func TestBuildCorsMaps(t *testing.T) {
 			expected: []shared.Map{
 				{
 					Source:   "$http_origin",
-					Variable: "$cors_allowed_origin_server0_path0_match0",
+					Variable: "$cors_allowed_origin_serverSSL_0_path0_match0",
 					Parameters: []shared.MapParameter{
 						{
 							Value:  "\"~^.*\\.example\\.com$\"",
@@ -835,7 +841,7 @@ func TestBuildCorsMaps(t *testing.T) {
 				},
 				{
 					Source:   "$http_origin",
-					Variable: "$cors_allow_credentials_server0_path0_match0",
+					Variable: "$cors_allow_credentials_serverSSL_0_path0_match0",
 					Parameters: []shared.MapParameter{
 						{
 							Value:  "\"~^.*\\.example\\.com$\"",
@@ -847,7 +853,7 @@ func TestBuildCorsMaps(t *testing.T) {
 		},
 		{
 			name: "virtual server with multiple PathRules and multiple MatchRules",
-			virtualServers: []dataplane.VirtualServer{
+			httpServers: []dataplane.VirtualServer{
 				{
 					Port: 80,
 					PathRules: []dataplane.PathRule{
@@ -886,6 +892,7 @@ func TestBuildCorsMaps(t *testing.T) {
 					},
 				},
 			},
+			sslServers: []dataplane.VirtualServer{},
 			expected: []shared.Map{
 				{
 					Source:   "$http_origin",
@@ -929,6 +936,70 @@ func TestBuildCorsMaps(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "HTTP and SSL servers with CORS - indices are independent",
+			httpServers: []dataplane.VirtualServer{
+				{
+					Port: 80,
+					PathRules: []dataplane.PathRule{
+						{
+							Path: "/api",
+							MatchRules: []dataplane.MatchRule{
+								{
+									Filters: dataplane.HTTPFilters{
+										CORSFilter: &dataplane.HTTPCORSFilter{
+											AllowOrigins: []string{"http.example.com"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			sslServers: []dataplane.VirtualServer{
+				{
+					Port: 443,
+					SSL:  &dataplane.SSL{},
+					PathRules: []dataplane.PathRule{
+						{
+							Path: "/secure",
+							MatchRules: []dataplane.MatchRule{
+								{
+									Filters: dataplane.HTTPFilters{
+										CORSFilter: &dataplane.HTTPCORSFilter{
+											AllowOrigins: []string{"ssl.example.com"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []shared.Map{
+				{
+					Source:   "$http_origin",
+					Variable: "$cors_allowed_origin_server0_path0_match0",
+					Parameters: []shared.MapParameter{
+						{
+							Value:  "\"~^http\\.example\\.com$\"",
+							Result: "$http_origin",
+						},
+					},
+				},
+				{
+					Source:   "$http_origin",
+					Variable: "$cors_allowed_origin_serverSSL_0_path0_match0",
+					Parameters: []shared.MapParameter{
+						{
+							Value:  "\"~^ssl\\.example\\.com$\"",
+							Result: "$http_origin",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -936,7 +1007,7 @@ func TestBuildCorsMaps(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			result := buildCorsMaps(test.virtualServers)
+			result := buildCorsMaps(test.httpServers, test.sslServers)
 
 			g.Expect(result).To(HaveLen(len(test.expected)))
 			for i, expected := range test.expected {


### PR DESCRIPTION
Cherrypick of #5071 

Problem: The CORS variable names generated in maps.go didn't match those generated in servers.go for SSL servers, causing a failure to configure nginx.

Solution: Ensure that both maps.go and servers.go iterate through their respective slices the same way so that indices are the same and variables are named the same.

Testing: Manually verified that the user-provided HTTPRoute now works.

Closes #5070

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix an issue where CORS would not work when attached to an HTTPS Listener, causing invalid NGINX config.
```
