### PR TITLE
If WAF is enabled, enable the logs-nap feature in the nginx-agent config

### DIFF
--- a/internal/controller/provisioner/objects.go
+++ b/internal/controller/provisioner/objects.go
@@ -550,8 +550,14 @@ func (p *NginxProvisioner) buildAgentConfigMap(
 		"AgentLabels":   agentLabels,
 	}
 
-	if nProxyCfg != nil && nProxyCfg.Logging != nil && nProxyCfg.Logging.AgentLevel != nil {
-		agentFields["LogLevel"] = *nProxyCfg.Logging.AgentLevel
+	if nProxyCfg != nil {
+		if nProxyCfg.WAF != nil && *nProxyCfg.WAF == ngfAPIv1alpha2.WAFEnabled {
+			agentFields["WafEnabled"] = true
+		}
+
+		if nProxyCfg.Logging != nil && nProxyCfg.Logging.AgentLevel != nil {
+			agentFields["LogLevel"] = *nProxyCfg.Logging.AgentLevel
+		}
 	}
 
 	if p.cfg.NginxOneConsoleTelemetryConfig.DataplaneKeySecretName != "" {

--- a/internal/controller/provisioner/objects_test.go
+++ b/internal/controller/provisioner/objects_test.go
@@ -160,6 +160,13 @@ func TestBuildNginxResourceObjects(t *testing.T) {
 	validateLabelsAndAnnotations(cm)
 	g.Expect(cm.Data).To(HaveKey(configmaps.AgentConfKey))
 	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("command:"))
+	// Verify base agent features (metrics enabled by default)
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- configuration"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- certificates"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- metrics"))
+	// Should not have WAF or Plus features
+	g.Expect(cm.Data[configmaps.AgentConfKey]).ToNot(ContainSubstring("- logs-nap"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).ToNot(ContainSubstring("- api-action"))
 
 	svcAcctObj := objects[3]
 	svcAcct, ok := svcAcctObj.(*corev1.ServiceAccount)
@@ -349,6 +356,10 @@ func TestBuildNginxResourceObjects_NginxProxyConfig(t *testing.T) {
 	g.Expect(ok).To(BeTrue())
 	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("level: debug"))
 	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("port: 8080"))
+	// Verify agent features - should have base + metrics
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- configuration"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- certificates"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- metrics"))
 
 	svcObj := objects[4]
 	svc, ok := svcObj.(*corev1.Service)
@@ -828,7 +839,10 @@ func TestBuildNginxResourceObjects_Plus(t *testing.T) {
 	cm, ok = cmObj.(*corev1.ConfigMap)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(cm.Data).To(HaveKey(configmaps.AgentConfKey))
-	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("api-action"))
+	// Verify agent features - should have base + api-action (Plus)
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- configuration"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- certificates"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- api-action"))
 
 	depObj := objects[8]
 	dep, ok := depObj.(*appsv1.Deployment)
@@ -1040,6 +1054,15 @@ func TestBuildNginxResourceObjects_DaemonSet(t *testing.T) {
 		"gateway.networking.k8s.io/gateway-name": "gw",
 		"app.kubernetes.io/name":                 "gw-nginx",
 	}
+
+	// Verify agent ConfigMap contains WAF logs-nap feature
+	cmObj := objects[2]
+	cm, ok := cmObj.(*corev1.ConfigMap)
+	g.Expect(ok).To(BeTrue())
+	// Verify agent features - should have base + logs-nap (WAF)
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- configuration"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- certificates"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- logs-nap"))
 
 	dsObj := objects[5]
 	ds, ok := dsObj.(*appsv1.DaemonSet)
@@ -1633,6 +1656,13 @@ func TestBuildNginxConfigMaps_AgentFields(t *testing.T) {
 	g.Expect(data).To(ContainSubstring("host: console.example.com"))
 	g.Expect(data).To(ContainSubstring("port: 443"))
 	g.Expect(data).To(ContainSubstring("skip_verify: false"))
+	// Verify base agent features are present (metrics enabled by default)
+	g.Expect(data).To(ContainSubstring("- configuration"))
+	g.Expect(data).To(ContainSubstring("- certificates"))
+	g.Expect(data).To(ContainSubstring("- metrics"))
+	// Should not have WAF or Plus features
+	g.Expect(data).ToNot(ContainSubstring("- logs-nap"))
+	g.Expect(data).ToNot(ContainSubstring("- api-action"))
 }
 
 func TestBuildReadinessProbe(t *testing.T) {
@@ -2391,6 +2421,15 @@ func TestBuildNginxResourceObjects_WAF(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(objects).To(HaveLen(6))
+
+	// Verify agent ConfigMap contains WAF logs-nap feature
+	cmObj := objects[2]
+	cm, ok := cmObj.(*corev1.ConfigMap)
+	g.Expect(ok).To(BeTrue())
+	// Verify agent features - should have base + logs-nap (WAF)
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- configuration"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- certificates"))
+	g.Expect(cm.Data[configmaps.AgentConfKey]).To(ContainSubstring("- logs-nap"))
 
 	// WAF-specific validations on the deployment
 	depObj := objects[5]

--- a/internal/controller/provisioner/templates.go
+++ b/internal/controller/provisioner/templates.go
@@ -55,6 +55,9 @@ features:
 {{- if .EnableMetrics }}
 - metrics
 {{- end }}
+{{- if eq true .WafEnabled }}
+- logs-nap
+{{- end }}
 {{- if eq true .Plus }}
 - api-action
 {{- end }}


### PR DESCRIPTION
### Proposed changes

Problem: Currently if WAF is enabled, the logs-nap feature in agent is disabled and security violations aren't able to be collected.

Solution: Enable logs-nap feature in agent if WAF is enabled.

Testing: Tested locally and via unit tests as well.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
