### PR TITLE
Allow externalTrafficPolicy on ClusterIP services with externalIPs (#…

### DIFF
--- a/apis/v1alpha2/nginxproxy_types.go
+++ b/apis/v1alpha2/nginxproxy_types.go
@@ -811,7 +811,7 @@ type ServiceSpec struct {
 
 	// ExternalTrafficPolicy describes how nodes distribute service traffic they
 	// receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs,
-	// and LoadBalancer IPs.
+	// and LoadBalancer IPs).
 	//
 	// +optional
 	// +kubebuilder:default:=Local
@@ -868,7 +868,7 @@ const (
 
 // ExternalTrafficPolicy describes how nodes distribute service traffic they
 // receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs,
-// and LoadBalancer IPs. Ignored for ClusterIP services.
+// and LoadBalancer IPs).
 // +kubebuilder:validation:Enum=Cluster;Local
 type ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicy
 

--- a/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
+++ b/config/crd/bases/gateway.nginx.org_nginxproxies.yaml
@@ -7988,7 +7988,7 @@ spec:
                         description: |-
                           ExternalTrafficPolicy describes how nodes distribute service traffic they
                           receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs,
-                          and LoadBalancer IPs.
+                          and LoadBalancer IPs).
                         enum:
                         - Cluster
                         - Local

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -9029,7 +9029,7 @@ spec:
                         description: |-
                           ExternalTrafficPolicy describes how nodes distribute service traffic they
                           receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs,
-                          and LoadBalancer IPs.
+                          and LoadBalancer IPs).
                         enum:
                         - Cluster
                         - Local

--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -655,8 +655,15 @@ func buildNginxService(
 		serviceType = corev1.ServiceType(*serviceCfg.ServiceType)
 	}
 
+	var externalIPs []string
+	for _, addr := range addresses {
+		if addr.Type != nil && *addr.Type == gatewayv1.IPAddressType {
+			externalIPs = append(externalIPs, addr.Value)
+		}
+	}
+
 	var servicePolicy corev1.ServiceExternalTrafficPolicy
-	if serviceType != corev1.ServiceTypeClusterIP {
+	if serviceType != corev1.ServiceTypeClusterIP || len(externalIPs) > 0 {
 		servicePolicy = defaultServicePolicy
 		if serviceCfg.ExternalTrafficPolicy != nil {
 			servicePolicy = corev1.ServiceExternalTrafficPolicy(*serviceCfg.ExternalTrafficPolicy)
@@ -671,12 +678,11 @@ func buildNginxService(
 			Type:                  serviceType,
 			Ports:                 servicePorts,
 			ExternalTrafficPolicy: servicePolicy,
+			ExternalIPs:           externalIPs,
 			Selector:              selectorLabels,
 			IPFamilyPolicy:        helpers.GetPointer(corev1.IPFamilyPolicyPreferDualStack),
 		},
 	}
-
-	setSvcExternalIPs(svc, addresses)
 
 	setIPFamily(nProxyCfg, svc)
 
@@ -741,14 +747,6 @@ func buildServicePorts(
 	})
 
 	return servicePorts
-}
-
-func setSvcExternalIPs(svc *corev1.Service, addresses []gatewayv1.GatewaySpecAddress) {
-	for _, address := range addresses {
-		if address.Type != nil && *address.Type == gatewayv1.IPAddressType {
-			svc.Spec.ExternalIPs = append(svc.Spec.ExternalIPs, address.Value)
-		}
-	}
 }
 
 func setIPFamily(nProxyCfg *graph.EffectiveNginxProxy, svc *corev1.Service) {

--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -2297,3 +2297,101 @@ func TestOwnerReferencesAreSet(t *testing.T) {
 		g.Expect(*ownerRefs[0].BlockOwnerDeletion).To(BeTrue())
 	}
 }
+
+func TestBuildNginxResourceObjects_ClusterIPWithExternalIPs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		nProxyCfg                     *graph.EffectiveNginxProxy
+		name                          string
+		expectedExternalTrafficPolicy corev1.ServiceExternalTrafficPolicy
+		gatewayAddresses              []gatewayv1.GatewaySpecAddress
+		expectedExternalIPs           []string
+	}{
+		{
+			name: "ClusterIP service with an IP-type Gateway address sets externalTrafficPolicy to Local",
+			gatewayAddresses: []gatewayv1.GatewaySpecAddress{
+				{
+					Type:  helpers.GetPointer(gatewayv1.IPAddressType),
+					Value: "10.0.0.1",
+				},
+			},
+			nProxyCfg: &graph.EffectiveNginxProxy{
+				Kubernetes: &ngfAPIv1alpha2.KubernetesSpec{
+					Service: &ngfAPIv1alpha2.ServiceSpec{
+						ServiceType:           helpers.GetPointer(ngfAPIv1alpha2.ServiceTypeClusterIP),
+						ExternalTrafficPolicy: helpers.GetPointer(ngfAPIv1alpha2.ExternalTrafficPolicyLocal),
+					},
+				},
+			},
+			expectedExternalIPs:           []string{"10.0.0.1"},
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+		},
+		{
+			name: "ClusterIP service with no Gateway addresses leaves externalTrafficPolicy unset",
+			nProxyCfg: &graph.EffectiveNginxProxy{
+				Kubernetes: &ngfAPIv1alpha2.KubernetesSpec{
+					Service: &ngfAPIv1alpha2.ServiceSpec{
+						ServiceType: helpers.GetPointer(ngfAPIv1alpha2.ServiceTypeClusterIP),
+					},
+				},
+			},
+			expectedExternalIPs:           nil,
+			expectedExternalTrafficPolicy: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			agentTLSSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      agentTLSTestSecretName,
+					Namespace: ngfNamespace,
+				},
+				Data: map[string][]byte{secrets.TLSCertKey: []byte("tls")},
+			}
+			fakeClient := createFakeClientWithScheme(agentTLSSecret)
+
+			provisioner := &NginxProvisioner{
+				cfg: Config{
+					GatewayPodConfig: &config.GatewayPodConfig{
+						Namespace: ngfNamespace,
+						Version:   "1.0.0",
+					},
+					AgentTLSSecretName: agentTLSTestSecretName,
+					AgentLabels:        make(map[string]string),
+				},
+				baseLabelSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "nginx"},
+				},
+				k8sClient: fakeClient,
+			}
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{{Port: 80}},
+					Addresses: test.gatewayAddresses,
+				},
+			}
+
+			objects, err := provisioner.buildNginxResourceObjects("gw-nginx", gateway, test.nProxyCfg)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var svc *corev1.Service
+			for _, obj := range objects {
+				if s, ok := obj.(*corev1.Service); ok {
+					svc = s
+					break
+				}
+			}
+			g.Expect(svc).ToNot(BeNil())
+			g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			g.Expect(svc.Spec.ExternalIPs).To(Equal(test.expectedExternalIPs))
+			g.Expect(svc.Spec.ExternalTrafficPolicy).To(Equal(test.expectedExternalTrafficPolicy))
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of [5075](https://github.com/nginx/nginx-gateway-fabric/pull/5075)

### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: When using a ClusterIP service with externalIPs (set via Gateway spec.addresses), users are unable to set `externalTrafficPolicy: Local` to preserve client IPs.

Solution: Allow externalTrafficPolicy to be set on ClusterIP services when externalIPs are present via Gateway spec.addresses, to allow services to be externally-accessible.

Testing: Manual testing

Created a gateway with an address specified

```
spec:
  gatewayClassName: nginx
  addresses:
  - type: IPAddress
    value: 172.18.0.2
  listeners:
  - name: http
    port: 80
    protocol: HTTP
    hostname: "*.example.com"

```

able to create a service of with `externalTrafficPolicy` to `local` with an externalIP set

```
k get svc gateway-nginx -o yaml
  name: gateway-nginx
spec:
  clusterIP: 10.96.202.159
  clusterIPs:
  - 10.96.202.159
  - fd00:10:96::79ec
  externalIPs:
  - 172.18.0.2
  externalTrafficPolicy: Local
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  - IPv6
  ipFamilyPolicy: PreferDualStack
  ports:
  - name: port-80
    port: 80
    protocol: TCP
    targetPort: 80
  selector:
```

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #5048

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fixes an issue where `externalTrafficPolicy: Local` could not be set on a ClusterIP service with externalIPs configured via Gateway `spec.addresses`.  The field [externalIPs](https://kubernetes.io/blog/2026/03/30/kubernetes-v1-36-sneak-peek/#deprecation-of-spec-externalips-in-service) for the Service spec will be deprecated and removed completely by Kubernetes v1.43.
```