### PR TITLE
ci: Update F5 CLA

### DIFF
--- a/.github/workflows/f5-cla.yml
+++ b/.github/workflows/f5-cla.yml
@@ -1,21 +1,11 @@
+---
 name: F5 CLA
-
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
-
-concurrency:
-  group: ${{ github.ref_name }}-cla
-
-permissions:
-  contents: read
-
+    types: [opened, closed, synchronize]
+permissions: read-all
 jobs:
   f5-cla:
     name: F5 CLA
@@ -30,20 +20,21 @@ jobs:
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have hereby read the F5 CLA and agree to its terms') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         with:
-          # Any pull request targeting the following branch will trigger a CLA check.
-          branch: "main"
           # Path to the CLA document.
-          path-to-document: "https://github.com/f5/.github/blob/main/CLA/cla-markdown.md"
+          path-to-document: https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md
           # Custom CLA messages.
-          custom-notsigned-prcomment: "🎉 Thank you for your contribution! It appears you have not yet signed the F5 Contributor License Agreement (CLA), which is required for your changes to be incorporated into an F5 Open Source Software (OSS) project. Please kindly read the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) and reply on a new comment with the following text to agree:"
-          custom-pr-sign-comment: "I have hereby read the F5 CLA and agree to its terms"
-          custom-allsigned-prcomment: "✅ All required contributors have signed the F5 CLA for this PR. Thank you!"
+          custom-notsigned-prcomment: '🎉 Thank you for your contribution! It appears you have not yet signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md), which is required for your changes to be incorporated into an F5 Open Source Software (OSS) project. Please kindly read the [F5 CLA](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md) and reply on a new comment with the following text to agree:'
+          custom-pr-sign-comment: 'I have hereby read the F5 CLA and agree to its terms'
+          custom-allsigned-prcomment: '✅ All required contributors have signed the F5 CLA for this PR. Thank you!'
           # Remote repository storing CLA signatures.
-          remote-organization-name: "f5"
-          remote-repository-name: "f5-cla-data"
-          path-to-signatures: "signatures/beta/signatures.json"
+          remote-organization-name: f5
+          remote-repository-name: f5-cla-data
+          # Branch where CLA signatures are stored.
+          branch: main
+          path-to-signatures: signatures/signatures.json
           # Comma separated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
-          allowlist: bot*
+          # NOTE: You will want to edit the usernames to suit your project needs.
+          allowlist: Copilot,dependabot[bot],renovate[bot],nginx-bot
           # Do not lock PRs after a merge.
           lock-pullrequest-aftermerge: false
         env:


### PR DESCRIPTION
### Proposed changes

Problem: The F5 CLA workflow has not been updated in two years and there have been a few changes to the main workflow in the meantime.

Solution: I have updated the CLA to use the latest workflow available at https://github.com/f5/f5-cla.

Testing: The workflow has been extensively tested on the [main F5 CLA repo](https://github.com/f5/f5-cla), as well as [the NGINX template repo](https://github.com/nginx/template-repository) and other NGINX repos such as the [core NGINX repo](https://github.com/nginx/nginx).

Please focus on (optional): The bots in the allowlist. I would like to ensure I am not missing any bots that might break the pipelines in this repo.

Other changes worth noting:
* Removed the concurrency group as there is only one CLA workflow and due to the implementation, there should be no racing conditions.
* Signatures are no longer stored in the "beta" directory. This might require some contributors to sign the CLA yet again, but no further breaking changes are expected in the future.
* The new styling follows the main/source of truth F5 CLA repo workflow's styling. This will help in the future as there are plans to automate syncing the workflow in the main F5 CLA repo across all relevant OSS repos.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note
NONE
```
