### PR TITLE
Add update to musl, musl-utils, and zlib packages in nginx plus dockerfile

### DIFF
--- a/build/Dockerfile.nginxplus
+++ b/build/Dockerfile.nginxplus
@@ -6,6 +6,8 @@ ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.p
 
 FROM alpine:3.22
 
+RUN apk update && apk upgrade --no-cache musl musl-utils
+
 ARG NGINX_PLUS_VERSION=R36
 # renovate: datasource=github-tags depName=nginx/agent
 ARG NGINX_AGENT_VERSION=v3.9.0

--- a/build/Dockerfile.nginxplus
+++ b/build/Dockerfile.nginxplus
@@ -6,7 +6,7 @@ ADD --link --chown=101:1001 https://cs.nginx.com/static/keys/nginx_signing.rsa.p
 
 FROM alpine:3.22
 
-RUN apk update && apk upgrade --no-cache musl musl-utils
+RUN apk update && apk upgrade --no-cache musl musl-utils zlib
 
 ARG NGINX_PLUS_VERSION=R36
 # renovate: datasource=github-tags depName=nginx/agent


### PR DESCRIPTION
This should fix the following scans:
- https://github.com/nginx/nginx-gateway-fabric/security/code-scanning/765
- https://github.com/nginx/nginx-gateway-fabric/security/code-scanning/766
- https://github.com/nginx/nginx-gateway-fabric/security/code-scanning/770
- https://github.com/nginx/nginx-gateway-fabric/security/code-scanning/771
- https://github.com/nginx/nginx-gateway-fabric/security/code-scanning/711

The packages only exist in our non-ubi nginx plus images. 
