### PR TITLE
Escape $ in rewrites

### DIFF
--- a/internal/controller/nginx/config/servers.go
+++ b/internal/controller/nginx/config/servers.go
@@ -1525,8 +1525,13 @@ func createMainRewriteForFilters(pathModifier *dataplane.HTTPPathModifier, pathR
 			filterPrefix = "/"
 		}
 
+		// Escape $ in the path so it is treated as a literal character in the PCRE regex,
+		// not as an end-of-string anchor. This matters when the route path contains a $ sign
+		// (e.g. /$coffee), which is valid in a Gateway API path but has special meaning in PCRE.
+		escapedPath := strings.ReplaceAll(pathRule.Path, "$", `\$`)
+
 		// capture everything following the configured prefix up to the first ?, if present.
-		regex := fmt.Sprintf("^%s([^?]*)?", pathRule.Path)
+		regex := fmt.Sprintf("^%s([^?]*)?", escapedPath)
 		// replace the configured prefix with the filter prefix, append the captured segment,
 		// and include the request arguments stored in nginx variable $args.
 		// https://nginx.org/en/docs/http/ngx_http_core_module.html#var_args
@@ -1536,7 +1541,7 @@ func createMainRewriteForFilters(pathModifier *dataplane.HTTPPathModifier, pathR
 		// then make sure that we *require* but *don't capture* a trailing slash in the request,
 		// otherwise we'll get duplicate slashes in the full replacement
 		if strings.HasSuffix(filterPrefix, "/") && !strings.HasSuffix(pathRule.Path, "/") {
-			regex = fmt.Sprintf("^%s(?:/([^?]*))?", pathRule.Path)
+			regex = fmt.Sprintf("^%s(?:/([^?]*))?", escapedPath)
 		}
 
 		// if configured prefix ends in / we won't capture it for a request (since it's not in the regex),

--- a/internal/controller/nginx/config/servers_test.go
+++ b/internal/controller/nginx/config/servers_test.go
@@ -4048,6 +4048,23 @@ func TestCreateRewritesValForRewriteFilter(t *testing.T) {
 			},
 			msg: "prefix path both with trailing slashes",
 		},
+		{
+			pathRule: dataplane.PathRule{
+				Path:     "/$coffee",
+				PathType: dataplane.PathTypePrefix,
+			},
+			filter: &dataplane.HTTPURLRewriteFilter{
+				Path: &dataplane.HTTPPathModifier{
+					Type:        dataplane.ReplacePrefixMatch,
+					Replacement: "/",
+				},
+			},
+			expected: &rewriteConfig{
+				InternalRewrite: "^ $request_uri",
+				MainRewrite:     `^/\$coffee(?:/([^?]*))? /$1?$args? break`,
+			},
+			msg: "prefix path with dollar sign is escaped in regex",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Problem: If the $ character was included in a rewrite, regex matching would treat it as the end of the pattern, and the match evaluation would fail, preventing the rewrite.

Solution: Escape the $ character in a rewrite.

Testing: Manually verified that the user issue is now fixed.

Closes #5096

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
Fix issue where rewrite would fail if path had a `$` character in it.
```
